### PR TITLE
feat: notify other users when a version is restored

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -296,3 +296,4 @@ jobs:
       run: |
         flyctl apps destroy "$APP_NAME" --yes || true
         flyctl apps destroy "$APP_NAME-db" --yes || true
+

--- a/frontend/src/composables/useRestoreNotification.ts
+++ b/frontend/src/composables/useRestoreNotification.ts
@@ -1,0 +1,103 @@
+/**
+ * @file useRestoreNotification composable
+ *
+ * Watches Y.js awareness states for other users' 'restoring' field.
+ * When another user transitions from restoring=null to restoring=<versionId>,
+ * shows an info toast so the current user knows the document was restored.
+ */
+
+import { watch, unref, onUnmounted, type ShallowRef, type Ref } from 'vue'
+import { toast } from '@/utils/toast'
+
+export function useRestoreNotification(
+  awarenessRef: ShallowRef<any>,
+  currentUserId: number | Ref<number | undefined>,
+) {
+  // Track the last-known restoring value per clientId to detect transitions
+  const previousRestoring = new Map<number, any>()
+  let currentAwareness: any = null
+
+  function onAwarenessChange([changes]: [{ added: number[]; updated: number[]; removed: number[] }]) {
+    const awareness = currentAwareness
+    if (!awareness) return
+
+    const userId = unref(currentUserId)
+    const states = awareness.getStates()
+    const changedIds = [...changes.added, ...changes.updated]
+
+    for (const clientId of changedIds) {
+      const state = states.get(clientId)
+      if (!state) continue
+
+      // Skip self
+      if (state.user?.id === userId) {
+        previousRestoring.set(clientId, state.restoring ?? null)
+        continue
+      }
+
+      const prev = previousRestoring.get(clientId) ?? null
+      const curr = state.restoring ?? null
+
+      // Only fire on null → versionId transition (restore started)
+      if (prev === null && curr !== null) {
+        const userName = state.user?.name || 'Someone'
+        toast.info(`${userName} restored a previous version`, {
+          description: 'Your editor has been updated.',
+          duration: 5000,
+        })
+      }
+
+      previousRestoring.set(clientId, curr)
+    }
+
+    // Clean up removed clients
+    for (const clientId of changes.removed) {
+      previousRestoring.delete(clientId)
+    }
+  }
+
+  function attach(awareness: any) {
+    if (!awareness) return
+    currentAwareness = awareness
+
+    // Seed previous state so existing restoring=null doesn't trigger on first real change
+    const states = awareness.getStates()
+    states.forEach((state: any, clientId: number) => {
+      previousRestoring.set(clientId, state.restoring ?? null)
+    })
+
+    awareness.on('change', onAwarenessChange)
+  }
+
+  function detach() {
+    if (currentAwareness) {
+      currentAwareness.off('change', onAwarenessChange)
+      currentAwareness = null
+    }
+    previousRestoring.clear()
+  }
+
+  // Watch for awareness becoming available (it's null until WebSocket connects)
+  const stopWatch = watch(
+    () => awarenessRef.value,
+    (newAwareness, oldAwareness) => {
+      if (oldAwareness) detach()
+      if (newAwareness) attach(newAwareness)
+    },
+    { immediate: true },
+  )
+
+  function stop() {
+    stopWatch()
+    detach()
+  }
+
+  // Auto-cleanup if used inside a component
+  try {
+    onUnmounted(stop)
+  } catch {
+    // Called outside component lifecycle — caller must call stop() manually
+  }
+
+  return { stop }
+}

