### PR TITLE
feat: version restore safety guards (concurrent editor detection + read-only lock)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -296,3 +296,4 @@ jobs:
       run: |
         flyctl apps destroy "$APP_NAME" --yes || true
         flyctl apps destroy "$APP_NAME-db" --yes || true
+

--- a/frontend/src/composables/useAwareness.ts
+++ b/frontend/src/composables/useAwareness.ts
@@ -1,7 +1,4 @@
-/**
- * @file useAwareness composable stub
- * @description Provides access to Y.js awareness for presence/collaboration
- */
+import { inject, type ShallowRef, type Ref } from 'vue'
 
 interface AwarenessReturn {
   awareness: any
@@ -9,6 +6,29 @@ interface AwarenessReturn {
 }
 
 export function useAwareness(): AwarenessReturn {
-  // This is a stub - actual implementation will be in EditorCodeMirror
-  throw new Error('useAwareness must be mocked in tests or implemented properly')
+  const awarenessRef = inject<ShallowRef<any>>('awareness', null)
+  const userRef = inject<Ref<any>>('user', null)
+
+  // Return a proxy that defers to the current ref value at access time.
+  // At setup time, awareness may be null (EditorCodeMirror hasn't mounted yet).
+  // By the time restoreVersion() runs, it will be populated.
+  const awareness = new Proxy({} as any, {
+    get(_target, prop) {
+      const instance = awarenessRef?.value
+      if (!instance) throw new Error('Awareness not initialized — editor must be mounted first')
+      const val = instance[prop]
+      return typeof val === 'function' ? val.bind(instance) : val
+    },
+  })
+
+  const currentUser = new Proxy({} as { id: number; name: string }, {
+    get(_target, prop) {
+      const u = userRef?.value
+      if (prop === 'id') return u?.id ?? 0
+      if (prop === 'name') return u?.name ?? u?.email ?? 'Unknown'
+      return undefined
+    },
+  })
+
+  return { awareness, currentUser }
 }

--- a/frontend/src/composables/useCurrentUser.ts
+++ b/frontend/src/composables/useCurrentUser.ts
@@ -1,9 +1,4 @@
-/**
- * @file useCurrentUser composable stub
- * @description Provides access to current user information
- */
-
-import type { Ref } from 'vue'
+import { inject, type Ref } from 'vue'
 
 interface User {
   id: number
@@ -16,6 +11,6 @@ interface CurrentUserReturn {
 }
 
 export function useCurrentUser(): CurrentUserReturn {
-  // This is a stub - actual implementation will use inject('user')
-  throw new Error('useCurrentUser must be mocked in tests or implemented properly')
+  const user = inject<Ref<User | null>>('user', null)
+  return { user: user! }
 }

--- a/frontend/src/composables/useEditor.ts
+++ b/frontend/src/composables/useEditor.ts
@@ -1,7 +1,7 @@
-/**
- * @file useEditor composable stub
- * @description Provides access to CodeMirror editor instance
- */
+import { inject, type ShallowRef } from 'vue'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import type { Compartment } from '@codemirror/state'
 
 interface EditorReturn {
   editor: {
@@ -11,6 +11,24 @@ interface EditorReturn {
 }
 
 export function useEditor(): EditorReturn {
-  // This is a stub - actual implementation will be in EditorCodeMirror
-  throw new Error('useEditor must be mocked in tests or implemented properly')
+  const cmView = inject<ShallowRef<EditorView | null>>('cmView', null)
+  const readOnlyCompartment = inject<ShallowRef<Compartment | null>>('readOnlyCompartment', null)
+
+  const editor = {
+    isReadOnly(): boolean {
+      return cmView?.value?.state?.readOnly ?? false
+    },
+    setReadOnly(readOnly: boolean): void {
+      const view = cmView?.value
+      const compartment = readOnlyCompartment?.value
+      if (!view || !compartment) return
+
+      const exts = readOnly
+        ? [EditorState.readOnly.of(true), EditorView.editable.of(false)]
+        : []
+      view.dispatch({ effects: compartment.reconfigure(exts) })
+    },
+  }
+
+  return { editor }
 }

--- a/frontend/src/composables/useVersionRestore.ts
+++ b/frontend/src/composables/useVersionRestore.ts
@@ -9,7 +9,7 @@
  * 4. Permission: Owner-only (enforced by backend)
  */
 
-import { ref } from 'vue'
+import { ref, inject } from 'vue'
 import { useYText } from './useYText'
 import { useAwareness } from './useAwareness'
 import { useEditor } from './useEditor'
@@ -28,6 +28,7 @@ interface RestoreOrigin {
  */
 export function useVersionRestore(fileId: number) {
   const isRestoring = ref(false)
+  const api = inject<any>('api')
   const { ytext, ydoc } = useYText(fileId)
   const { awareness, currentUser } = useAwareness()
   const { editor } = useEditor()
@@ -64,21 +65,9 @@ export function useVersionRestore(fileId: number) {
     try {
       isRestoring.value = true
 
-      // 1. Fetch version content
-      const response = await fetch(
-        `/api/files/${fileId}/versions/${versionId}/preview`,
-        {
-          headers: {
-            'Authorization': `Bearer ${localStorage.getItem('token')}`
-          }
-        }
-      )
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch version: ${response.statusText}`)
-      }
-
-      const versionContent = await response.text()
+      // 1. Fetch version content via injected axios client
+      const response = await api.get(`/files/${fileId}/versions/${versionId}/preview`)
+      const versionContent = response.data.rsm_content
 
       // 2. Check for concurrent editors
       const activeUsers = getActiveUsers(currentUser.id)

--- a/frontend/src/composables/useYText.ts
+++ b/frontend/src/composables/useYText.ts
@@ -1,8 +1,4 @@
-/**
- * @file useYText composable stub
- * @description Provides access to Y.Text instance for collaborative editing
- */
-
+import { inject, type ShallowRef } from 'vue'
 import type * as Y from 'yjs'
 
 interface YTextReturn {
@@ -11,7 +7,28 @@ interface YTextReturn {
 }
 
 export function useYText(_fileId: number): YTextReturn {
-  // This is a stub - actual implementation will be in EditorCodeMirror
-  throw new Error('useYText must be mocked in tests or implemented properly')
-}
+  const ydocRef = inject<ShallowRef<Y.Doc | null>>('ydoc', null)
 
+  // Return proxies that defer to the current ref value at access time.
+  // At setup time, ydoc may be null (EditorCodeMirror hasn't mounted yet).
+  // By the time restoreVersion() runs, it will be populated.
+  const ydoc = new Proxy({} as Y.Doc, {
+    get(_target, prop) {
+      const instance = ydocRef?.value
+      if (!instance) throw new Error('Y.Doc not initialized — editor must be mounted first')
+      const val = (instance as any)[prop]
+      return typeof val === 'function' ? val.bind(instance) : val
+    },
+  })
+
+  const ytext = new Proxy({} as Y.Text, {
+    get(_target, prop) {
+      const instance = ydocRef?.value?.getText('text')
+      if (!instance) throw new Error('Y.Text not initialized — editor must be mounted first')
+      const val = (instance as any)[prop]
+      return typeof val === 'function' ? val.bind(instance) : val
+    },
+  })
+
+  return { ytext, ydoc }
+}

--- a/frontend/src/tests/components/Minimap.test.js
+++ b/frontend/src/tests/components/Minimap.test.js
@@ -466,14 +466,14 @@ describe("Layout regressions — editor/manuscript split", () => {
     expect(editorSource).toMatch(/\.cm-gutters[^}]*font-size:\s*11px/s);
   });
 
-  it("Canvas provides awareness as a shallowRef for sibling communication", () => {
-    expect(canvasSource).toContain('provide("awareness"');
-    expect(canvasSource).toContain("shallowRef(null)");
+  it("Canvas injects awareness from View.vue (not creates its own)", () => {
+    expect(canvasSource).toContain('inject("awareness"');
+    expect(canvasSource).not.toContain('provide("awareness"');
   });
 
   it("EditorCodeMirror injects awareness (not provides)", () => {
     expect(editorSource).toContain('inject("awareness"');
-    // Must NOT create its own provide — it shares via Canvas
+    // Must NOT create its own provide — it shares via View.vue
     expect(editorSource).not.toContain('provide("awareness"');
   });
 });

--- a/frontend/src/tests/components/VersionPreviewModal.test.js
+++ b/frontend/src/tests/components/VersionPreviewModal.test.js
@@ -4,10 +4,20 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
+import { ref } from "vue";
 import VersionPreviewModal from "@/views/workspace/VersionPreviewModal.vue";
 import Button from "@/components/base/Button.vue";
 
-// Mock API
+const mockRestoreVersion = vi.fn();
+const mockIsRestoring = ref(false);
+
+vi.mock("@/composables/useVersionRestore.ts", () => ({
+  useVersionRestore: vi.fn(() => ({
+    restoreVersion: mockRestoreVersion,
+    isRestoring: mockIsRestoring,
+  })),
+}));
+
 const mockApi = {
   get: vi.fn(),
 };
@@ -27,6 +37,8 @@ describe("VersionPreviewModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsRestoring.value = false;
+    mockRestoreVersion.mockResolvedValue(true);
     mockApi.get.mockResolvedValue({
       data: {
         rsm_content: mockVersionContent,
@@ -36,7 +48,6 @@ describe("VersionPreviewModal", () => {
         created_by: mockVersion.created_by,
       },
     });
-    // Mock window.addEventListener for ESC key
     global.addEventListener = vi.fn();
     global.removeEventListener = vi.fn();
   });
@@ -58,6 +69,11 @@ describe("VersionPreviewModal", () => {
       global: {
         provide: {
           api: mockApi,
+          awareness: { value: null },
+          cmView: { value: null },
+          readOnlyCompartment: { value: null },
+          ydoc: { value: null },
+          user: { value: { id: 1, name: "Test User", email: "test@example.com" } },
         },
         components: {
           Button,
@@ -78,7 +94,7 @@ describe("VersionPreviewModal", () => {
     });
 
     it("displays loading state while fetching content", async () => {
-      mockApi.get.mockImplementation(() => new Promise(() => {})); // Never resolves
+      mockApi.get.mockImplementation(() => new Promise(() => {}));
       wrapper = createWrapper();
       await wrapper.vm.$nextTick();
 
@@ -106,7 +122,6 @@ describe("VersionPreviewModal", () => {
 
       expect(wrapper.find(".error-state").exists()).toBe(true);
 
-      // Click retry button
       await wrapper.find(".error-state button").trigger("click");
       await wrapper.vm.$nextTick();
       await wrapper.vm.$nextTick();
@@ -189,19 +204,10 @@ describe("VersionPreviewModal", () => {
   });
 
   describe("restore functionality for owner", () => {
-    let mockDispatch;
-
     beforeEach(async () => {
-      mockDispatch = vi.fn();
-      window.__cmView = { dispatch: mockDispatch, state: { doc: { length: 50 } } };
-
       wrapper = createWrapper({ isOwner: true });
       await wrapper.vm.$nextTick();
       await wrapper.vm.$nextTick();
-    });
-
-    afterEach(() => {
-      delete window.__cmView;
     });
 
     it("displays restore button for owner", () => {
@@ -224,61 +230,56 @@ describe("VersionPreviewModal", () => {
       await wrapper.find('[data-testid="cancel-restore-button"]').trigger("click");
 
       expect(wrapper.find(".confirmation").exists()).toBe(false);
-      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockRestoreVersion).not.toHaveBeenCalled();
     });
 
-    it("dispatches version content to __cmView on confirm", async () => {
+    it("calls restoreVersion on confirm", async () => {
       await wrapper.find('[data-testid="restore-version-button"]').trigger("click");
       await wrapper.find('[data-testid="confirm-restore-button"]').trigger("click");
+      await wrapper.vm.$nextTick();
 
-      expect(mockDispatch).toHaveBeenCalledWith({
-        changes: { from: 0, to: 50, insert: mockVersionContent },
-      });
+      expect(mockRestoreVersion).toHaveBeenCalledWith(1);
     });
 
     it("emits restored event on successful restore", async () => {
       await wrapper.find('[data-testid="restore-version-button"]').trigger("click");
       await wrapper.find('[data-testid="confirm-restore-button"]').trigger("click");
       await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
 
       expect(wrapper.emitted("restored")).toBeTruthy();
       expect(wrapper.emitted("restored")).toHaveLength(1);
     });
 
-    it("shows alert when editor is not available", async () => {
-      delete window.__cmView;
-      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
-
-      await wrapper.find('[data-testid="restore-version-button"]').trigger("click");
-      await wrapper.find('[data-testid="confirm-restore-button"]').trigger("click");
-
-      expect(alertSpy).toHaveBeenCalledWith(
-        "Editor not available. Please open the source editor and try again."
-      );
-
-      alertSpy.mockRestore();
-    });
-
-    it("shows alert on dispatch failure", async () => {
-      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
-      mockDispatch.mockImplementation(() => {
-        throw new Error("Dispatch failed");
-      });
+    it("does not emit restored when restoreVersion returns false", async () => {
+      mockRestoreVersion.mockResolvedValue(false);
 
       await wrapper.find('[data-testid="restore-version-button"]').trigger("click");
       await wrapper.find('[data-testid="confirm-restore-button"]').trigger("click");
       await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted("restored")).toBeFalsy();
+    });
+
+    it("shows alert on restore failure", async () => {
+      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+      mockRestoreVersion.mockRejectedValue(new Error("Restore failed"));
+
+      await wrapper.find('[data-testid="restore-version-button"]').trigger("click");
+      await wrapper.find('[data-testid="confirm-restore-button"]').trigger("click");
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
 
       expect(alertSpy).toHaveBeenCalledWith("Failed to restore version. Please try again.");
-      expect(wrapper.find(".confirmation").exists()).toBe(true);
 
       alertSpy.mockRestore();
     });
 
-    it("close is allowed after synchronous restore completes", async () => {
-      // dispatch is synchronous — isRestoring resets before any UI interaction can occur
+    it("close is allowed after restore completes", async () => {
       await wrapper.find('[data-testid="restore-version-button"]').trigger("click");
       await wrapper.find('[data-testid="confirm-restore-button"]').trigger("click");
+      await wrapper.vm.$nextTick();
       await wrapper.vm.$nextTick();
 
       await wrapper.find(".btn-close").trigger("click");

--- a/frontend/src/tests/composables/useAwareness.test.js
+++ b/frontend/src/tests/composables/useAwareness.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { shallowRef, ref } from "vue";
+import { withSetup } from "../test-utils.js";
+import { useAwareness } from "@/composables/useAwareness.ts";
+
+describe("useAwareness", () => {
+  it("returns awareness proxy and currentUser", () => {
+    const { result } = withSetup(() => useAwareness(), {
+      provide: {
+        awareness: shallowRef(null),
+        user: ref({ id: 1, name: "Test User", email: "test@example.com" }),
+      },
+    });
+
+    expect(result.awareness).toBeDefined();
+    expect(result.currentUser).toBeDefined();
+  });
+
+  it("currentUser reflects injected user values", () => {
+    const { result } = withSetup(() => useAwareness(), {
+      provide: {
+        awareness: shallowRef(null),
+        user: ref({ id: 42, name: "Alice", email: "alice@test.com" }),
+      },
+    });
+
+    expect(result.currentUser.id).toBe(42);
+    expect(result.currentUser.name).toBe("Alice");
+  });
+
+  it("awareness proxy delegates to awareness instance", () => {
+    const mockAwareness = {
+      getStates: () => new Map([[1, { user: { id: 1, name: "User 1" } }]]),
+      setLocalStateField: () => {},
+    };
+
+    const { result } = withSetup(() => useAwareness(), {
+      provide: {
+        awareness: shallowRef(mockAwareness),
+        user: ref({ id: 1, name: "User 1", email: "u1@test.com" }),
+      },
+    });
+
+    const states = result.awareness.getStates();
+    expect(states).toBeInstanceOf(Map);
+    expect(states.size).toBe(1);
+  });
+
+  it("awareness proxy throws when awareness ref is null", () => {
+    const { result } = withSetup(() => useAwareness(), {
+      provide: {
+        awareness: shallowRef(null),
+        user: ref({ id: 1, name: "User", email: "u@test.com" }),
+      },
+    });
+
+    expect(() => result.awareness.getStates()).toThrow("Awareness not initialized");
+  });
+
+  it("currentUser falls back to email when name is missing", () => {
+    const { result } = withSetup(() => useAwareness(), {
+      provide: {
+        awareness: shallowRef(null),
+        user: ref({ id: 1, name: null, email: "fallback@test.com" }),
+      },
+    });
+
+    expect(result.currentUser.name).toBe("fallback@test.com");
+  });
+});

--- a/frontend/src/tests/composables/useEditor.test.js
+++ b/frontend/src/tests/composables/useEditor.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { shallowRef } from "vue";
+import { withSetup } from "../test-utils.js";
+import { useEditor } from "@/composables/useEditor.ts";
+
+describe("useEditor", () => {
+  it("returns editor with isReadOnly and setReadOnly methods", () => {
+    const { result } = withSetup(() => useEditor(), {
+      provide: {
+        cmView: shallowRef(null),
+        readOnlyCompartment: shallowRef(null),
+      },
+    });
+
+    expect(result.editor).toBeDefined();
+    expect(typeof result.editor.isReadOnly).toBe("function");
+    expect(typeof result.editor.setReadOnly).toBe("function");
+  });
+
+  it("isReadOnly returns false when cmView is null", () => {
+    const { result } = withSetup(() => useEditor(), {
+      provide: {
+        cmView: shallowRef(null),
+        readOnlyCompartment: shallowRef(null),
+      },
+    });
+
+    expect(result.editor.isReadOnly()).toBe(false);
+  });
+
+  it("isReadOnly reads from EditorState.readOnly", () => {
+    const mockView = { state: { readOnly: true } };
+    const { result } = withSetup(() => useEditor(), {
+      provide: {
+        cmView: shallowRef(mockView),
+        readOnlyCompartment: shallowRef(null),
+      },
+    });
+
+    expect(result.editor.isReadOnly()).toBe(true);
+  });
+
+  it("setReadOnly dispatches reconfigure effect", () => {
+    const mockReconfigure = vi.fn(() => ({ type: "reconfigure" }));
+    const mockDispatch = vi.fn();
+    const mockView = {
+      state: { readOnly: false },
+      dispatch: mockDispatch,
+    };
+    const mockCompartment = { reconfigure: mockReconfigure };
+
+    const { result } = withSetup(() => useEditor(), {
+      provide: {
+        cmView: shallowRef(mockView),
+        readOnlyCompartment: shallowRef(mockCompartment),
+      },
+    });
+
+    result.editor.setReadOnly(true);
+
+    expect(mockReconfigure).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({
+      effects: { type: "reconfigure" },
+    });
+  });
+
+  it("setReadOnly is a no-op when cmView is null", () => {
+    const { result } = withSetup(() => useEditor(), {
+      provide: {
+        cmView: shallowRef(null),
+        readOnlyCompartment: shallowRef(null),
+      },
+    });
+
+    expect(() => result.editor.setReadOnly(true)).not.toThrow();
+  });
+
+  it("reflects updated cmView ref value", () => {
+    const cmViewRef = shallowRef(null);
+    const { result } = withSetup(() => useEditor(), {
+      provide: {
+        cmView: cmViewRef,
+        readOnlyCompartment: shallowRef(null),
+      },
+    });
+
+    expect(result.editor.isReadOnly()).toBe(false);
+
+    cmViewRef.value = { state: { readOnly: true } };
+    expect(result.editor.isReadOnly()).toBe(true);
+  });
+});

--- a/frontend/src/tests/composables/useVersionRestore.test.js
+++ b/frontend/src/tests/composables/useVersionRestore.test.js
@@ -64,7 +64,21 @@ vi.mock("@/composables/useCurrentUser", () => ({
   })),
 }));
 
-global.fetch = vi.fn();
+const mockApi = {
+  get: vi.fn(),
+};
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual("vue");
+  return {
+    ...actual,
+    inject: vi.fn((key) => {
+      if (key === "api") return mockApi;
+      return actual.inject(key);
+    }),
+  };
+});
+
 global.confirm = vi.fn();
 
 // Import after mocks are set up
@@ -83,10 +97,9 @@ describe("useVersionRestore (simplified)", () => {
       ])
     );
 
-    // Setup fetch mock
-    global.fetch.mockResolvedValue({
-      ok: true,
-      text: () => Promise.resolve("# Original Content\n\nThis is the first version."),
+    // Setup api mock
+    mockApi.get.mockResolvedValue({
+      data: { rsm_content: "# Original Content\n\nThis is the first version." },
     });
 
     // Default confirm to true
@@ -98,10 +111,7 @@ describe("useVersionRestore (simplified)", () => {
       const { restoreVersion } = useVersionRestore(123);
       await restoreVersion(456);
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/files/123/versions/456/preview"),
-        expect.any(Object)
-      );
+      expect(mockApi.get).toHaveBeenCalledWith("/files/123/versions/456/preview");
     });
 
     it("detects concurrent editors and shows confirmation", async () => {
@@ -170,12 +180,11 @@ describe("useVersionRestore (simplified)", () => {
     });
 
     it("handles fetch errors gracefully", async () => {
-      global.fetch.mockRejectedValue(new Error("Network error"));
+      mockApi.get.mockRejectedValue(new Error("Network error"));
 
       const { restoreVersion } = useVersionRestore(123);
 
       await expect(restoreVersion(456)).rejects.toThrow("Network error");
-      // Editor was never locked since fetch failed early, so setReadOnly shouldn't be called
       expect(mockEditor.setReadOnly).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/tests/composables/useYText.test.js
+++ b/frontend/src/tests/composables/useYText.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { shallowRef } from "vue";
+import { withSetup } from "../test-utils.js";
+import { useYText } from "@/composables/useYText.ts";
+
+describe("useYText", () => {
+  it("returns ytext and ydoc proxies", () => {
+    const { result } = withSetup(() => useYText(123), {
+      provide: {
+        ydoc: shallowRef(null),
+      },
+    });
+
+    expect(result.ytext).toBeDefined();
+    expect(result.ydoc).toBeDefined();
+  });
+
+  it("ydoc proxy delegates to injected ydoc", () => {
+    const mockTransact = vi.fn((cb) => cb());
+    const mockDoc = {
+      transact: mockTransact,
+      getText: vi.fn(() => ({ insert: vi.fn(), delete: vi.fn(), length: 0 })),
+    };
+
+    const { result } = withSetup(() => useYText(123), {
+      provide: {
+        ydoc: shallowRef(mockDoc),
+      },
+    });
+
+    result.ydoc.transact(() => {});
+    expect(mockTransact).toHaveBeenCalled();
+  });
+
+  it("ytext proxy accesses getText('text') from ydoc", () => {
+    const mockYText = { insert: vi.fn(), delete: vi.fn(), length: 42 };
+    const mockDoc = {
+      getText: vi.fn(() => mockYText),
+    };
+
+    const { result } = withSetup(() => useYText(123), {
+      provide: {
+        ydoc: shallowRef(mockDoc),
+      },
+    });
+
+    expect(result.ytext.length).toBe(42);
+    expect(mockDoc.getText).toHaveBeenCalledWith("text");
+  });
+
+  it("ydoc proxy throws when ydoc ref is null", () => {
+    const { result } = withSetup(() => useYText(123), {
+      provide: {
+        ydoc: shallowRef(null),
+      },
+    });
+
+    expect(() => result.ydoc.transact).toThrow("Y.Doc not initialized");
+  });
+
+  it("ytext proxy throws when ydoc ref is null", () => {
+    const { result } = withSetup(() => useYText(123), {
+      provide: {
+        ydoc: shallowRef(null),
+      },
+    });
+
+    expect(() => result.ytext.length).toThrow("Y.Text not initialized");
+  });
+
+  it("reflects updated ydoc ref value", () => {
+    const ydocRef = shallowRef(null);
+    const { result } = withSetup(() => useYText(123), {
+      provide: {
+        ydoc: ydocRef,
+      },
+    });
+
+    expect(() => result.ydoc.transact).toThrow("Y.Doc not initialized");
+
+    const mockDoc = {
+      transact: vi.fn((cb) => cb()),
+      getText: vi.fn(() => ({ insert: vi.fn(), delete: vi.fn(), length: 10 })),
+    };
+    ydocRef.value = mockDoc;
+
+    result.ydoc.transact(() => {});
+    expect(mockDoc.transact).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/e2e/content/version-restore.spec.js
+++ b/frontend/src/tests/e2e/content/version-restore.spec.js
@@ -3,7 +3,7 @@
  * @tags @auth @version-restore
  *
  * Tests the core restore flow: owner restores a named version via the
- * preview modal, content is replaced via Y.js (window.__cmView.dispatch),
+ * preview modal, content is replaced via Y.js (useVersionRestore composable),
  * and all connected clients receive the update.
  *
  * Tests for concurrent-editor detection, read-only lock, and in-progress
@@ -118,7 +118,7 @@ test.describe("Version Restore Tests @auth @version-restore", () => {
       timeout: 5000,
     });
 
-    // Content is replaced via __cmView.dispatch (synchronous, no Y.js propagation delay)
+    // Content is replaced via Y.js transaction (useVersionRestore composable)
     const content = await page.evaluate(() => window.__cmView?.state.doc.toString());
     expect(content).toContain("Original Content");
     expect(content).not.toContain("Modified Content");

--- a/frontend/src/tests/e2e/content/version-restore.spec.js
+++ b/frontend/src/tests/e2e/content/version-restore.spec.js
@@ -6,9 +6,9 @@
  * preview modal, content is replaced via Y.js (useVersionRestore composable),
  * and all connected clients receive the update.
  *
- * Tests for concurrent-editor detection, read-only lock, and in-progress
- * guard are skipped pending implementation of the useAwareness /
- * useEditor composables (currently stubs).
+ * Tests for concurrent-editor detection and read-only lock exercise the
+ * useAwareness / useEditor composables via the useVersionRestore flow.
+ * The in-progress guard is covered by unit tests (race condition is fragile in e2e).
  */
 
 import { test, expect } from "../fixtures.js";
@@ -187,16 +187,122 @@ test.describe("Version Restore Tests @auth @version-restore", () => {
     }
   });
 
-  test("concurrent editor detection shows warning", async () => {
-    // Requires useAwareness composable (currently a stub that throws).
-    // Implement once useAwareness is wired to the Y.js provider.
-    test.skip();
+  test("concurrent editor detection shows warning", async ({ page, browser, request }) => {
+    test.setTimeout(90000);
+
+    const backendURL = getBackendURL();
+    const timeouts = getTimeouts();
+
+    // Register + login a second user
+    await request
+      .post(`${backendURL}/register`, {
+        data: {
+          email: "concurrenttest@example.com",
+          name: "Concurrent Test User",
+          initials: "CT",
+          password: "testpass123",
+        },
+      })
+      .catch(() => {});
+    const editorAuth = await loginUser(request, "concurrenttest@example.com", "testpass123");
+
+    // Share the file with the second user as EDITOR
+    const { accessToken } = await authHelpers.getStoredTokens();
+    await request.post(`${backendURL}/files/${fileId}/permissions`, {
+      headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+      data: { user_id: editorAuth.userData.id, role: "EDITOR" },
+    });
+
+    // Open the file as the editor in a separate browser context
+    const editor = await createAuthenticatedContext(browser, editorAuth);
+    try {
+      await openFileInEditor(editor.page, fileId);
+
+      // Simulate active editing by setting awareness cursor state
+      await editor.page.evaluate(() => {
+        if (window.__awareness) {
+          window.__awareness.setLocalStateField("cursor", { anchor: 0, head: 5 });
+          window.__awareness.setLocalStateField("editing", true);
+        }
+      });
+
+      // Wait for awareness to propagate
+      await page.waitForTimeout(500);
+
+      // page1 (owner): open version preview and attempt restore
+      await page.locator('[data-testid="version-item"]').first().locator(".version-info").click();
+      await page.waitForSelector('[data-testid="version-preview-modal"]', {
+        timeout: timeouts.heavyOperation,
+      });
+      await page.waitForSelector(".loading-state", { state: "hidden", timeout: 5000 });
+
+      await page.click('[data-testid="restore-version-button"]');
+      await page.waitForSelector('[data-testid="restore-confirm-dialog"]');
+
+      // Set up dialog handler to capture the confirm() prompt about concurrent editors
+      let dialogMessage = "";
+      page.once("dialog", async (dialog) => {
+        dialogMessage = dialog.message();
+        await dialog.accept();
+      });
+
+      await page.click('[data-testid="confirm-restore-button"]');
+
+      // Wait for restore to complete (dialog + Y.js transaction)
+      await expect(page.locator('[data-testid="version-preview-modal"]')).not.toBeVisible({
+        timeout: timeouts.heavyOperation,
+      });
+
+      // Verify the confirm dialog was shown with concurrent editor info
+      expect(dialogMessage).toContain("other user");
+    } finally {
+      await cleanupYjs(editor.page).catch(() => {});
+      await editor.context.close();
+    }
   });
 
-  test("editor is read-only during restore", async () => {
-    // Requires useEditor composable (currently a stub that throws).
-    // The read-only lock feature will be enabled when useEditor is implemented.
-    test.skip();
+  test("editor is read-only during restore", async ({ page }) => {
+    test.setTimeout(60000);
+    const timeouts = getTimeouts();
+
+    // Open version preview
+    await page.locator('[data-testid="version-item"]').first().locator(".version-info").click();
+    await page.waitForSelector('[data-testid="version-preview-modal"]', {
+      timeout: timeouts.heavyOperation,
+    });
+    await page.waitForSelector(".loading-state", { state: "hidden", timeout: 5000 });
+
+    // Set up a promise to check read-only state during restore.
+    // useVersionRestore locks the editor and waits 1000ms, giving us time to observe.
+    const readOnlyDuringRestore = page.evaluate(() => {
+      return new Promise((resolve) => {
+        const checkInterval = setInterval(() => {
+          if (window.__cmView?.state?.readOnly) {
+            clearInterval(checkInterval);
+            resolve(true);
+          }
+        }, 50);
+        setTimeout(() => {
+          clearInterval(checkInterval);
+          resolve(false);
+        }, 5000);
+      });
+    });
+
+    await page.click('[data-testid="restore-version-button"]');
+    await page.waitForSelector('[data-testid="restore-confirm-dialog"]');
+    await page.click('[data-testid="confirm-restore-button"]');
+
+    // Verify editor was read-only at some point during the restore
+    const wasReadOnly = await readOnlyDuringRestore;
+    expect(wasReadOnly).toBe(true);
+
+    // After restore completes, editor should be editable again
+    await expect(page.locator('[data-testid="version-preview-modal"]')).not.toBeVisible({
+      timeout: timeouts.heavyOperation,
+    });
+    const isEditableAfter = await page.evaluate(() => !window.__cmView?.state?.readOnly);
+    expect(isEditableAfter).toBe(true);
   });
 
   test("all connected clients see restored content", async ({ page, context }) => {
@@ -239,9 +345,9 @@ test.describe("Version Restore Tests @auth @version-restore", () => {
   });
 
   test("cannot restore while another restore is in progress", async () => {
-    // The current dispatch-based restore is synchronous, so isRestoring flips
-    // true→false within a single microtask — no observable window to assert.
-    // Implement once restore becomes async (e.g., awaiting backend persistence).
+    // The isRestoring ref gates the UI (buttons disabled while restoring),
+    // but testing a race condition between two simultaneous restores in e2e
+    // is fragile. The unit tests in useVersionRestore.test.js cover this.
     test.skip();
   });
 });

--- a/frontend/src/tests/test-utils.js
+++ b/frontend/src/tests/test-utils.js
@@ -1,0 +1,28 @@
+import { createApp, defineComponent, h } from "vue";
+
+/**
+ * Run a composable inside a Vue setup context with provide/inject support.
+ * Returns { result, app } where result is the composable's return value.
+ */
+export function withSetup(composable, options = {}) {
+  let result;
+
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = composable();
+        return () => h("div");
+      },
+    }),
+  );
+
+  if (options.provide) {
+    for (const [key, value] of Object.entries(options.provide)) {
+      app.provide(key, value);
+    }
+  }
+
+  app.mount(document.createElement("div"));
+
+  return { result, app };
+}

--- a/frontend/src/views/workspace/Canvas.vue
+++ b/frontend/src/views/workspace/Canvas.vue
@@ -48,13 +48,11 @@
   );
   provide("manuscriptRef", manuscriptRef);
 
-  // Shared awareness ref — EditorCodeMirror writes to it, ScrollbarMinimap reads it
-  const awareness = shallowRef(null);
-  provide("awareness", awareness);
+  // Shared awareness ref — provided by View.vue, EditorCodeMirror writes to it
+  const awareness = inject("awareness", shallowRef(null));
 
-  // Shared CodeMirror view — EditorCodeMirror writes, TopbarSearch reads for Source scope search
-  const cmView = shallowRef(null);
-  provide("cmView", cmView);
+  // Shared CodeMirror view — provided by View.vue, EditorCodeMirror writes to it
+  const cmView = inject("cmView", shallowRef(null));
 
   // LSP client and document URI — EditorCodeMirror writes, used for source/preview navigation
   const lspClient = shallowRef(null);

--- a/frontend/src/views/workspace/EditorCodeMirror.vue
+++ b/frontend/src/views/workspace/EditorCodeMirror.vue
@@ -62,6 +62,8 @@
   const isInitialized = ref(false);
   const roomName = ref("");
   const readOnlyCompartment = new Compartment();
+  const parentReadOnlyCompartment = inject("readOnlyCompartment", null);
+  if (parentReadOnlyCompartment) parentReadOnlyCompartment.value = readOnlyCompartment;
 
   // WebSocket server URL
   const serverUrl = ref(import.meta.env.VITE_MULTIPLAYER_URL || "ws://localhost:1234");

--- a/frontend/src/views/workspace/VersionPreviewModal.vue
+++ b/frontend/src/views/workspace/VersionPreviewModal.vue
@@ -1,7 +1,8 @@
 <script setup>
-  import { ref, inject, onMounted } from "vue";
+  import { ref, inject, onMounted, onBeforeUnmount } from "vue";
   import { IconX } from "@/components/base/iconRegistry.js";
   import Button from "@/components/base/Button.vue";
+  import { useVersionRestore } from "@/composables/useVersionRestore.ts";
 
   const props = defineProps({
     version: { type: Object, required: true },
@@ -12,14 +13,13 @@
   const emit = defineEmits(["close", "restored"]);
 
   const api = inject("api");
+  const { restoreVersion, isRestoring } = useVersionRestore(props.fileId);
 
   const versionContent = ref("");
   const isLoadingContent = ref(false);
   const contentError = ref(null);
-  const isRestoring = ref(false);
   const showConfirmation = ref(false);
 
-  // Fetch version content for preview
   async function fetchVersionContent() {
     isLoadingContent.value = true;
     contentError.value = null;
@@ -35,59 +35,43 @@
     }
   }
 
-  // Handle restore button click
   function handleRestoreClick() {
     showConfirmation.value = true;
   }
 
-  // Confirm and execute restore via Y.js (window.__cmView is the live CodeMirror/Y.js binding)
   async function confirmRestore() {
-    const view = window.__cmView;
-    if (!view) {
-      alert("Editor not available. Please open the source editor and try again.");
-      return;
-    }
-
     if (!versionContent.value) {
       alert("Version content not loaded. Please wait and try again.");
       return;
     }
 
-    isRestoring.value = true;
-
     try {
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: versionContent.value },
-      });
-      emit("restored");
+      const success = await restoreVersion(props.version.id);
+      if (success) {
+        emit("restored");
+      }
     } catch (err) {
       console.error("Failed to restore version:", err);
       alert("Failed to restore version. Please try again.");
-    } finally {
-      isRestoring.value = false;
     }
   }
 
-  // Cancel restore
   function cancelRestore() {
     showConfirmation.value = false;
   }
 
-  // Close modal
   function close() {
     if (!isRestoring.value) {
       emit("close");
     }
   }
 
-  // Handle backdrop click
   function handleBackdropClick(event) {
     if (event.target === event.currentTarget) {
       close();
     }
   }
 
-  // Handle ESC key
   function handleKeydown(event) {
     if (event.key === "Escape" && !isRestoring.value) {
       event.stopImmediatePropagation();
@@ -98,12 +82,9 @@
 
   onMounted(() => {
     fetchVersionContent();
-    // Use capture phase to run before drawer's ESC handler
     window.addEventListener("keydown", handleKeydown, { capture: true });
   });
 
-  // Cleanup
-  import { onBeforeUnmount } from "vue";
   onBeforeUnmount(() => {
     window.removeEventListener("keydown", handleKeydown, { capture: true });
   });

--- a/frontend/src/views/workspace/View.vue
+++ b/frontend/src/views/workspace/View.vue
@@ -94,6 +94,16 @@
   const ydoc = shallowRef(null);
   provide("ydoc", ydoc);
 
+  // Shared awareness + cmView refs — lifted here so both Canvas and Sidebar subtrees can inject
+  const awareness = shallowRef(null);
+  provide("awareness", awareness);
+
+  const cmView = shallowRef(null);
+  provide("cmView", cmView);
+
+  const readOnlyCompartment = shallowRef(null);
+  provide("readOnlyCompartment", readOnlyCompartment);
+
   const fileId = computed(() => file.value?.id);
   const {
     annotations,


### PR DESCRIPTION
## Summary
- Implement stub composables (`useEditor`, `useAwareness`, `useYText`, `useCurrentUser`) with inject-based implementations using lazy proxy patterns for deferred access
- Wire `VersionPreviewModal` to use `useVersionRestore` composable instead of raw `window.__cmView.dispatch`, enabling concurrent editor detection, read-only lock, awareness broadcasting, and atomic Y.js transactions
- Lift `awareness`/`cmView`/`readOnlyCompartment` provides from `Canvas.vue` to `View.vue` so both Canvas and Sidebar subtrees can inject them
- Add 17 unit tests for composables + update 27 existing modal tests

## Test plan
- [x] All composable unit tests pass (useEditor: 6, useAwareness: 5, useYText: 6, useVersionRestore: 12)
- [x] VersionPreviewModal unit tests pass (27 tests)
- [x] DrawerVersions tests pass (30 tests)
- [x] Minimap architecture test updated and passing
- [x] Full frontend test suite: 0 new failures (7 pre-existing on main)
- [ ] E2E: version restore flow (CI)
- [ ] E2E: concurrent editor detection (skipped pending full collab setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)