### PR TITLE
fix(annotations): unify edit state; un-skip 10 regressed frontend tests

### DIFF
--- a/frontend/src/components/annotations/Note.vue
+++ b/frontend/src/components/annotations/Note.vue
@@ -1,5 +1,14 @@
 <script setup>
-  import { ref, inject, computed, watch, nextTick, onMounted, onUnmounted, useTemplateRef } from "vue";
+  import {
+    ref,
+    inject,
+    computed,
+    watch,
+    nextTick,
+    onMounted,
+    onUnmounted,
+    useTemplateRef,
+  } from "vue";
   import { HIGHLIGHT_COLORS, SWATCH_COLORS } from "@/constants/annotationColors.js";
   import { renderInlineMath, ensureTemml } from "@/utils/renderInlineMath.js";
   import Avatar from "@/components/base/Avatar.vue";
@@ -75,6 +84,12 @@
   const annotationOwner = computed(() => props.annotation.owner);
 
   const isActive = computed(() => activeAnnotationId.value === props.annotation.id);
+
+  // Unified edit indicator: true when either the legacy whole-card edit (private
+  // notes with no existing message) or per-message edit (existing private notes
+  // and thread messages) is active. Drives the "suppress active border while
+  // editing" UX and the ESC-cancels-edit-before-deselect behavior.
+  const isEditing = computed(() => editing.value || editingMessageId.value !== null);
 
   const note = computed(() => {
     const msgs = props.annotation.messages?.filter((m) => !m.deleted_at);
@@ -286,7 +301,10 @@
   }
 
   function onEsc(e) {
-    if (editing.value) {
+    if (editingMessageId.value !== null) {
+      onCancelMessageEdit();
+      e.stopPropagation();
+    } else if (editing.value) {
       onCancelEdit();
     } else if (isActive.value) {
       activeAnnotationId.value = null;
@@ -422,8 +440,8 @@
     ref="note-ref"
     class="note"
     :class="{
-      active: isActive && !editing,
-      editing,
+      active: isActive && !isEditing,
+      editing: isEditing,
       collapsed: collapsed && note,
       shared: isShared,
       orphaned: orphaned,
@@ -448,7 +466,8 @@
         v-if="!isShared && note && isMessageEdited(note)"
         class="edited-tag"
         :title="editedTimeAgo(note)"
-      >edited</span>
+        >edited</span
+      >
       <div class="actions">
         <Button
           v-if="isOwnAnnotation && !isShared"
@@ -539,6 +558,7 @@
           ref="editInput"
           :model-value="editText"
           placeholder="Add a note..."
+          aria-label="Annotation note"
           :rows="2"
           :compact="true"
           layout="inline"
@@ -566,11 +586,9 @@
               <Avatar v-if="msg.owner" :user="msg.owner" size="sm" :tooltip="true" />
               <span class="thread-author">{{ msg.owner?.name || "Unknown" }}</span>
               <span class="thread-time">{{ messageTimeAgo(msg) }}</span>
-              <span
-                v-if="isMessageEdited(msg)"
-                class="edited-tag"
-                :title="editedTimeAgo(msg)"
-              >edited</span>
+              <span v-if="isMessageEdited(msg)" class="edited-tag" :title="editedTimeAgo(msg)"
+                >edited</span
+              >
             </div>
             <template v-if="editingMessageId === msg.id">
               <div class="thread-message-edit-area" @click.stop>
@@ -582,13 +600,18 @@
                   layout="inline"
                   :show-buttons="false"
                   :submit-on-enter="true"
+                  aria-label="Edit annotation message"
                   @update:model-value="editMessageText = $event"
                   @submit="(val) => onSaveMessageEdit(msg, val)"
                   @keydown.esc.stop="onCancelMessageEdit"
                 />
                 <div class="edit-actions">
-                  <Button kind="tertiary" size="xs" @click.stop="onCancelMessageEdit">Cancel</Button>
-                  <Button kind="primary" size="xs" @click.stop="onSaveMessageEdit(msg)">Save</Button>
+                  <Button kind="tertiary" size="xs" @click.stop="onCancelMessageEdit"
+                    >Cancel</Button
+                  >
+                  <Button kind="primary" size="xs" @click.stop="onSaveMessageEdit(msg)"
+                    >Save</Button
+                  >
                 </div>
               </div>
             </template>
@@ -639,6 +662,7 @@
               layout="inline"
               :show-buttons="false"
               :submit-on-enter="true"
+              aria-label="Edit annotation note"
               @update:model-value="editMessageText = $event"
               @submit="(val) => onSaveMessageEdit(note, val)"
               @keydown.esc.stop="onCancelMessageEdit"
@@ -665,7 +689,9 @@
               size="xs"
               :icon="confirmingDeleteMessageId === note.id ? '' : 'Trash'"
               :text="confirmingDeleteMessageId === note.id ? 'Delete' : 'Delete'"
-              :aria-label="confirmingDeleteMessageId === note.id ? 'Confirm delete note' : 'Delete note'"
+              :aria-label="
+                confirmingDeleteMessageId === note.id ? 'Confirm delete note' : 'Delete note'
+              "
               @click.stop="onDeleteMessageClick(note)"
             />
           </div>
@@ -744,16 +770,22 @@
     border-radius: var(--radius-lg);
     padding: 12px 14px 14px;
     background-color: var(--surface-page);
-    box-shadow: 0 1px 4px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06);
+    box-shadow:
+      0 1px 4px rgba(0, 0, 0, 0.12),
+      0 2px 6px rgba(0, 0, 0, 0.06);
   }
 
   .note.shared.active:not(:focus-within) {
-    box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 2px 10px var(--note-color-100);
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.06),
+      0 2px 10px var(--note-color-100);
   }
 
   .note.shared:hover:not(.active) {
     background-color: var(--surface-page);
-    box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 2px 10px var(--note-color-100);
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.06),
+      0 2px 10px var(--note-color-100);
   }
 
   .note.shared.search-match {
@@ -1033,7 +1065,9 @@
     cursor: pointer;
     border-radius: 4px;
     opacity: 0;
-    transition: opacity 0.15s ease, color 0.15s ease;
+    transition:
+      opacity 0.15s ease,
+      color 0.15s ease;
   }
 
   .thread-message:hover .inline-edit-btn,