--- a/frontend/src/tests/composables/useRestoreNotification.test.js
+++ b/frontend/src/tests/composables/useRestoreNotification.test.js
@@ -1,0 +1,204 @@
+/**
+ * @file Unit tests for useRestoreNotification composable
+ * @description Tests that awareness state changes from other users trigger toast notifications
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { shallowRef } from "vue";
+
+// Mock toast
+const mockToast = {
+  info: vi.fn(),
+};
+vi.mock("@/utils/toast", () => ({
+  toast: mockToast,
+  default: mockToast,
+}));
+
+// Import after mocks
+const { useRestoreNotification } = await import(
+  "@/composables/useRestoreNotification"
+);
+
+/**
+ * Helper: create a fake awareness object that supports on/off and getStates.
+ */
+function createMockAwareness(initialStates = new Map()) {
+  const listeners = new Map();
+  return {
+    _states: initialStates,
+    getStates() {
+      return this._states;
+    },
+    getLocalState() {
+      return this._states.get(0) || {};
+    },
+    on(event, fn) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event).add(fn);
+    },
+    off(event, fn) {
+      listeners.get(event)?.delete(fn);
+    },
+    _emit(event, changes) {
+      listeners.get(event)?.forEach((fn) => fn(changes));
+    },
+    _listeners: listeners,
+  };
+}
+
+describe("useRestoreNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows toast when another user starts restoring", () => {
+    const awareness = createMockAwareness(
+      new Map([
+        [0, { user: { id: 1, name: "Me" } }],
+        [
+          2,
+          {
+            user: { id: 2, name: "Alice" },
+            restoring: null,
+          },
+        ],
+      ]),
+    );
+    const awarenessRef = shallowRef(awareness);
+
+    useRestoreNotification(awarenessRef, 1);
+
+    // Simulate Alice starting a restore
+    awareness._states.set(2, {
+      user: { id: 2, name: "Alice" },
+      restoring: 42,
+    });
+    awareness._emit("change", [
+      { added: [], updated: [2], removed: [] },
+      "local",
+    ]);
+
+    expect(mockToast.info).toHaveBeenCalledTimes(1);
+    expect(mockToast.info).toHaveBeenCalledWith(
+      "Alice restored a previous version",
+      expect.objectContaining({
+        description: expect.stringContaining("updated"),
+      }),
+    );
+  });
+
+  it("does not show toast for own restoring state", () => {
+    const awareness = createMockAwareness(
+      new Map([[0, { user: { id: 1, name: "Me" }, restoring: null }]]),
+    );
+    const awarenessRef = shallowRef(awareness);
+
+    useRestoreNotification(awarenessRef, 1);
+
+    // Simulate self starting a restore
+    awareness._states.set(0, {
+      user: { id: 1, name: "Me" },
+      restoring: 99,
+    });
+    awareness._emit("change", [
+      { added: [], updated: [0], removed: [] },
+      "local",
+    ]);
+
+    expect(mockToast.info).not.toHaveBeenCalled();
+  });
+
+  it("does not show toast when restoring transitions to null (clear)", () => {
+    const awareness = createMockAwareness(
+      new Map([
+        [0, { user: { id: 1, name: "Me" } }],
+        [
+          2,
+          {
+            user: { id: 2, name: "Alice" },
+            restoring: 42,
+          },
+        ],
+      ]),
+    );
+    const awarenessRef = shallowRef(awareness);
+
+    // Composable starts — Alice already restoring, but no transition yet
+    useRestoreNotification(awarenessRef, 1);
+
+    // Alice clears her restoring state (restore finished)
+    awareness._states.set(2, {
+      user: { id: 2, name: "Alice" },
+      restoring: null,
+    });
+    awareness._emit("change", [
+      { added: [], updated: [2], removed: [] },
+      "local",
+    ]);
+
+    expect(mockToast.info).not.toHaveBeenCalled();
+  });
+
+  it("handles user with no user info gracefully", () => {
+    const awareness = createMockAwareness(
+      new Map([
+        [0, { user: { id: 1, name: "Me" } }],
+        [2, {}],
+      ]),
+    );
+    const awarenessRef = shallowRef(awareness);
+
+    useRestoreNotification(awarenessRef, 1);
+
+    // Client 2 sets restoring but has no user info
+    awareness._states.set(2, { restoring: 42 });
+    awareness._emit("change", [
+      { added: [], updated: [2], removed: [] },
+      "local",
+    ]);
+
+    expect(mockToast.info).toHaveBeenCalledTimes(1);
+    expect(mockToast.info).toHaveBeenCalledWith(
+      "Someone restored a previous version",
+      expect.any(Object),
+    );
+  });
+
+  it("cleans up listener on stop", () => {
+    const awareness = createMockAwareness(
+      new Map([[0, { user: { id: 1, name: "Me" } }]]),
+    );
+    const awarenessRef = shallowRef(awareness);
+
+    const { stop } = useRestoreNotification(awarenessRef, 1);
+    stop();
+
+    // Simulate a change after cleanup
+    awareness._states.set(2, {
+      user: { id: 2, name: "Bob" },
+      restoring: 10,
+    });
+    awareness._emit("change", [
+      { added: [2], updated: [], removed: [] },
+      "local",
+    ]);
+
+    expect(mockToast.info).not.toHaveBeenCalled();
+  });
+
+  it("handles late awareness (null ref initially, set later)", () => {
+    const awarenessRef = shallowRef(null);
+    useRestoreNotification(awarenessRef, 1);
+
+    // No error thrown — now set awareness
+    const awareness = createMockAwareness(
+      new Map([[0, { user: { id: 1, name: "Me" } }]]),
+    );
+    awarenessRef.value = awareness;
+
+    // Trigger Vue reactivity manually won't work in unit tests without a component,
+    // but we can verify no error was thrown during setup
+    expect(mockToast.info).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/views/workspace/Canvas.vue
+++ b/frontend/src/views/workspace/Canvas.vue
@@ -20,6 +20,7 @@
   import { registerAsFallback } from "@/composables/useKeyboardShortcuts.js";
   import { useHeadInjection } from "@/composables/useHeadInjection.js";
   import { useSourcePreviewNav } from "@/composables/useSourcePreviewNav.js";
+  import { useRestoreNotification } from "@/composables/useRestoreNotification";
   import { IconMessageFilled } from "@/components/base/iconRegistry.js";
   import useClosable from "@/composables/useClosable.js";
   import ReaderTopbar from "./ReaderTopbar.vue";
@@ -51,6 +52,13 @@
   // Shared awareness ref — EditorCodeMirror writes to it, ScrollbarMinimap reads it
   const awareness = shallowRef(null);
   provide("awareness", awareness);
+
+  // Notify current user when another connected user restores a version
+  const user = inject("user");
+  useRestoreNotification(
+    awareness,
+    computed(() => user.value?.id),
+  );
 
   // Shared CodeMirror view — EditorCodeMirror writes, TopbarSearch reads for Source scope search
   const cmView = shallowRef(null);


### PR DESCRIPTION
## Summary
- Added `useRestoreNotification` composable that watches Y.js awareness states for other users' `restoring` field
- When another connected user starts a version restore (null → versionId transition), shows an info toast: "{name} restored a previous version — Your editor has been updated"
- Wired into `Canvas.vue` where the shared awareness ref is provided
- Filters out self (no toast for own restores), handles missing user info gracefully, auto-cleans up on unmount

## Test plan
- [x] 6 unit tests for `useRestoreNotification` (all pass)
- [x] Existing 28 Canvas.vue tests still pass
- [x] Existing 12 `useVersionRestore` tests still pass
- [ ] Manual: open same file in two browser tabs, restore a version in one — other tab should show toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)