### PR TITLE
feat: BottomSheet component for mobile drawers

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -296,3 +296,4 @@ jobs:
       run: |
         flyctl apps destroy "$APP_NAME" --yes || true
         flyctl apps destroy "$APP_NAME-db" --yes || true
+

--- a/frontend/src/components/base/BottomSheet.vue
+++ b/frontend/src/components/base/BottomSheet.vue
@@ -1,0 +1,164 @@
+<script setup>
+  import { ref, watch } from "vue";
+
+  const props = defineProps({
+    modelValue: { type: Boolean, default: false },
+    height: {
+      type: String,
+      default: "half",
+      validator: (v) => ["half", "full"].includes(v),
+    },
+    title: { type: String, default: "" },
+  });
+
+  const emit = defineEmits(["update:modelValue", "close"]);
+
+  const panelRef = ref(null);
+  const dragging = ref(false);
+  const dragStartY = ref(0);
+  const dragOffset = ref(0);
+
+  const close = () => {
+    emit("update:modelValue", false);
+    emit("close");
+  };
+
+  const onBackdropClick = (e) => {
+    if (e.target === e.currentTarget) close();
+  };
+
+  const onKeydown = (e) => {
+    if (e.key === "Escape") close();
+  };
+
+  const onDragStart = (e) => {
+    dragging.value = true;
+    dragStartY.value = e.touches ? e.touches[0].clientY : e.clientY;
+    dragOffset.value = 0;
+  };
+
+  const onDragMove = (e) => {
+    if (!dragging.value) return;
+    const y = e.touches ? e.touches[0].clientY : e.clientY;
+    const delta = y - dragStartY.value;
+    // Only allow dragging downward
+    dragOffset.value = Math.max(0, delta);
+    if (panelRef.value) {
+      panelRef.value.style.transform = `translateY(${dragOffset.value}px)`;
+    }
+  };
+
+  const onDragEnd = () => {
+    if (!dragging.value) return;
+    dragging.value = false;
+    // Dismiss if dragged more than 100px down
+    if (dragOffset.value > 100) {
+      close();
+    }
+    if (panelRef.value) {
+      panelRef.value.style.transform = "";
+    }
+    dragOffset.value = 0;
+  };
+
+  watch(
+    () => props.modelValue,
+    (open) => {
+      if (open) dragOffset.value = 0;
+    },
+  );
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="modelValue"
+      class="bottom-sheet-backdrop"
+      tabindex="-1"
+      @click="onBackdropClick"
+      @keydown="onKeydown"
+    >
+      <div
+        ref="panelRef"
+        class="bottom-sheet-panel"
+        :class="height"
+        @click.stop
+        @touchstart.passive="onDragStart"
+        @touchmove.passive="onDragMove"
+        @touchend="onDragEnd"
+      >
+        <div class="drag-handle" @mousedown="onDragStart" />
+        <div v-if="title" class="bottom-sheet-header">
+          <h3>{{ title }}</h3>
+        </div>
+        <div class="bottom-sheet-body">
+          <slot />
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+  .bottom-sheet-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 9998;
+    display: flex;
+    align-items: flex-end;
+    backdrop-filter: blur(2px);
+  }
+
+  .bottom-sheet-panel {
+    width: 100%;
+    background: var(--surface-page, #fff);
+    border-radius: 16px 16px 0 0;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.12);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transition: transform 0.3s ease;
+    will-change: transform;
+  }
+
+  .bottom-sheet-panel.half {
+    max-height: 65vh;
+  }
+
+  .bottom-sheet-panel.full {
+    max-height: 90vh;
+  }
+
+  .drag-handle {
+    width: 36px;
+    height: 4px;
+    background: var(--border-primary, #ccc);
+    border-radius: 2px;
+    margin: 10px auto 4px;
+    cursor: grab;
+    flex-shrink: 0;
+  }
+
+  .drag-handle:active {
+    cursor: grabbing;
+  }
+
+  .bottom-sheet-header {
+    padding: 8px 16px 4px;
+    flex-shrink: 0;
+  }
+
+  .bottom-sheet-header h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary, #111);
+  }
+
+  .bottom-sheet-body {
+    flex: 1;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+</style>

--- a/frontend/src/components/base/BottomSheet.vue
+++ b/frontend/src/components/base/BottomSheet.vue
@@ -65,7 +65,7 @@
     () => props.modelValue,
     (open) => {
       if (open) dragOffset.value = 0;
-    },
+    }
   );
 </script>
 

