### PR TITLE
fix(authz): make /render/private render-only

### DIFF
--- a/backend/aris/routes/render.py
+++ b/backend/aris/routes/render.py
@@ -2,7 +2,6 @@
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
-from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, current_user
@@ -62,14 +61,8 @@ async def render(data: RenderObject):
 async def render_private(data: FileRenderObject, db: AsyncSession = Depends(get_db), user=Depends(current_user)):
     """Private endpoint for rendering RSM with database assets.
 
-    Renders RSM source for a specific file with access to uploaded assets,
-    and persists the source to the database so page-load renders stay current.
+    Renders the request body's RSM source for a specific file with access to
+    uploaded assets. This endpoint is render-only: it does NOT write source to
+    the database. The Y.js collaboration loop is the sole writer of files.source.
     """
-    # Persist source so the next page-load render uses the same content
-    await db.execute(
-        sql_text("UPDATE files SET source = :source WHERE id = :file_id"),
-        {"source": data.source, "file_id": data.file_id},
-    )
-    await db.commit()
-
     return await crud.render_with_assets(data.source, data.file_id, db, user.id)

--- a/backend/tests/test_routes/test_render_private.py
+++ b/backend/tests/test_routes/test_render_private.py
@@ -127,54 +127,68 @@ class TestRenderPrivate:
         private_html = private_response.json()
         assert "Private Asset" in private_html
 
-    async def test_render_private_persists_source_to_db(
+    async def test_render_private_does_not_write_source(
         self, client: AsyncClient, authenticated_user, db_session
     ):
+        """The render endpoint must NOT persist source. Y.js owns writes.
+
+        Regression test for std-83utdw: previously this endpoint UPDATE'd
+        files.source, allowing anyone authenticated to overwrite any file.
+        """
         headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
 
         file = File(owner_id=authenticated_user['user_id'], source="original source")
         db_session.add(file)
         await db_session.commit()
         await db_session.refresh(file)
+        file_id = file.id
 
         response = await client.post(
             "/render/private",
-            json={"source": "updated source", "file_id": file.id},
+            json={"source": "attempted overwrite", "file_id": file_id},
             headers=headers,
         )
         assert response.status_code == 200
 
         result = await db_session.execute(
             text("SELECT source FROM files WHERE id = :file_id"),
-            {"file_id": file.id},
+            {"file_id": file_id},
         )
         row = result.fetchone()
         assert row is not None
-        assert row[0] == "updated source"
+        assert row[0] == "original source"
 
-    async def test_render_private_persisted_source_matches_request(
-        self, client: AsyncClient, authenticated_user, db_session
+    async def test_render_private_cannot_overwrite_other_users_source(
+        self,
+        client: AsyncClient,
+        authenticated_user,
+        second_authenticated_user,
+        db_session,
     ):
-        headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+        """A non-owner cannot mutate another user's file via /render/private.
 
-        file = File(owner_id=authenticated_user['user_id'], source="placeholder")
+        Regression test for std-83utdw: the endpoint used to UPDATE
+        files.source for any authenticated caller, regardless of permissions.
+        """
+        file = File(owner_id=authenticated_user['user_id'], source="owner content")
         db_session.add(file)
         await db_session.commit()
         await db_session.refresh(file)
+        file_id = file.id
 
-        source_with_special_chars = ':manuscript:\n\n  A "paragraph" with <html> & symbols\'s.\n\n::'
-
-        response = await client.post(
+        attacker_headers = {
+            "Authorization": f"Bearer {second_authenticated_user['token']}"
+        }
+        await client.post(
             "/render/private",
-            json={"source": source_with_special_chars, "file_id": file.id},
-            headers=headers,
+            json={"source": "MALICIOUS REPLACEMENT", "file_id": file_id},
+            headers=attacker_headers,
         )
-        assert response.status_code == 200
 
         result = await db_session.execute(
             text("SELECT source FROM files WHERE id = :file_id"),
-            {"file_id": file.id},
+            {"file_id": file_id},
         )
         row = result.fetchone()
         assert row is not None
-        assert row[0] == source_with_special_chars
+        assert row[0] == "owner content"


### PR DESCRIPTION
## Summary
- POST /render/private previously persisted `files.source` for any authenticated caller, with no permission check on `file_id`. Editor.vue:doCompile fires it on every edit, so any authenticated user could wipe or replace any file's source via a single POST. Bug also caused races with the Y.js save loop (H4).
- This PR removes the UPDATE entirely. The endpoint now renders the request body's source so the preview works, but writes nothing. The Y.js save loop (`yjs_client._save_loop`, 500 ms debounce) is the sole writer of `files.source`.

Refs std-83utdw. Closes the cross-user authz hole and the H4 race in one change.

## Why decouple instead of adding require_edit?
Two writers of the same column (REST endpoint + Y.js save loop) racing on every keystroke was the underlying H4 bug. The Y.js loop already persists every keystroke; the REST write was redundant.

## Audit (per bead notes)
- Only writers of `files.source` after this change: `aris/collaboration/yjs_client.py` (Y.js save loop) and `aris/crud/file.py::update_file` (used by the import path and `PUT /files/{id}`).
- Editor.vue:doCompile still POSTs source from ytext to `/render/private` for rendering; that body is now read but not written.
- `useVersionRestore.ts` writes via Y.js transaction — unaffected.

## Test plan
- [x] `uv run pytest tests/test_routes/test_render_private.py -v` — 7 passed (5 existing + 2 new regression tests).
- [x] `uv run pytest tests/test_routes/ -n8 -m "not slow"` — 367 passed, 1 pre-existing failure in `test_routes_health.py::test_health_check_healthy` (degraded-message assertion mismatch on a `JWT_SECRET_KEY` short-key warning; unrelated to this change).
- [ ] CI: run the Y.js E2E suite (`compile-persistence.spec.js`, `yjs-crdt-duplication.spec.js`) — must still pass because Y.js owns the write path.

## Regression tests added
- `test_render_private_does_not_write_source`: owner POSTs different source, asserts row is unchanged.
- `test_render_private_cannot_overwrite_other_users_source`: second user POSTs to owner's `file_id`, asserts row is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)