### PR TITLE
fix(authz): POST /files derives owner from auth, not request body

### DIFF
--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -28,7 +28,6 @@ public_router = APIRouter(prefix="/files", tags=["files"])
 class FileCreate(BaseModel):
     title: str = ""
     abstract: str = ""
-    owner_id: int
     source: str
 
     @field_validator('source')
@@ -128,6 +127,7 @@ async def get_files(
 @router.post("")
 async def create_file(
     doc: FileCreate,
+    user: UserRead = Depends(current_user),
     file_service: InMemoryFileService = Depends(get_file_service),
     db: AsyncSession = Depends(get_db),
 ):
@@ -136,7 +136,9 @@ async def create_file(
     Parameters
     ----------
     doc : FileCreate
-        File creation data including source, owner_id, title, and abstract.
+        File creation data including source, title, and abstract.
+    user : UserRead
+        Current authenticated user; owns the new file.
     file_service : InMemoryFileService
         File service dependency.
     db : AsyncSession
@@ -155,7 +157,8 @@ async def create_file(
     Notes
     -----
     Requires authentication. Validates RSM source format before creation.
-    Sets file status to DRAFT by default.
+    Owner is always the authenticated caller; any ``owner_id`` in the
+    request body is ignored. Sets file status to DRAFT by default.
     """
     # Validation happens automatically via Pydantic field_validator
 
@@ -164,17 +167,17 @@ async def create_file(
         title=doc.title,
         abstract=doc.abstract,
         source=doc.source,
-        owner_id=doc.owner_id
+        owner_id=user.id,
     )
-    
+
     result = await file_service.create_file(create_data, db=db)
 
     # Create OWNER permission for the file creator
     await create_permission(
         file_id=result.id,
-        user_id=doc.owner_id,
+        user_id=user.id,
         role=FileRole.OWNER,
-        granted_by=doc.owner_id,
+        granted_by=user.id,
         db=db,
     )
 

--- a/backend/tests/test_routes/test_routes_file.py
+++ b/backend/tests/test_routes/test_routes_file.py
@@ -309,11 +309,70 @@ async def test_create_file_missing_required_fields(client: AsyncClient, authenti
         headers=headers,
         json={
             "title": "Test Document"
-            # Missing required fields: owner_id, source
+            # Missing required field: source
         },
     )
 
     assert response.status_code == 422  # Validation error
+
+
+async def test_create_file_owner_id_in_body_is_ignored(
+    client: AsyncClient, authenticated_user, second_authenticated_user
+):
+    """User A cannot create a file owned by user B by passing owner_id in the body.
+
+    Regression test for std-g2he0u: owner_id used to be a required field on
+    FileCreate and was trusted blindly, letting any authenticated user create
+    files attributed to anyone else.
+    """
+    headers_a = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    user_a_id = authenticated_user["user_id"]
+    user_b_id = second_authenticated_user["user_id"]
+    assert user_a_id != user_b_id
+
+    response = await client.post(
+        "/files",
+        headers=headers_a,
+        json={
+            "title": "Spoofed Owner",
+            "abstract": "A attempts to create a file owned by B",
+            "owner_id": user_b_id,
+            "source": "test content",
+        },
+    )
+    assert response.status_code == 200, response.text
+    file_id = response.json()["id"]
+
+    # The file's owner_id is user A (the caller), not user B from the body.
+    get_response = await client.get(f"/files/{file_id}", headers=headers_a)
+    assert get_response.status_code == 200
+    assert get_response.json()["owner_id"] == user_a_id
+
+    # User B, who was named in the spoofed body, has no access to the file.
+    headers_b = {"Authorization": f"Bearer {second_authenticated_user['token']}"}
+    b_get_response = await client.get(f"/files/{file_id}", headers=headers_b)
+    assert b_get_response.status_code == 403
+
+
+async def test_create_file_works_without_owner_id(client: AsyncClient, authenticated_user):
+    """Omitting owner_id from the body still creates a file owned by the caller."""
+    headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+
+    response = await client.post(
+        "/files",
+        headers=headers,
+        json={
+            "title": "No Owner In Body",
+            "abstract": "Owner derived from auth",
+            "source": "test content",
+        },
+    )
+    assert response.status_code == 200, response.text
+    file_id = response.json()["id"]
+
+    get_response = await client.get(f"/files/{file_id}", headers=headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["owner_id"] == authenticated_user["user_id"]
 
 
 # Download endpoint tests


### PR DESCRIPTION
## Summary
- `FileCreate` no longer accepts `owner_id`; it is derived from the authenticated caller (`current_user.id`).
- Both the file row and the OWNER permission grant now use the caller's id, so an authenticated user can no longer create files attributed to another user (or to a non-existent user id).
- Pydantic default `extra='ignore'` keeps backwards compatibility with the existing frontend, which still sends `owner_id`.

Closes std-g2he0u.

## Test plan
- [x] New regression test: user A POSTs `/files` with `owner_id = user_b.id` → file is owned by A, and B receives 403 on `GET /files/{id}`.
- [x] New test: POST without `owner_id` still works and yields a file owned by the caller.
- [x] Updated `test_create_file_missing_required_fields` (only `source` is required now).
- [x] `pytest tests/test_routes/test_routes_file.py` — 29 passed.
- [x] `pytest tests/test_authorization.py tests/test_routes/test_routes_permissions.py tests/test_routes/test_routes_file_assets.py tests/test_routes/test_routes_versions.py tests/test_services/test_file_service_routes.py tests/test_routes/test_routes_file_settings.py` — 99 passed.
- [x] `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)