--- a/frontend/src/tests/components/BottomSheet.test.js
+++ b/frontend/src/tests/components/BottomSheet.test.js
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
-import { nextTick, ref } from "vue";
 import BottomSheet from "@/components/base/BottomSheet.vue";
 
 describe("BottomSheet.vue", () => {

--- a/frontend/src/tests/components/BottomSheet.test.js
+++ b/frontend/src/tests/components/BottomSheet.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick, ref } from "vue";
+import BottomSheet from "@/components/base/BottomSheet.vue";
+
+describe("BottomSheet.vue", () => {
+  const mountSheet = (props = {}, slots = {}) =>
+    mount(BottomSheet, {
+      props: { modelValue: true, title: "Test Sheet", ...props },
+      slots: { default: "<p>Sheet content</p>", ...slots },
+      attachTo: document.body,
+    });
+
+  it("renders slot content when open", () => {
+    const wrapper = mountSheet();
+    expect(wrapper.html()).toContain("Sheet content");
+    wrapper.unmount();
+  });
+
+  it("does not render when modelValue is false", () => {
+    const wrapper = mountSheet({ modelValue: false });
+    expect(wrapper.find(".bottom-sheet-backdrop").exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("renders the title", () => {
+    const wrapper = mountSheet({ title: "Settings" });
+    expect(wrapper.text()).toContain("Settings");
+    wrapper.unmount();
+  });
+
+  it("renders a drag handle", () => {
+    const wrapper = mountSheet();
+    expect(wrapper.find(".drag-handle").exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("emits update:modelValue false on backdrop click", async () => {
+    const wrapper = mountSheet();
+    await wrapper.find(".bottom-sheet-backdrop").trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+    expect(wrapper.emitted("update:modelValue")[0]).toEqual([false]);
+    wrapper.unmount();
+  });
+
+  it("does not close when clicking inside the sheet panel", async () => {
+    const wrapper = mountSheet();
+    await wrapper.find(".bottom-sheet-panel").trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeFalsy();
+    wrapper.unmount();
+  });
+
+  it("emits close event on backdrop click", async () => {
+    const wrapper = mountSheet();
+    await wrapper.find(".bottom-sheet-backdrop").trigger("click");
+    expect(wrapper.emitted("close")).toBeTruthy();
+    wrapper.unmount();
+  });
+
+  it("applies half height class by default", () => {
+    const wrapper = mountSheet();
+    expect(wrapper.find(".bottom-sheet-panel.half").exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("applies full height class when height=full", () => {
+    const wrapper = mountSheet({ height: "full" });
+    expect(wrapper.find(".bottom-sheet-panel.full").exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("emits close on Escape key", async () => {
+    const wrapper = mountSheet();
+    await wrapper.find(".bottom-sheet-backdrop").trigger("keydown", { key: "Escape" });
+    expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+    expect(wrapper.emitted("update:modelValue")[0]).toEqual([false]);
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/tests/views/workspace/Drawer.mobile.test.js
+++ b/frontend/src/tests/views/workspace/Drawer.mobile.test.js
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
-import { ref, nextTick } from "vue";
+import { ref } from "vue";
 import Drawer from "@/views/workspace/Drawer.vue";
 
 vi.mock("@/composables/useClosable.js", () => ({

--- a/frontend/src/tests/views/workspace/Drawer.mobile.test.js
+++ b/frontend/src/tests/views/workspace/Drawer.mobile.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref, nextTick } from "vue";
+import Drawer from "@/views/workspace/Drawer.vue";
+
+vi.mock("@/composables/useClosable.js", () => ({
+  default: vi.fn(() => ({ activate: vi.fn(), deactivate: vi.fn() })),
+}));
+
+const PaneStub = { template: '<div class="pane"><slot name="header"/><slot/></div>' };
+const SectionStub = { template: '<div class="section"><slot name="header"/><slot/></div>' };
+
+const createWrapper = (component, mobileMode = false) =>
+  mount(Drawer, {
+    props: { component },
+    global: {
+      provide: {
+        drawerOpen: ref(true),
+        focusMode: ref(false),
+        mobileMode: ref(mobileMode),
+        api: {},
+        file: ref({ id: 1, title: "Test" }),
+        fileSettings: ref({}),
+        fileStore: {},
+        user: ref({ id: 1, name: "Test" }),
+      },
+      stubs: {
+        Pane: PaneStub,
+        Section: SectionStub,
+        BottomSheet: {
+          template: '<div class="bottom-sheet"><slot/></div>',
+          props: ["modelValue", "title", "height"],
+        },
+        FileSettings: {
+          template: '<div class="file-settings"/>',
+          methods: { startReceivingUserInput() {} },
+        },
+        IconFileText: { template: "<span/>" },
+      },
+    },
+  });
+
+describe("Drawer.vue mobile mode", () => {
+  it("renders desktop drawer when not in mobile mode", () => {
+    const wrapper = createWrapper("DrawerSettings", false);
+    expect(wrapper.find(".drawer").exists()).toBe(true);
+    expect(wrapper.find(".bottom-sheet").exists()).toBe(false);
+  });
+
+  it("renders BottomSheet when in mobile mode", () => {
+    const wrapper = createWrapper("DrawerSettings", true);
+    expect(wrapper.find(".bottom-sheet").exists()).toBe(true);
+    expect(wrapper.find(".drawer").exists()).toBe(false);
+  });
+
+  it("renders drawer content inside BottomSheet on mobile", () => {
+    const wrapper = createWrapper("DrawerSettings", true);
+    const sheet = wrapper.find(".bottom-sheet");
+    expect(sheet.exists()).toBe(true);
+  });
+
+  it("renders DrawerFile in BottomSheet on mobile", () => {
+    const wrapper = createWrapper("DrawerFile", true);
+    expect(wrapper.find(".bottom-sheet").exists()).toBe(true);
+  });
+});

--- a/frontend/src/views/workspace/Drawer.vue
+++ b/frontend/src/views/workspace/Drawer.vue
@@ -1,6 +1,7 @@
 <script setup>
-  import { ref, inject } from "vue";
+  import { inject, computed } from "vue";
   import useClosable from "@/composables/useClosable.js";
+  import BottomSheet from "@/components/base/BottomSheet.vue";
   import DrawerMargins from "./DrawerMargins.vue";
   import DrawerActivity from "./DrawerActivity.vue";
   import DrawerSettings from "./DrawerSettings.vue";
@@ -11,10 +12,13 @@
   const props = defineProps({ component: { type: String, required: true } });
   const active = inject("drawerOpen");
   const focusMode = inject("focusMode");
+  const mobileMode = inject("mobileMode", false);
+
   useClosable({
     onClose: () => (active.value = false),
     closeOnOutsideClick: false,
   });
+
   const componentMap = {
     DrawerMargins: DrawerMargins,
     DrawerActivity: DrawerActivity,
@@ -23,10 +27,29 @@
     DrawerShare: DrawerShare,
     DrawerFile: DrawerFile,
   };
+
+  const mobileDrawers = new Set(["DrawerSettings", "DrawerFile"]);
+  const useMobileSheet = computed(() => mobileMode?.value && mobileDrawers.has(props.component));
+
+  const drawerTitle = computed(() => {
+    const titles = {
+      DrawerSettings: "Document Display",
+      DrawerFile: "File Info",
+    };
+    return titles[props.component] || "";
+  });
 </script>
 
 <template>
-  <div class="drawer" :class="{ active, focus: focusMode }">
+  <BottomSheet
+    v-if="useMobileSheet"
+    :model-value="active"
+    :title="drawerTitle"
+    @update:model-value="active = $event"
+  >
+    <component :is="componentMap[component]" />
+  </BottomSheet>
+  <div v-else class="drawer" :class="{ active, focus: focusMode }">
     <component :is="componentMap[component]" v-if="component" />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- New `BottomSheet.vue` base component: slides up from bottom, drag-to-dismiss, backdrop overlay, half/full height modes
- Wired into `Drawer.vue`: on mobile viewports (<=640px), Settings and File drawers render inside BottomSheet instead of the desktop side panel
- Fixes drawers rendering off-screen on mobile due to desktop sidebar-relative positioning

## Test plan
- [x] 10 unit tests for BottomSheet (open/close, backdrop click, drag handle, height modes, escape key)
- [x] 4 integration tests for Drawer mobile mode (desktop vs mobile rendering, component switching)
- [ ] Manual test: open Settings/File drawer on mobile viewport, verify slide-up behavior
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)