### PR TITLE
ci: fix destroy job self-conflict on close

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -260,11 +260,15 @@ jobs:
   destroy:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
-    # Share the deploy job's concurrency group so a force-close mid-deploy
-    # waits for the in-flight deploy to finish before tearing it down.
-    # Without this, destroy can race with create and leave orphan resources.
+    # Use a destroy-specific concurrency group (NOT the workflow-level
+    # `preview-<head-ref>` group, which the close event already holds at
+    # workflow scope — same-group acquisition at job level self-conflicts
+    # and the destroy job dies during scheduling).
+    # Result: serializes destroy-vs-destroy on the same PR; does not
+    # serialize destroy against an in-flight deploy. The orphan-cleanup
+    # cron is the catch-all if a force-close races with a deploy.
     concurrency:
-      group: preview-${{ github.event.pull_request.head.ref }}
+      group: preview-destroy-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: false
 
     env:


### PR DESCRIPTION
## Summary

Follow-up to #392. The destroy job's added job-level \`concurrency\` group used the same name as the workflow-level group, causing the close event's destroy to fail at scheduling (same-run self-conflict). Every closed PR has been leaking its fly app + DB until the weekly cron catches it.

PR #392's own merge demonstrated the bug: destroy job started==completed at the same instant, no runner allocated, 0 steps, conclusion=failure. The cron then dispatched manually destroyed the orphans.

## Fix
Rename the destroy job's concurrency group to \`preview-destroy-<head-ref>\` so it doesn't collide with the workflow-level \`preview-<head-ref>\` group. Inline destroy will run cleanly again. The cron remains the catch-all for the (rare) case where a force-close races with an in-flight deploy.

This is option A from the experts review:
- Drops the speculative race-fix-via-shared-group (the cron has empirically proved it works)
- Restores the inline destroy path
- One-line YAML change

## Test plan
- [ ] Merge this PR and watch its own destroy job complete successfully (smoke test).
- [ ] Confirm no orphan apps remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)