### PR TITLE
fix(authz): GET /files filters to owned + shared files

### DIFF
--- a/backend/aris/authorization.py
+++ b/backend/aris/authorization.py
@@ -8,7 +8,7 @@ guards for enforcing file access control based on user roles.
 from typing import Optional
 
 from fastapi import Depends, HTTPException
-from sqlalchemy import and_, select
+from sqlalchemy import and_, desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aris.deps import current_user, get_db
@@ -22,6 +22,55 @@ class PermissionLevel:
     EDIT = [FileRole.OWNER, FileRole.EDITOR]
     COMMENT = [FileRole.OWNER, FileRole.EDITOR, FileRole.COMMENTER]
     MANAGE = [FileRole.OWNER]
+
+
+async def list_user_accessible_files(
+    user_id: int, db: AsyncSession
+) -> list[tuple[File, FileRole]]:
+    """List all non-deleted files a user can access, with their effective role.
+
+    Returns the union of:
+      - files where the user is owner (role is FileRole.OWNER even when no
+        FilePermission row exists, to be safe against legacy data);
+      - files where an undeleted FilePermission row grants the user any role.
+
+    Parameters
+    ----------
+    user_id : int
+        The user whose accessible files to list.
+    db : AsyncSession
+        Database session.
+
+    Returns
+    -------
+    list[tuple[File, FileRole]]
+        Ordered by File.last_edited_at descending. Each file appears once.
+
+    """
+    stmt = (
+        select(File, FilePermission.role)
+        .outerjoin(
+            FilePermission,
+            and_(
+                FilePermission.file_id == File.id,
+                FilePermission.user_id == user_id,
+                FilePermission.deleted_at.is_(None),
+            ),
+        )
+        .where(
+            File.deleted_at.is_(None),
+            or_(File.owner_id == user_id, FilePermission.id.isnot(None)),
+        )
+        .order_by(desc(File.last_edited_at))
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    files_with_roles: list[tuple[File, FileRole]] = []
+    for file, role in rows:
+        effective_role = role if role is not None else FileRole.OWNER
+        files_with_roles.append((file, effective_role))
+    return files_with_roles
 
 
 async def get_user_role_for_file(

--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -7,7 +7,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import current_user, get_db, get_file_service
-from ..authorization import require_edit, require_manage, require_view
+from ..authorization import (
+    list_user_accessible_files,
+    require_edit,
+    require_manage,
+    require_view,
+)
 from ..collaboration import get_collaboration_manager
 from ..crud.file_assets import FileAssetCreate, FileAssetDB, FileAssetOut, FileAssetUpdate
 from ..crud.permissions import create_permission
@@ -79,13 +84,20 @@ class FileUpdate(BaseModel):
 
 @router.get("")
 async def get_files(
+    user: UserRead = Depends(current_user),
     file_service: InMemoryFileService = Depends(get_file_service),
     db: AsyncSession = Depends(get_db)
 ):
-    """Retrieve all files with extracted titles.
+    """Retrieve files the current user can access (owned or shared).
+
+    Returns the union of files where the user is the owner and files where an
+    undeleted FilePermission row grants the user any role. Each entry includes
+    a ``role`` field so the frontend can distinguish owned-vs-shared.
 
     Parameters
     ----------
+    user : UserRead
+        Current authenticated user.
     file_service : InMemoryFileService
         File service dependency.
     db : AsyncSession
@@ -93,22 +105,15 @@ async def get_files(
 
     Returns
     -------
-    list of FileData
-        List of all non-deleted files with title attributes populated.
-
-    Notes
-    -----
-    Requires authentication. Uses file service for in-memory access.
+    list of dict
+        Non-deleted files the user can access, ordered by last edited descending.
     """
-    # Sync from database to ensure we have latest data
     await file_service.sync_from_database(db)
-    
-    # Get files from memory
-    files = await file_service.get_all_files()
-    
-    # Convert to response format with extracted titles and rendered HTML
+
+    files_with_roles = await list_user_accessible_files(user.id, db)
+
     result = []
-    for f in files:
+    for f, role in files_with_roles:
         title = await file_service.get_file_title(f.id)
         html = await file_service.get_file_html(f.id, db=db)
         result.append({
@@ -121,6 +126,7 @@ async def get_files(
             "status": f.status.value,
             "created_at": f.created_at,
             "html": html or "",
+            "role": role.value,
         })
     return result
 

--- a/backend/tests/test_routes/test_routes_file.py
+++ b/backend/tests/test_routes/test_routes_file.py
@@ -22,6 +22,142 @@ async def test_get_files_with_auth(client: AsyncClient, authenticated_user):
     assert isinstance(response.json(), list)
 
 
+async def test_get_files_only_returns_owned_for_isolated_users(
+    client: AsyncClient, authenticated_user, second_authenticated_user
+):
+    """GET /files must not leak files between users (authz regression).
+
+    Previously the endpoint returned the entire files table to any authenticated
+    user. Each user should only see files they own or have been granted access to.
+    """
+    headers_a = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    headers_b = {"Authorization": f"Bearer {second_authenticated_user['token']}"}
+
+    create_a = await client.post(
+        "/files",
+        headers=headers_a,
+        json={
+            "title": "User A File",
+            "abstract": "",
+            "owner_id": authenticated_user["user_id"],
+            "source": "alpha",
+        },
+    )
+    file_a_id = create_a.json()["id"]
+
+    create_b = await client.post(
+        "/files",
+        headers=headers_b,
+        json={
+            "title": "User B File",
+            "abstract": "",
+            "owner_id": second_authenticated_user["user_id"],
+            "source": "bravo",
+        },
+    )
+    file_b_id = create_b.json()["id"]
+
+    resp_a = await client.get("/files", headers=headers_a)
+    assert resp_a.status_code == 200
+    ids_a = {f["id"] for f in resp_a.json()}
+    assert file_a_id in ids_a
+    assert file_b_id not in ids_a, "User A must not see user B's files"
+
+    resp_b = await client.get("/files", headers=headers_b)
+    assert resp_b.status_code == 200
+    ids_b = {f["id"] for f in resp_b.json()}
+    assert file_b_id in ids_b
+    assert file_a_id not in ids_b, "User B must not see user A's files"
+
+
+async def test_get_files_includes_shared_files_with_role(
+    client: AsyncClient, authenticated_user, second_authenticated_user
+):
+    """GET /files includes files shared with the user, with their role."""
+    headers_a = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    headers_b = {"Authorization": f"Bearer {second_authenticated_user['token']}"}
+
+    create_a = await client.post(
+        "/files",
+        headers=headers_a,
+        json={
+            "title": "Shared File",
+            "abstract": "",
+            "owner_id": authenticated_user["user_id"],
+            "source": "shared",
+        },
+    )
+    file_a_id = create_a.json()["id"]
+
+    create_b = await client.post(
+        "/files",
+        headers=headers_b,
+        json={
+            "title": "B Own File",
+            "abstract": "",
+            "owner_id": second_authenticated_user["user_id"],
+            "source": "private",
+        },
+    )
+    file_b_id = create_b.json()["id"]
+
+    share = await client.post(
+        f"/files/{file_a_id}/permissions",
+        headers=headers_a,
+        json={"user_id": second_authenticated_user["user_id"], "role": "EDITOR"},
+    )
+    assert share.status_code == 201
+
+    resp_b = await client.get("/files", headers=headers_b)
+    assert resp_b.status_code == 200
+    by_id = {f["id"]: f for f in resp_b.json()}
+    assert file_a_id in by_id, "B must see the file A shared with them"
+    assert file_b_id in by_id
+    assert by_id[file_a_id]["role"] == "EDITOR"
+    assert by_id[file_b_id]["role"] == "OWNER"
+
+
+async def test_get_files_excludes_revoked_shares(
+    client: AsyncClient, authenticated_user, second_authenticated_user
+):
+    """Revoking a share removes the file from the recipient's GET /files."""
+    headers_a = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    headers_b = {"Authorization": f"Bearer {second_authenticated_user['token']}"}
+
+    create_a = await client.post(
+        "/files",
+        headers=headers_a,
+        json={
+            "title": "To Revoke",
+            "abstract": "",
+            "owner_id": authenticated_user["user_id"],
+            "source": "x",
+        },
+    )
+    file_a_id = create_a.json()["id"]
+
+    share = await client.post(
+        f"/files/{file_a_id}/permissions",
+        headers=headers_a,
+        json={"user_id": second_authenticated_user["user_id"], "role": "COMMENTER"},
+    )
+    assert share.status_code == 201
+    permission_id = share.json()["id"]
+
+    resp_b_before = await client.get("/files", headers=headers_b)
+    assert file_a_id in {f["id"] for f in resp_b_before.json()}
+
+    revoke = await client.delete(
+        f"/files/{file_a_id}/permissions/{permission_id}",
+        headers=headers_a,
+    )
+    assert revoke.status_code == 204
+
+    resp_b_after = await client.get("/files", headers=headers_b)
+    assert resp_b_after.status_code == 200
+    assert file_a_id not in {f["id"] for f in resp_b_after.json()}
+
+
 async def test_create_file_valid_rsm_source(client: AsyncClient, authenticated_user):
     """Test creating a file with valid RSM source."""
     headers = {"Authorization": f"Bearer {authenticated_user['token']}"}

--- a/frontend/src/tests/views/register/View.test.js
+++ b/frontend/src/tests/views/register/View.test.js
@@ -20,22 +20,28 @@ vi.mock("vue-router", async (importOriginal) => {
 const toastInfoMock = vi.hoisted(() => vi.fn());
 vi.mock("@/utils/toast", () => ({ toast: { info: toastInfoMock } }));
 
+const createFileStoreMock = vi.hoisted(() => vi.fn(() => ({})));
+vi.mock("@/store/FileStore.js", () => ({ createFileStore: createFileStoreMock }));
+
 describe("RegisterView", () => {
   let wrapper;
   const user = ref(null);
+  const fileStore = ref(null);
   const api = { post: vi.fn(), defaults: { baseURL: "" } };
 
   beforeEach(() => {
     pushMock.mockClear();
     toastInfoMock.mockClear();
+    createFileStoreMock.mockClear();
     api.post.mockReset();
     user.value = null;
+    fileStore.value = null;
     localStorage.clear();
     wrapper = mount(RegisterView, {
       global: {
         components: { AuthLayout, InputText, PasswordInput, Button, Logo },
         stubs: { RouterLink: RouterLinkStub },
-        provide: { api, user },
+        provide: { api, user, fileStore },
       },
     });
   });
@@ -47,7 +53,7 @@ describe("RegisterView", () => {
       global: {
         components: { AuthLayout, InputText, PasswordInput, Button, Logo },
         stubs: { RouterLink: RouterLinkStub },
-        provide: { api, user },
+        provide: { api, user, fileStore },
       },
     });
     await nextTick();
@@ -62,7 +68,7 @@ describe("RegisterView", () => {
       global: {
         components: { AuthLayout, InputText, PasswordInput, Button, Logo },
         stubs: { RouterLink: RouterLinkStub },
-        provide: { api, user },
+        provide: { api, user, fileStore },
       },
     });
     await nextTick();

--- a/frontend/src/views/register/View.vue
+++ b/frontend/src/views/register/View.vue
@@ -2,6 +2,7 @@
   import { ref, computed, inject, onMounted } from "vue";
   import { useRouter, RouterLink } from "vue-router";
   import { toast } from "@/utils/toast";
+  import { createFileStore } from "@/store/FileStore.js";
   import AuthLayout from "@/components/layout/AuthLayout.vue";
   import PasswordInput from "@/components/forms/PasswordInput.vue";
   import PasswordStrength from "@/components/ui/PasswordStrength.vue";
@@ -15,6 +16,7 @@
 
   const api = inject("api");
   const user = inject("user");
+  const fileStore = inject("fileStore");
 
   const derivedInitials = computed(() => {
     return name.value
@@ -65,6 +67,9 @@
       localStorage.setItem("refreshToken", refresh_token);
       localStorage.setItem("user", JSON.stringify(registeredUser));
       user.value = registeredUser;
+      // Initialize fileStore so the user can create/list files without a hard
+      // reload (App.vue only runs createFileStore in onMounted).
+      fileStore.value = createFileStore(api, user.value);
       toast.info("Check your inbox", {
         description: `We sent a verification link to ${email.value}. The link expires in 24 hours.`,
         duration: 0,


### PR DESCRIPTION
## Summary

- `GET /files` previously returned the entire files table to any authenticated user. Total data exfiltration via one curl — beta-blocker.
- Now filters to the union of (a) files owned by the current user and (b) files where an undeleted `FilePermission` row grants the user any role. Each item includes a `role` field so the frontend can distinguish owned vs shared.
- New `authorization.list_user_accessible_files()` helper does the join in one query, ordered by `last_edited_at` desc.

## Test plan

- [x] `test_get_files_only_returns_owned_for_isolated_users`: A creates F1, B creates F2 — A's GET /files returns [F1] only; B's returns [F2] only.
- [x] `test_get_files_includes_shared_files_with_role`: A grants B EDITOR on F1 — B's GET /files returns [F1 (role=EDITOR), F2 (role=OWNER)].
- [x] `test_get_files_excludes_revoked_shares`: revoking the permission removes F1 from B's listing.
- [x] Existing 30 tests in `test_routes_file.py` still pass; all 370 route tests pass (one pre-existing unrelated `test_health_check_healthy` failure on main).
- [x] `ruff` and `mypy` clean on changed files.

Closes std-r8ithd

🤖 Generated with [Claude Code](https://claude.com/claude-code)