@@ -1051,7 +1085,6 @@
     outline-offset: 1px;
   }
 
-
   .thread-message-edit-area {
     margin: 3px 0 0 22px;
     display: flex;
@@ -1063,7 +1096,6 @@
     margin-left: 0;
     margin-top: 6px;
   }
-
 
   /* ---------------------------------------------------------------
      REPLY AREA (shared threads)
@@ -1105,7 +1137,6 @@
     justify-content: flex-end;
     gap: 4px;
   }
-
 
   .color-picker {
     display: flex;

--- a/frontend/src/components/base/TextareaInput.vue
+++ b/frontend/src/components/base/TextareaInput.vue
@@ -6,6 +6,7 @@
       :placeholder="placeholder"
       :disabled="disabled"
       :rows="rows"
+      :aria-label="ariaLabel || undefined"
       class="textarea"
       @keydown="handleKeydown"
       @input="handleInput"
@@ -49,6 +50,10 @@
       placeholder: {
         type: String,
         default: "Type something...",
+      },
+      ariaLabel: {
+        type: String,
+        default: "",
       },
       disabled: {
         type: Boolean,

--- a/frontend/src/tests/components/AnnotationMenuRedesign.test.js
+++ b/frontend/src/tests/components/AnnotationMenuRedesign.test.js
@@ -10,14 +10,11 @@ import { resolve } from "path";
 
 const menuSource = readFileSync(
   resolve(__dirname, "../../components/annotations/AnnotationMenu.vue"),
-  "utf-8",
+  "utf-8"
 );
-const menuScript =
-  menuSource.match(/<script[^>]*>([\s\S]*)<\/script>/)?.[1] ?? "";
-const menuTemplate =
-  menuSource.match(/<template>([\s\S]*)<\/template>/)?.[1] ?? "";
-const menuStyle =
-  menuSource.match(/<style[^>]*>([\s\S]*)<\/style>/)?.[1] ?? "";
+const menuScript = menuSource.match(/<script[^>]*>([\s\S]*)<\/script>/)?.[1] ?? "";
+const menuTemplate = menuSource.match(/<template>([\s\S]*)<\/template>/)?.[1] ?? "";
+const menuStyle = menuSource.match(/<style[^>]*>([\s\S]*)<\/style>/)?.[1] ?? "";
 
 describe("AnnotationMenu redesign — swatches as color selectors", () => {
   it("has a selectedColor ref defaulting to purple", () => {
@@ -39,9 +36,7 @@ describe("AnnotationMenu redesign — swatches as color selectors", () => {
   });
 
   it("clearSelection resets selectedColor to purple", () => {
-    expect(menuScript).toMatch(
-      /clearSelection[\s\S]*selectedColor\.value\s*=\s*["']purple["']/,
-    );
+    expect(menuScript).toMatch(/clearSelection[\s\S]*selectedColor\.value\s*=\s*["']purple["']/);
   });
 });
 
@@ -63,15 +58,11 @@ describe("AnnotationMenu redesign — three labeled action buttons", () => {
   });
 
   it("Note button creates private annotation", () => {
-    expect(menuTemplate).toMatch(
-      /onCreateAnnotation\(["']private["']\)/,
-    );
+    expect(menuTemplate).toMatch(/onCreateAnnotation\(["']private["']\)/);
   });
 
   it("Comment button creates shared annotation", () => {
-    expect(menuTemplate).toMatch(
-      /onCreateAnnotation\(["']shared["']\)/,
-    );
+    expect(menuTemplate).toMatch(/onCreateAnnotation\(["']shared["']\)/);
   });
 });
 
@@ -81,9 +72,7 @@ describe("AnnotationMenu redesign — actions use selectedColor", () => {
   });
 
   it("onHighlight uses selectedColor.value for color", () => {
-    expect(menuScript).toMatch(
-      /onHighlight[\s\S]*color:\s*selectedColor\.value/,
-    );
+    expect(menuScript).toMatch(/onHighlight[\s\S]*color:\s*selectedColor\.value/);
   });
 });
 
@@ -94,18 +83,12 @@ describe("AnnotationMenu redesign — keyboard navigation", () => {
   });
 
   it("swatches use roving tabindex pattern", () => {
-    expect(menuTemplate).toMatch(
-      /tabindex.*selectedColor\s*===\s*name\s*\?\s*0\s*:\s*-1/,
-    );
+    expect(menuTemplate).toMatch(/tabindex.*selectedColor\s*===\s*name\s*\?\s*0\s*:\s*-1/);
   });
 });
 
 describe("AnnotationMenu redesign — selected swatch visual", () => {
-  // TODO(std-dm4v): regressed silently while unit-frontend CI was no-op'ing (#399 unmasked).
-  // The AnnotationMenu component template no longer matches /boxShadow.*selectedColor/.
-  // Likely the styling moved to CSS variables or a computed style; update the test to
-  // match the actual implementation when triaging.
-  it.skip("selected swatch has a ring via box-shadow", () => {
-    expect(menuTemplate).toMatch(/boxShadow.*selectedColor/);
+  it("selected swatch has a ring via box-shadow", () => {
+    expect(menuTemplate).toMatch(/boxShadow[\s\S]*selectedColor/);
   });
 });

--- a/frontend/src/tests/components/ManuscriptWrapper.test.js
+++ b/frontend/src/tests/components/ManuscriptWrapper.test.js
@@ -19,39 +19,36 @@ describe("ManuscriptWrapper.vue", () => {
     onloadStub.mockReset();
   });
 
-  // TODO(std-dm4v): regressed silently while unit-frontend CI was no-op'ing (#399 unmasked).
-  // The `[data-test="manuscript"]` element no longer mounts via the stub. Likely the
-  // ManuscriptWrapper internals changed (recall it now uses parseHtmlToVNodes via h() instead
-  // of a child <Manuscript> component). Re-enable after triage — the test design likely
-  // needs to be rewritten against the new VNode-based architecture.
-  it.skip("renders Manuscript component with given htmlString and settings", async () => {
+  it("applies settings as inline styles on the mount point", async () => {
+    // The redesign renders htmlString directly into mount-point-ref via DOM
+    // manipulation (onload/onrender hooks), replacing the previous child
+    // <Manuscript> component. Verify the settings reach the mount point as
+    // inline styles, which is the contract this wrapper is responsible for.
     const html = "<div>content</div>";
     const settings = {
-      background: "bg",
-      fontSize: "fs",
-      lineHeight: "lh",
-      fontFamily: "ff",
-      marginWidth: "mw",
+      background: "rgb(255, 0, 0)",
+      fontSize: "18px",
+      lineHeight: "1.6",
+      fontFamily: "Inter",
+      marginWidth: "2rem",
     };
     const api = { defaults: { baseURL: "" } };
-    const stubManuscript = defineComponent({
-      props: { htmlString: { type: String }, settings: { type: Object } },
-      template: '<div data-test="manuscript">{{ htmlString }}</div>',
-    });
     const wrapper = mount(ManuscriptWrapper, {
       props: { htmlString: html, keys: true, settings },
       global: {
         provide: { api },
-        stubs: { Manuscript: stubManuscript, Teleport: true, AnnotationMenu: true },
+        stubs: { Teleport: true, AnnotationMenu: true },
       },
     });
     await flushPromises();
     await nextTick();
-    const ms = wrapper.find('[data-test="manuscript"]');
-    expect(ms.exists()).toBe(true);
-    expect(ms.text()).toBe(html);
-    expect(wrapper.findComponent(stubManuscript).props("htmlString")).toBe(html);
-    expect(wrapper.findComponent(stubManuscript).props("settings")).toStrictEqual(settings);
+    const mountPoint = wrapper.find(".manuscriptwrapper");
+    expect(mountPoint.exists()).toBe(true);
+    const style = mountPoint.attributes("style") || "";
+    expect(style).toContain("background-color: rgb(255, 0, 0)");
+    expect(style).toContain("font-size: 18px");
+    expect(style).toContain("line-height: 1.6");
+    expect(style).toContain("font-family: Inter");
   });
 
   // Removed: "calls onload with element and keys option" test

--- a/frontend/src/tests/components/NoteEditDelete.test.js
+++ b/frontend/src/tests/components/NoteEditDelete.test.js
@@ -12,14 +12,11 @@ import { resolve } from "path";
 
 const noteSource = readFileSync(
   resolve(__dirname, "../../components/annotations/Note.vue"),
-  "utf-8",
+  "utf-8"
 );
-const noteScript =
-  noteSource.match(/<script[^>]*>([\s\S]*)<\/script>/)?.[1] ?? "";
-const noteTemplate =
-  noteSource.match(/<template>([\s\S]*)<\/template>/)?.[1] ?? "";
-const noteStyle =
-  noteSource.match(/<style[^>]*>([\s\S]*)<\/style>/)?.[1] ?? "";
+const noteScript = noteSource.match(/<script[^>]*>([\s\S]*)<\/script>/)?.[1] ?? "";
+const noteTemplate = noteSource.match(/<template>([\s\S]*)<\/template>/)?.[1] ?? "";
+const noteStyle = noteSource.match(/<style[^>]*>([\s\S]*)<\/style>/)?.[1] ?? "";
 
 describe("Note.vue — per-message edit/delete", () => {
   describe("state management", () => {
@@ -66,7 +63,7 @@ describe("Note.vue — per-message edit/delete", () => {
     it("does NOT show delete button in shared thread messages", () => {
       // Extract the shared thread section: from class="thread" to the reply-area
       const sharedThreadSection = noteTemplate.match(
-        /class="thread"[\s\S]*?class="reply-area"/,
+        /class="thread"[\s\S]*?class="reply-area"/
       )?.[0];
       expect(sharedThreadSection).toBeDefined();
       // Should have inline edit button for messages
@@ -85,9 +82,7 @@ describe("Note.vue — per-message edit/delete", () => {
   describe("private note template", () => {
     it("shows edited indicator for private notes in the header", () => {
       // The edited tag for private notes is in the header, next to the timestamp
-      const headerSection = noteTemplate.match(
-        /class="header"[\s\S]*?class="actions"/,
-      )?.[0];
+      const headerSection = noteTemplate.match(/class="header"[\s\S]*?class="actions"/)?.[0];
       expect(headerSection).toBeDefined();
       expect(headerSection).toMatch(/isMessageEdited\(note\)/);
       expect(headerSection).toMatch(/editedTimeAgo\(note\)/);
@@ -110,10 +105,9 @@ describe("Note.vue — per-message edit/delete", () => {
       expect(noteScript).toMatch(/editMessageText\.value = msg\.content/);
     });
 
-    // TODO(std-dm4v): regressed silently while unit-frontend CI was no-op'ing (#399 unmasked).
-    // Note.vue no longer contains `function onSaveMessageEdit(msg)`. Re-enable after triage.
-    it.skip("onSaveMessageEdit calls annotationActions.updateNote", () => {
-      expect(noteScript).toMatch(/function onSaveMessageEdit\(msg\)/);
+    it("onSaveMessageEdit calls annotationActions.updateNote", () => {
+      // Signature now takes (msg, submittedValue) to support submit-on-enter
+      expect(noteScript).toMatch(/function onSaveMessageEdit\(msg(?:,\s*\w+)?\)/);
       expect(noteScript).toMatch(/annotationActions\.updateNote\(msg\.id/);
     });
 

--- a/frontend/src/tests/components/annotations/Note.regression.test.js
+++ b/frontend/src/tests/components/annotations/Note.regression.test.js
@@ -300,31 +300,28 @@ describe("Note.vue — ESC deselects active card (std-e0vc)", () => {
     expect(activeAnnotationId.value).toBe(999);
   });
 
-  // TODO(std-dm4v): regressed silently while unit-frontend CI was no-op'ing (#399 unmasked).
-  // The original std-e0vc work was closed; behavior has drifted. Re-enable after triage.
-  it.skip("ESC on textarea cancels edit without deselecting (stopPropagation)", async () => {
+  it("ESC on textarea cancels edit without deselecting (stopPropagation)", async () => {
     const { wrapper, activeAnnotationId } = createWrapper(makeAnnotationWithNote({ id: 3 }), {
       activeId: 3,
     });
-    // Enter edit mode
+    // Enter edit mode — existing private notes use the per-message edit path
+    // (.thread-message-edit-area), not the legacy .edit-area.
     const editBtn = findButtonByIcon(wrapper, "Edit");
     await editBtn.trigger("click");
     await nextTick();
-    expect(wrapper.find(".edit-area").exists()).toBe(true);
+    expect(wrapper.find(".thread-message-edit-area").exists()).toBe(true);
 
-    // ESC on textarea
-    await wrapper.find(".edit-input").trigger("keydown", { key: "Escape" });
+    // ESC on the textarea inside the edit area
+    await wrapper.find(".thread-message-edit-area textarea").trigger("keydown", { key: "Escape" });
     await nextTick();
 
-    expect(wrapper.find(".edit-area").exists()).toBe(false);
+    expect(wrapper.find(".thread-message-edit-area").exists()).toBe(false);
     expect(activeAnnotationId.value).toBe(3);
   });
 });
 
 describe("Note.vue — edit mode suppresses active border (std-5l1z)", () => {
-  // TODO(std-dm4v): regressed silently while unit-frontend CI was no-op'ing (#399 unmasked).
-  // The original std-5l1z work was closed; behavior has drifted. Re-enable after triage.
-  it.skip("active class is removed during editing", async () => {
+  it("active class is removed during editing", async () => {
     const { wrapper } = createWrapper(makeAnnotationWithNote({ id: 3 }), { activeId: 3 });
     expect(wrapper.find(".note").classes()).toContain("active");
 
@@ -336,8 +333,7 @@ describe("Note.vue — edit mode suppresses active border (std-5l1z)", () => {
     expect(wrapper.find(".note").classes()).toContain("editing");
   });
 
-  // TODO(std-dm4v): same regression as the test above (std-5l1z).
-  it.skip("active class returns after saving edit", async () => {
+  it("active class returns after saving edit", async () => {
     const { wrapper } = createWrapper(makeAnnotationWithNote({ id: 3 }), { activeId: 3 });
     await findButtonByIcon(wrapper, "Edit").trigger("click");
     await nextTick();

--- a/frontend/src/tests/components/annotations/a11y.test.js
+++ b/frontend/src/tests/components/annotations/a11y.test.js
@@ -61,12 +61,18 @@ describe("Note.vue — aria-labels on action buttons (std-01at)", () => {
   });
 });
 
-describe("Note.vue — textarea focus outline (std-9ywg)", () => {
-  // TODO(std-dm4v): regressed silently while unit-frontend CI was no-op'ing (#399 unmasked).
-  // The original std-9ywg work was closed; .edit-input:focus block no longer contains 'outline'.
-  it.skip("edit-input focus has outline, not just border-color", () => {
-    const focusBlock = noteStyle.match(/\.edit-input:focus\s*\{([^}]*)\}/s)?.[1] ?? "";
-    expect(focusBlock).toContain("outline");
+describe("Note.vue — textarea focus indicator (std-9ywg)", () => {
+  // Focus indication moved from <textarea class="edit-input"> in Note.vue to the
+  // shared TextareaInput component (.textarea:focus). The intent (visible focus
+  // ring distinct from border-color) is preserved via a box-shadow ring.
+  it("TextareaInput focus has a visible focus ring", () => {
+    const textareaSource = readFileSync(
+      resolve(__dirname, "../../../components/base/TextareaInput.vue"),
+      "utf-8"
+    );
+    const focusBlock = textareaSource.match(/\.textarea:focus\s*\{([^}]*)\}/s)?.[1] ?? "";
+    // Accept either outline or a focus-ring box-shadow — both satisfy WCAG 2.4.7.
+    expect(focusBlock).toMatch(/outline|box-shadow/);
   });
 });
 
@@ -89,7 +95,8 @@ describe("AnnotationMenu.vue — swatch border contrast (std-sdg2)", () => {
 
 describe("AnnotationMenu.vue — button focus outline (std-9ywg)", () => {
   it("swatch-btn focus-visible has outline", () => {
-    const focusBlock = menuStyle.match(/\.swatch-btn[\s\S]*?&:focus-visible\s*\{([^}]*)\}/s)?.[1] ?? "";
+    const focusBlock =
+      menuStyle.match(/\.swatch-btn[\s\S]*?&:focus-visible\s*\{([^}]*)\}/s)?.[1] ?? "";
     expect(focusBlock).toContain("outline");
   });
 });
@@ -144,18 +151,17 @@ describe("DockableAnnotations.vue — container semantics (std-yyo8)", () => {
   });
 });
 
-describe("Note.vue — visually-hidden textarea label (std-wz20)", () => {
-  // TODO(std-dm4v): regressed silently while unit-frontend CI was no-op'ing (#399 unmasked).
-  // The original std-wz20 work was closed; <label class="sr-only"> + matching for/id binding
-  // is no longer present in Note.vue. Re-enable after triage.
-  it.skip("edit textarea has a label element", () => {
-    expect(noteTemplate).toMatch(/<label[\s\S]*?class="sr-only"[\s\S]*?Annotation note/);
+describe("Note.vue — textarea accessible name (std-wz20)", () => {
+  // The redesign replaced <label class="sr-only"> wrappers around bare textareas
+  // with TextareaInput's aria-label prop. The a11y intent — give screen readers
+  // an accessible name for each edit textarea — is preserved.
+  it("private-note edit textarea has aria-label", () => {
+    expect(noteTemplate).toMatch(/<TextareaInput[\s\S]*?aria-label="Annotation note"/);
   });
 
-  // TODO(std-dm4v): same regression as the test above (std-wz20).
-  it.skip("label for attribute matches textarea id", () => {
-    expect(noteTemplate).toMatch(/:for="`note-edit-\$\{annotation\.id\}`"/);
-    expect(noteTemplate).toMatch(/:id="`note-edit-\$\{annotation\.id\}`"/);
+  it("per-message edit textareas have aria-label", () => {
+    expect(noteTemplate).toMatch(/aria-label="Edit annotation message"/);
+    expect(noteTemplate).toMatch(/aria-label="Edit annotation note"/);
   });
 });
 

--- a/frontend/src/tests/components/layout/BaseLayout.test.js
+++ b/frontend/src/tests/components/layout/BaseLayout.test.js
@@ -270,14 +270,14 @@ describe("BaseLayout", () => {
   });
 
   describe("Sidebar Actions", () => {
-    // TODO(std-dm4v): regressed silently while unit-frontend CI was no-op'ing (#399 unmasked).
-    // BaseLayout's newEmptyFile handler signature drifted from what the test asserts.
-    it.skip("handles newEmptyFile action", async () => {
+    it("handles newEmptyFile action", async () => {
       const baseSidebar = wrapper.findComponent({ name: "BaseSidebar" });
       await baseSidebar.vm.$emit("newEmptyFile");
 
+      // Title defaults to "" (set later from the source heading); ownerId comes
+      // from the injected user.
       expect(mockProvideValues.fileStore.value.createFile).toHaveBeenCalledWith({
-        title: "New File",
+        title: "",
         ownerId: "user-123",
         source: expect.stringContaining("# New File"),
       });

--- a/frontend/src/tests/utils/sourceAnchor.test.js
+++ b/frontend/src/tests/utils/sourceAnchor.test.js
@@ -1,9 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
 import * as Y from "yjs";
-import {
-  extractSourceAnchor,
-  resolveSourceAnchor,
-} from "@/utils/sourceAnchor.js";
+import { extractSourceAnchor, resolveSourceAnchor } from "@/utils/sourceAnchor.js";
 
 beforeAll(() => {
   if (!globalThis.CSS) globalThis.CSS = {};
@@ -214,8 +211,7 @@ describe("resolveSourceAnchor", () => {
   });
 
   it("falls back to legacy resolution for old-format anchors", () => {
-    manuscriptEl.innerHTML =
-      '<p data-nodeid="n1">Hello world</p>';
+    manuscriptEl.innerHTML = '<p data-nodeid="n1">Hello world</p>';
 
     const anchor = {
       node_id: "n1",
@@ -253,7 +249,7 @@ describe("extractSourceAnchor — math selections", () => {
     manuscriptEl.innerHTML =
       '<p data-nodeid="1" data-source-start="0" data-source-end="19">' +
       'Text <span class="math" data-source-start="5" data-source-end="16">' +
-      '<math><mrow><mi>k</mi><mo>≥</mo><mn>2</mn></mrow></math>' +
+      "<math><mrow><mi>k</mi><mo>≥</mo><mn>2</mn></mrow></math>" +
       "</span> end</p>";
 
     // User selects "≥" inside the MathML
@@ -276,7 +272,7 @@ describe("extractSourceAnchor — math selections", () => {
     manuscriptEl.innerHTML =
       '<p data-nodeid="1" data-source-start="0" data-source-end="19">' +
       'Text <span class="math" data-source-start="5" data-source-end="16">' +
-      '<math><mrow><mi>k</mi><mo>≥</mo><mn>2</mn></mrow></math>' +
+      "<math><mrow><mi>k</mi><mo>≥</mo><mn>2</mn></mrow></math>" +
       "</span> end</p>";
 
     // Create anchor pointing to the math source range
@@ -301,7 +297,7 @@ describe("extractSourceAnchor — math selections", () => {
     manuscriptEl.innerHTML =
       '<p data-nodeid="1" data-source-start="0" data-source-end="19">' +
       'Text <span class="math" data-source-start="5" data-source-end="16">' +
-      '<math><mrow><mi>k</mi><mo>≥</mo><mn>2</mn></mrow></math>' +
+      "<math><mrow><mi>k</mi><mo>≥</mo><mn>2</mn></mrow></math>" +
       "</span> end</p>";
 
     const mo = manuscriptEl.querySelector("mo");
@@ -317,7 +313,7 @@ describe("extractSourceAnchor — math selections", () => {
     manuscriptEl.innerHTML =
       '<p data-nodeid="1" data-source-start="0" data-source-end="23">' +
       'NEW Text <span class="math" data-source-start="9" data-source-end="20">' +
-      '<math><mrow><mi>k</mi><mo>≥</mo><mn>2</mn></mrow></math>' +
+      "<math><mrow><mi>k</mi><mo>≥</mo><mn>2</mn></mrow></math>" +
       "</span> end</p>";
 
     const resolved = resolveSourceAnchor(anchor, manuscriptEl, ydoc);
@@ -393,9 +389,10 @@ describe("extractSourceAnchor — text next to inline markup", () => {
     expect(sliced).toBe("The value");
   });
 
-  // TODO(std-s41a): multi-line paragraph anchoring requires text-run spans landing
-  // on rendered output. Expected-to-fail until that ships. Skipped to unblock CI;
-  // re-enable once std-s41a lands.
+  // Expected-to-fail: multi-line paragraph anchoring needs per-run source
+  // offsets on the rendered DOM (so collapsed whitespace can still map back to
+  // the original source). The test author flagged it as known-fail in the
+  // inline comment below referencing rendered-offset mismatch.
   it.skip("correctly anchors text in a multi-line paragraph", () => {
     // Source has newline+indent that rendered text collapses
     const source = "First line\n  second line end";


### PR DESCRIPTION
## Summary

Two real UX regressions in `Note.vue` that surfaced once #399/#400 made `unit-frontend` actually run again, plus un-skip 10 of 11 tests parked in #400.

**Real fixes (Note.vue + TextareaInput.vue):**
- **Active-border suppression during edit** — adding per-message edit introduced \`editingMessageId\` parallel to \`editing\`. The template's \`active: isActive && !editing\` no longer fired for existing private notes (where Edit goes through the per-message path). Introduce an \`isEditing\` computed that ORs both states; use it in the template and \`onEsc\`.
- **ESC cancels edit, doesn't deselect** — \`onEsc\` only checked the legacy \`editing.value\`; ESC inside a per-message textarea fell through to deselect-the-card. Now checks \`editingMessageId\` first and stopPropagation's.
- **Screen-reader label on edit textareas** — restore the accessible name dropped during the marginalia redesign. Add an \`ariaLabel\` prop to \`TextareaInput\` and wire it from Note.vue's three TextareaInput call sites.

**Test changes:**
For each previously-skipped test, decided: fix the code, or update the assertion to match an intentional architecture change.
- Code-fix → assertion preserved: Note.vue active class × 2, ESC stopPropagation, textarea aria-labels × 2
- Architecture moved → test updated:
  - TextareaInput focus indicator (outline → box-shadow ring): accept either
  - ManuscriptWrapper Manuscript child stub → DOM-mount style assertion
  - BaseLayout \`newEmptyFile\` title default \`""\`
  - \`onSaveMessageEdit\` signature now \`(msg, submittedValue)\`
  - AnnotationMenu \`boxShadow\`/\`selectedColor\` regex updated to allow newline

11th test (\`sourceAnchor\` multi-line) stays skipped — it needs per-run source offsets on rendered output (text-run spans).

## Verification

\`pnpm exec vitest run\` under Node 22:
\`\`\`
Test Files  157 passed (157)
     Tests  2230 passed | 1 skipped (2231)
\`\`\`

## Test plan

- [ ] CI passes (unit-frontend, e2e-frontend, e2e-collab)
- [ ] In deploy preview: open an annotation card with an existing note
  - [ ] Click Edit → blue \`active\` border disappears; \`editing\` style shows
  - [ ] Press ESC in the textarea → edit cancels; card stays selected
  - [ ] Tab into the textarea → screen reader announces accessible name

🤖 Generated with [Claude Code](https://claude.com/claude-code)