### PR TITLE
feat(security): authenticate multi-player WebSocket connections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,29 @@ jobs:
     - name: Run unit tests
       run: pnpm --filter ./site run test:run
 
+  unit-multiplayer:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v6
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '23'
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Run unit tests
+      run: pnpm --filter ./multi-player run test
+
   # Site E2E Tests (All Browsers)
   e2e-site:
     strategy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -223,6 +223,17 @@ jobs:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_FRONTEND_SITE_ID }}
 
+    - name: Smoke-test multi-player WS auth handshake
+      if: steps.pr.outputs.skip != 'true'
+      working-directory: studio
+      # End-to-end check that catches deploy-config drift the unit tests
+      # can't see — TLS handler on port 1234, supervisord env forwarding
+      # of INTERNAL_SHARED_SECRET, and /collab/start returning a verifiable
+      # token. Fails the deploy if the editor would be Offline in a browser.
+      run: |
+        pip install httpx websockets
+        python scripts/smoke-test-preview.py "${{ steps.backend.outputs.url }}"
+
     - name: Comment preview URLs
       if: steps.pr.outputs.skip != 'true'
       uses: actions/github-script@v9

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ coverage/
 .beads/dolt/beads_std/.dolt/noms/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 backend/.mypy_cache/3.13/cache.db
 cli/.venv/lib/python3.13/site-packages/playwright/driver/node
+
+# HNS exit marker
+.hns-exit

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ See more at [aris.pub](https://aris.pub).
    just dev      # Starts all services in Docker containers
    ```
 
+## Environments
+
+Studio runs in four environments — Dev, Test (CI), Staging (preview), and
+Prod. They differ in orchestration and in how the `rsm` dependency is
+sourced. See [docs/environments.md](docs/environments.md) for the full
+breakdown.
+
 ## CLI Tool
 
 The `studio` CLI tool accelerates UI testing and development by managing authentication sessions and generating Playwright scripts.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -70,16 +70,21 @@ COPY studio/backend/ .
 COPY studio/styles/ ./styles
 
 # Copy the rsm source so the editable rsm-lang dependency resolves.
-# backend/pyproject.toml's [tool.uv.sources] points rsm-lang at "../../rsm",
-# which resolves to /rsm from /app. This makes staging + prod install
-# rsm-lang (and its tree-sitter-rsm dependency) from the cloned aris-pub/rsm
-# checkout in the build context — identical to how dev and CI source it,
-# instead of pulling a pinned release from PyPI. The cloned rsm is added to
-# the build context by the deploy workflow's "Clone RSM repository" step.
+# This makes staging + prod install rsm-lang (and its tree-sitter-rsm
+# dependency) from the cloned aris-pub/rsm checkout in the build context —
+# identical to how dev and CI source it, instead of pulling a pinned release
+# from PyPI. The cloned rsm is added to the build context by the deploy
+# workflow's "Clone RSM repository" step.
 COPY rsm /rsm
 
-# Install Python dependencies. The uv.lock already encodes rsm-lang and
-# tree-sitter-rsm as editable sources, so the lock is consistent with /rsm.
+# backend/pyproject.toml points rsm-lang at the relative "../../rsm", which
+# matches the host/CI layout but cannot normalize inside the container —
+# /app/../../rsm escapes the filesystem root and uv rejects it. Rewrite the
+# source to the absolute /rsm where the checkout was copied.
+RUN sed -i 's|path = "../../rsm"|path = "/rsm"|' pyproject.toml
+
+# Install Python dependencies. uv re-locks because the rewritten source path
+# no longer matches uv.lock; the container lock is ephemeral so that is fine.
 RUN uv sync --no-cache
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -69,11 +69,17 @@ WORKDIR /app
 COPY studio/backend/ .
 COPY studio/styles/ ./styles
 
-# Remove local sources section from pyproject.toml for production build
-# This allows PROD to use PyPI packages (rsm-lang 1.0.0, tree-sitter-rsm 1.0.0)
-RUN sed -i '/^\[tool\.uv\.sources\]/d; /^rsm-lang = /d' pyproject.toml
+# Copy the rsm source so the editable rsm-lang dependency resolves.
+# backend/pyproject.toml's [tool.uv.sources] points rsm-lang at "../../rsm",
+# which resolves to /rsm from /app. This makes staging + prod install
+# rsm-lang (and its tree-sitter-rsm dependency) from the cloned aris-pub/rsm
+# checkout in the build context — identical to how dev and CI source it,
+# instead of pulling a pinned release from PyPI. The cloned rsm is added to
+# the build context by the deploy workflow's "Clone RSM repository" step.
+COPY rsm /rsm
 
-# Install Python dependencies (no --frozen since we removed local source)
+# Install Python dependencies. The uv.lock already encodes rsm-lang and
+# tree-sitter-rsm as editable sources, so the lock is consistent with /rsm.
 RUN uv sync --no-cache
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/backend/aris/collaboration/__init__.py
+++ b/backend/aris/collaboration/__init__.py
@@ -6,8 +6,15 @@ backend maintains Y.Doc instances, connects to the y-websocket server,
 and handles persistence to PostgreSQL.
 """
 
+from .auth import decode_collab_token, mint_collab_token
 from .manager import CollaborationManager, get_collaboration_manager
 from .yjs_client import YDocClient
 
 
-__all__ = ["YDocClient", "CollaborationManager", "get_collaboration_manager"]
+__all__ = [
+    "CollaborationManager",
+    "YDocClient",
+    "decode_collab_token",
+    "get_collaboration_manager",
+    "mint_collab_token",
+]

--- a/backend/aris/collaboration/auth.py
+++ b/backend/aris/collaboration/auth.py
@@ -1,0 +1,83 @@
+"""Auth tokens for the Y.js multi-player WebSocket server.
+
+The multi-player WebSocket service has no DB access and no user JWTs to
+inspect — anyone who could reach the WS port could previously enumerate
+rooms (e.g. ``file-1-prod``) and read/inject Y.js updates. This module
+mints short-lived tokens that the backend hands to the frontend/CLI/agent
+on ``/collab/start``; the multi-player server verifies them on the first
+WebSocket frame and only then proceeds with the Y.js handshake.
+
+The token is signed with ``INTERNAL_SHARED_SECRET`` — the same secret the
+multi-player server already uses to authenticate ``/internal/collab/start``
+calls back to the backend — so it can be verified without sharing a
+database or the user-facing ``JWT_SECRET_KEY``.
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from jose import JWTError, jwt
+
+from ..config import settings
+from ..models.models import FileRole
+
+
+COLLAB_TOKEN_TTL_SECS: int = 300
+COLLAB_TOKEN_ALGORITHM: str = "HS256"
+
+VALID_ROLES: frozenset[str] = frozenset(
+    {role.value for role in FileRole} | {"backend"}
+)
+
+
+def mint_collab_token(
+    user_id: int | str,
+    file_id: int,
+    role: str,
+    ttl_secs: int = COLLAB_TOKEN_TTL_SECS,
+) -> str:
+    """Mint a short-lived JWT for the multi-player WebSocket connection.
+
+    Parameters
+    ----------
+    user_id : int | str
+        Subject of the token. For role='backend', a stable string like
+        "backend" is acceptable (no associated user).
+    file_id : int
+        The numeric file id; the multi-player server checks this against
+        the ``file-{id}-{env}`` docName the client connected to.
+    role : str
+        One of ``OWNER`` / ``EDITOR`` / ``COMMENTER`` (matching
+        ``FileRole``) or ``backend``. The multi-player server passes this
+        through; downstream services may use it.
+    ttl_secs : int
+        Token lifetime in seconds. Default 300s; short by design so a
+        stolen token expires before it's interesting.
+    """
+    if role not in VALID_ROLES:
+        raise ValueError(f"Invalid role for collab token: {role!r}")
+
+    now = datetime.now(UTC)
+    expire = now + timedelta(seconds=ttl_secs)
+    payload: dict[str, Any] = {
+        "sub": str(user_id),
+        "file_id": int(file_id),
+        "role": role,
+        "iat": int(now.timestamp()),
+        "exp": int(expire.timestamp()),
+    }
+    return jwt.encode(
+        payload, settings.INTERNAL_SHARED_SECRET, algorithm=COLLAB_TOKEN_ALGORITHM
+    )
+
+
+def decode_collab_token(token: str) -> dict[str, Any] | None:
+    """Decode and verify a collab token. Returns None on any failure."""
+    try:
+        return jwt.decode(
+            token,
+            settings.INTERNAL_SHARED_SECRET,
+            algorithms=[COLLAB_TOKEN_ALGORITHM],
+        )
+    except JWTError:
+        return None

--- a/backend/aris/collaboration/yjs_client.py
+++ b/backend/aris/collaboration/yjs_client.py
@@ -5,6 +5,7 @@ Uses pycrdt's native sync protocol which is compatible with JavaScript y-websock
 """
 
 import asyncio
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Optional
@@ -16,6 +17,8 @@ from websockets import ClientConnection, connect
 from websockets.exceptions import ConnectionClosed, WebSocketException
 
 from aris.deps import CollabSession
+
+from .auth import mint_collab_token
 
 
 # Collaboration-specific logger
@@ -157,12 +160,12 @@ class YDocClient:
                 logger.debug(f"Cancelled lingering save task for file {self.file_id}")
         self._save_event.clear()
 
-        # Identify as the backend client so the server's cleanup logic
-        # knows not to kill frontends when we disconnect (hot-reload, crash).
-        url = self.websocket_url + ("&" if "?" in self.websocket_url else "?") + "role=backend"
-        logger.info(f"Connecting to {url} for file {self.file_id}")
+        # Role is established via the auth JWT sent as the first message;
+        # the server uses it to drive role-aware cleanup so frontend edits
+        # survive a backend hot-reload.
+        logger.info(f"Connecting to {self.websocket_url} for file {self.file_id}")
 
-        async with connect(url, open_timeout=10, close_timeout=5) as websocket:
+        async with connect(self.websocket_url, open_timeout=10, close_timeout=5) as websocket:
             self._ws = websocket
             self._reconnect_attempt = 0
             # Scope the websockets library's internal logger to this file so that
@@ -170,6 +173,8 @@ class YDocClient:
             # can be identified after tests.
             websocket.logger = logging.getLogger(f"websockets.client.file_{self.file_id}")
             logger.info(f"WebSocket connected for file {self.file_id}")
+
+            await self._authenticate(websocket)
 
             # Create Y.Doc
             self.doc = Doc()
@@ -223,6 +228,47 @@ class YDocClient:
 
             # Handle incoming messages
             await self._message_loop(websocket)
+
+    async def _authenticate(self, websocket):
+        """Send the auth message and wait for the server's ack.
+
+        The multi-player server expects ``{type: 'auth', token: '<jwt>'}`` as
+        the first JSON text frame and replies with ``{type: 'auth_ok'}``
+        before any Y.js binary traffic. Failure → server closes with code
+        4401; we let that surface as a ConnectionClosed in the run loop.
+        """
+        token = mint_collab_token(
+            user_id="backend",
+            file_id=self.file_id,
+            role="backend",
+        )
+        await websocket.send(json.dumps({"type": "auth", "token": token}))
+
+        try:
+            raw = await asyncio.wait_for(websocket.recv(), timeout=10.0)
+        except asyncio.TimeoutError as exc:
+            raise WebSocketException(
+                f"No auth response from multi-player for file {self.file_id}"
+            ) from exc
+
+        if isinstance(raw, bytes):
+            raise WebSocketException(
+                f"Expected JSON auth_ok, got binary frame for file {self.file_id}"
+            )
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise WebSocketException(
+                f"Multi-player auth response was not JSON for file {self.file_id}"
+            ) from exc
+
+        if payload.get("type") != "auth_ok":
+            raise WebSocketException(
+                f"Multi-player rejected auth for file {self.file_id}: {payload!r}"
+            )
+
+        logger.debug(f"WebSocket authenticated for file {self.file_id}")
 
     async def _receive_sync_step2(self, websocket):
         """Receive messages until the room's SyncStep2 has been processed.

--- a/backend/aris/collaboration/yjs_client.py
+++ b/backend/aris/collaboration/yjs_client.py
@@ -100,7 +100,21 @@ class YDocClient:
                     await self._wait_before_reconnect()
             except ConnectionClosed as e:
                 if e.rcvd is not None and e.rcvd.code == 4000:
-                    logger.info(f"Server cleanup close for file {self.file_id} (all frontends left)")
+                    # All frontends left and the multi-player server tore the
+                    # room down. Our next reconnect rejoins an empty, freshly
+                    # recreated room, so the new Doc must be re-seeded from the
+                    # DB — otherwise we'd hold an empty document and serve it to
+                    # the next editor that opens (the "edits lost after reload"
+                    # bug). Clear the one-time seed guard so _connect_and_run
+                    # loads from the DB again. We only do this on a 4000 close
+                    # (no frontends remain); on a plain reconnect with live
+                    # frontends present, keeping the guard avoids re-seeding
+                    # stale DB content over their newer edits.
+                    logger.info(
+                        f"Server cleanup close for file {self.file_id} "
+                        f"(all frontends left); will re-seed from DB on reconnect"
+                    )
+                    self._has_seeded = False
                 if not self._shutdown:
                     logger.warning(f"WebSocket closed for file {self.file_id}: {e}, reconnecting...")
                     await self._flush_before_reconnect()

--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -13,7 +13,7 @@ from ..authorization import (
     require_manage,
     require_view,
 )
-from ..collaboration import get_collaboration_manager
+from ..collaboration import get_collaboration_manager, mint_collab_token
 from ..crud.file_assets import FileAssetCreate, FileAssetDB, FileAssetOut, FileAssetUpdate
 from ..crud.permissions import create_permission
 from ..deps import UserRead
@@ -340,14 +340,21 @@ async def get_file(
 @router.post("/{file_id}/collab/start")
 async def collab_start(
     file_id: int,
-    user_role: FileRole = Depends(require_edit),
+    user: UserRead = Depends(current_user),
+    user_role: FileRole = Depends(require_view),
     file_service: InMemoryFileService = Depends(get_file_service),
     db: AsyncSession = Depends(get_db),
 ):
     """Signal that the collaborative editor has opened for this file.
 
-    Called by the frontend when the CodeMirror editor mounts. Starts the backend
-    Y.js client so edits are persisted to the database.
+    Called by the frontend (and CLI/agents) when an editor mounts. Starts the
+    backend Y.js client so edits are persisted to the database, and returns a
+    short-lived WS-auth token the caller must present as the first message on
+    its multi-player WebSocket connection.
+
+    Gate is ``require_view``: viewers/commenters connect read-only; the role
+    claim in the returned token reflects their actual permission so downstream
+    services (the multi-player server, frontend) can enforce read-only mode.
     """
     await file_service.sync_from_database(db)
     doc = await file_service.get_file(file_id)
@@ -356,7 +363,13 @@ async def collab_start(
 
     manager = get_collaboration_manager()
     await manager.start_client(file_id)
-    return {"status": "ok"}
+
+    token = mint_collab_token(
+        user_id=user.id,
+        file_id=file_id,
+        role=user_role.value,
+    )
+    return {"status": "ok", "token": token}
 
 
 @router.post("/{file_id}/collab/stop")

--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -341,7 +341,7 @@ async def get_file(
 async def collab_start(
     file_id: int,
     user: UserRead = Depends(current_user),
-    user_role: FileRole = Depends(require_view),
+    user_role: FileRole = Depends(require_edit),
     file_service: InMemoryFileService = Depends(get_file_service),
     db: AsyncSession = Depends(get_db),
 ):
@@ -352,9 +352,11 @@ async def collab_start(
     short-lived WS-auth token the caller must present as the first message on
     its multi-player WebSocket connection.
 
-    Gate is ``require_view``: viewers/commenters connect read-only; the role
-    claim in the returned token reflects their actual permission so downstream
-    services (the multi-player server, frontend) can enforce read-only mode.
+    Gate is ``require_edit``: only users with write permission can obtain a
+    token. The multi-player server does not currently enforce role-based
+    write restrictions on incoming Y.js frames, so widening this gate to
+    ``require_view`` would let COMMENTER-role users inject persisted updates.
+    See TODO(collab-readonly) below to enable read-only participation.
     """
     await file_service.sync_from_database(db)
     doc = await file_service.get_file(file_id)

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -26,7 +26,11 @@ kill_timeout = "30s"
   min_machines_running = 0
   processes = ['app']
 
-# WebSocket service for Y.js multiplayer (TCP passthrough)
+# WebSocket service for Y.js multiplayer.
+# `handlers = ["tls", "http"]` makes Fly's edge terminate TLS on port 1234
+# using the app's wildcard *.fly.dev cert, then forward plain HTTP/WS to the
+# container. Without this the frontend's `wss://...:1234` connection fails
+# the TLS handshake and the editor never goes online.
 [[services]]
   internal_port = 1234
   protocol = "tcp"
@@ -36,6 +40,7 @@ kill_timeout = "30s"
 
   [[services.ports]]
     port = 1234
+    handlers = ["tls", "http"]
 
 [[vm]]
   memory = '1gb'

--- a/backend/tests/test_collaboration/test_auth.py
+++ b/backend/tests/test_collaboration/test_auth.py
@@ -1,0 +1,87 @@
+"""Tests for the short-lived JWT minted for the multi-player WebSocket.
+
+The multi-player WS server previously had no authentication — anyone who
+could reach the port could enumerate rooms and inject Y.js updates. The
+backend now mints a short-lived token, scoped to a single file, that the
+multi-player verifies as the first WS frame.
+"""
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from aris.collaboration.auth import (
+    COLLAB_TOKEN_TTL_SECS,
+    decode_collab_token,
+    mint_collab_token,
+)
+
+
+def test_mint_token_roundtrips():
+    token = mint_collab_token(user_id=42, file_id=7, role="EDITOR")
+    payload = decode_collab_token(token)
+    assert payload is not None
+    assert payload["sub"] == "42"
+    assert payload["file_id"] == 7
+    assert payload["role"] == "EDITOR"
+    assert "iat" in payload
+    assert "exp" in payload
+
+
+def test_default_ttl_is_five_minutes():
+    before = int(datetime.now(timezone.utc).timestamp())
+    token = mint_collab_token(user_id=1, file_id=1, role="OWNER")
+    after = int(datetime.now(timezone.utc).timestamp())
+    payload = decode_collab_token(token)
+    assert payload is not None
+    expected_exp_low = before + COLLAB_TOKEN_TTL_SECS
+    expected_exp_high = after + COLLAB_TOKEN_TTL_SECS
+    assert expected_exp_low <= payload["exp"] <= expected_exp_high
+
+
+def test_expired_token_does_not_verify():
+    # ttl=-1 forces an immediate-past exp
+    token = mint_collab_token(user_id=1, file_id=1, role="OWNER", ttl_secs=-1)
+    # Sleep a moment to clear any clock-skew leniency
+    time.sleep(0.1)
+    assert decode_collab_token(token) is None
+
+
+def test_token_signed_with_wrong_secret_does_not_verify(monkeypatch):
+    token = mint_collab_token(user_id=1, file_id=1, role="OWNER")
+    # Now mutate the settings secret and try to decode
+    from aris.collaboration import auth as auth_mod
+    from aris.config import settings
+
+    real = settings.INTERNAL_SHARED_SECRET
+    monkeypatch.setattr(settings, "INTERNAL_SHARED_SECRET", "other-secret")
+    try:
+        assert auth_mod.decode_collab_token(token) is None
+    finally:
+        monkeypatch.setattr(settings, "INTERNAL_SHARED_SECRET", real)
+
+
+def test_garbled_token_returns_none():
+    assert decode_collab_token("not.a.token") is None
+    assert decode_collab_token("") is None
+
+
+def test_rejects_invalid_role():
+    with pytest.raises(ValueError):
+        mint_collab_token(user_id=1, file_id=1, role="GOD")
+
+
+def test_accepts_backend_role():
+    token = mint_collab_token(user_id="backend", file_id=99, role="backend")
+    payload = decode_collab_token(token)
+    assert payload is not None
+    assert payload["role"] == "backend"
+
+
+def test_accepts_all_file_roles():
+    for role in ("OWNER", "EDITOR", "COMMENTER"):
+        token = mint_collab_token(user_id=1, file_id=1, role=role)
+        payload = decode_collab_token(token)
+        assert payload is not None
+        assert payload["role"] == role

--- a/backend/tests/test_collaboration/test_yjs_client_crdt.py
+++ b/backend/tests/test_collaboration/test_yjs_client_crdt.py
@@ -141,6 +141,12 @@ async def _empty_room_server(websocket):
     doc is empty so the client's `_receive_sync_step2` leaves `self.text`
     empty.
     """
+    # Consume the JWT auth handshake before doing Y.js sync (see _room_server).
+    auth_raw = await websocket.recv()
+    auth_msg = json.loads(auth_raw if isinstance(auth_raw, str) else auth_raw.decode("utf-8"))
+    assert auth_msg.get("type") == "auth"
+    await websocket.send(json.dumps({"type": "auth_ok"}))
+
     room_doc = Doc()
     # Note: no edits — empty room.
     room_doc.get("text", type=Text)

--- a/backend/tests/test_collaboration/test_yjs_client_crdt.py
+++ b/backend/tests/test_collaboration/test_yjs_client_crdt.py
@@ -10,6 +10,7 @@ Fix: sync with room first, then call _load_from_db() only if len(self.text) == 0
 """
 
 import asyncio
+import json
 from unittest.mock import AsyncMock
 
 from pycrdt import Doc, Text, create_sync_message, handle_sync_message
@@ -31,6 +32,12 @@ async def _room_server(websocket):
       1. Receive SyncStep1 from client → reply with SyncStep2
       2. Send our own SyncStep1 → client replies with SyncStep2
     """
+    # New: consume the JWT auth handshake before doing Y.js sync.
+    auth_raw = await websocket.recv()
+    auth_msg = json.loads(auth_raw if isinstance(auth_raw, str) else auth_raw.decode("utf-8"))
+    assert auth_msg.get("type") == "auth"
+    await websocket.send(json.dumps({"type": "auth_ok"}))
+
     room_doc = Doc()
     room_text = room_doc.get("text", type=Text)
     with room_doc.transaction():

--- a/backend/tests/test_collaboration/test_yjs_client_reseed_on_teardown.py
+++ b/backend/tests/test_collaboration/test_yjs_client_reseed_on_teardown.py
@@ -1,0 +1,103 @@
+"""
+Regression: edits are lost after a page reload.
+
+Reproduction in production: a user types (edits relay through the backend and
+the preview recompiles), then reloads the page. After the reload the editor
+shows the *old* content — the just-typed edits are gone.
+
+Root cause: when the last frontend disconnects, the multi-player server kicks
+the backend YDocClient with close code 4000 ("all-frontends-left") and tears
+the room down. The YDocClient flushes to the DB and then reconnects — but
+``_connect_and_run`` builds a *fresh, empty* ``Doc`` every time and the
+one-time ``_has_seeded`` guard suppresses the DB re-seed. So the backend
+rejoins the now-empty room holding an empty document and serves *that* to the
+next editor that opens, masking the content that is safely in the DB.
+
+Fix: on a 4000 close (and only then — no frontends remain) clear
+``_has_seeded`` so the next ``_connect_and_run`` re-seeds from the DB. A plain
+reconnect with live frontends still present must NOT reset the guard, or the
+backend would re-seed stale DB content over the frontends' newer edits.
+"""
+
+import asyncio
+
+import pytest
+from pycrdt import Doc, Text
+from websockets.exceptions import ConnectionClosed, WebSocketException
+from websockets.frames import Close
+
+from aris.collaboration.yjs_client import YDocClient
+
+
+def _make_client():
+    c = YDocClient(
+        file_id=42,
+        websocket_url="ws://localhost:9999",
+        debounce_ms=50,
+    )
+    c.doc = Doc()
+    c.text = c.doc.get("text", type=Text)
+    return c
+
+
+def _connection_closed(code: int, reason: str) -> ConnectionClosed:
+    close = Close(code, reason)
+    return ConnectionClosed(close, close, rcvd_then_sent=True)
+
+
+async def _drive_one_iteration(client: YDocClient, exc: Exception):
+    """Run client.run() for exactly one iteration with _connect_and_run raising ``exc``."""
+
+    async def fake_connect_and_run():
+        raise exc
+
+    async def fake_flush():
+        pass
+
+    async def fake_wait():
+        # Stop after the first reconnect so run() exits.
+        client._shutdown = True
+
+    client._connect_and_run = fake_connect_and_run  # type: ignore[method-assign]
+    client._flush_before_reconnect = fake_flush  # type: ignore[method-assign]
+    client._wait_before_reconnect = fake_wait  # type: ignore[method-assign]
+
+    await asyncio.wait_for(client.run(), timeout=1.0)
+
+
+class TestReseedOnRoomTeardown:
+    @pytest.mark.asyncio
+    async def test_4000_close_clears_has_seeded(self):
+        """A 4000 (all-frontends-left) close must re-arm the DB seed."""
+        client = _make_client()
+        client._has_seeded = True
+
+        await _drive_one_iteration(client, _connection_closed(4000, "all-frontends-left"))
+
+        assert client._has_seeded is False, (
+            "after the room is torn down the backend must re-seed from the DB on "
+            "reconnect, otherwise it serves an empty document to the next editor"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_4000_close_keeps_has_seeded(self):
+        """A plain reconnect (frontends still present) must NOT re-seed.
+
+        Re-seeding here would pull stale DB content into a fresh Doc and merge
+        it with the frontends' newer in-room edits, duplicating/garbling text.
+        """
+        client = _make_client()
+        client._has_seeded = True
+
+        await _drive_one_iteration(client, _connection_closed(1006, "abnormal-closure"))
+
+        assert client._has_seeded is True
+
+    @pytest.mark.asyncio
+    async def test_generic_websocket_exception_keeps_has_seeded(self):
+        client = _make_client()
+        client._has_seeded = True
+
+        await _drive_one_iteration(client, WebSocketException("boom"))
+
+        assert client._has_seeded is True

--- a/backend/tests/test_collaboration/test_yjs_client_role.py
+++ b/backend/tests/test_collaboration/test_yjs_client_role.py
@@ -1,27 +1,37 @@
 """
-Tests for the backend Y.js client's role identification and reconnection behavior.
+Tests for the backend Y.js client's auth handshake and reconnection behavior.
 
-1. The backend client must connect with ?role=backend so the multiplayer
-   server's cleanup logic can distinguish it from frontend clients.
+1. The backend client must send a JWT auth message as the first WebSocket
+   frame and wait for ``{type: 'auth_ok'}`` before any Y.js sync traffic.
 2. The backend client must always reconnect after a disconnection (including
    close code 4000) unless explicitly shut down by the CollaborationManager.
 """
 
 import asyncio
+import json
 from unittest.mock import AsyncMock
 
 from pycrdt import Doc, Text, create_sync_message, handle_sync_message
 from websockets.asyncio.server import serve
 
+from aris.collaboration.auth import decode_collab_token
 from aris.collaboration.yjs_client import YDocClient
 
 
+async def _do_auth_handshake(websocket):
+    """Receive an auth message, send auth_ok. Returns the decoded payload."""
+    raw = await asyncio.wait_for(websocket.recv(), timeout=5.0)
+    msg = json.loads(raw) if isinstance(raw, str) else json.loads(raw.decode("utf-8"))
+    assert msg.get("type") == "auth", f"expected auth message, got {msg}"
+    payload = decode_collab_token(msg["token"])
+    assert payload is not None, "token failed to verify"
+    await websocket.send(json.dumps({"type": "auth_ok"}))
+    return payload
+
+
 async def _echo_server(websocket):
-    """Minimal server that records the request path and does Y.js sync."""
-    # Store the request path for assertions
-    websocket._test_path = websocket.request.path
-    if hasattr(websocket.request, 'query_string'):
-        websocket._test_query = websocket.request.query_string
+    """Minimal server that performs auth then a Y.js sync handshake."""
+    await _do_auth_handshake(websocket)
 
     room_doc = Doc()
     room_doc.get("text", type=Text)
@@ -48,16 +58,29 @@ async def _echo_server(websocket):
     await asyncio.sleep(0.3)
 
 
-async def test_backend_connects_with_role_param():
-    """The backend client must include ?role=backend in the WebSocket URL."""
-    received_paths = []
+async def test_backend_sends_auth_token_first():
+    """The backend client must present a backend-role JWT as the first frame."""
+    captured: list[dict] = []
 
     async def tracking_server(websocket):
-        # Capture the full request path + query string
-        path = str(websocket.request.path)
-        # websockets parses the URL; query params are in request.path
-        received_paths.append(path)
-        await _echo_server(websocket)
+        payload = await _do_auth_handshake(websocket)
+        captured.append(payload)
+
+        room_doc = Doc()
+        room_doc.get("text", type=Text)
+        raw = await websocket.recv()
+        reply = handle_sync_message(raw[1:], room_doc)
+        if reply:
+            await websocket.send(reply)
+        await websocket.send(create_sync_message(room_doc))
+        try:
+            raw2 = await asyncio.wait_for(websocket.recv(), timeout=1.0)
+            if raw2 and raw2[0] == 0:
+                reply2 = handle_sync_message(raw2[1:], room_doc)
+                if reply2:
+                    await websocket.send(reply2)
+        except asyncio.TimeoutError:
+            pass
 
     async with serve(tracking_server, "127.0.0.1", 0) as server:
         port = server.sockets[0].getsockname()[1]
@@ -76,22 +99,21 @@ async def test_backend_connects_with_role_param():
         except (ConnectionClosed, asyncio.TimeoutError):
             pass
 
-    assert len(received_paths) > 0, "Server never received a connection"
-    assert "role=backend" in received_paths[0], (
-        f"Backend client did not include ?role=backend in URL. Got: {received_paths[0]}"
-    )
+    assert captured, "server never received an auth message"
+    payload = captured[0]
+    assert payload.get("role") == "backend"
+    assert payload.get("file_id") == 42
 
 
 async def test_backend_reconnects_after_code_4000():
-    """
-    The backend client must reconnect after receiving close code 4000
-    (server cleanup). It should NOT treat 4000 as a permanent shutdown.
-    """
+    """The backend client must reconnect after receiving close code 4000."""
     connection_count = 0
 
     async def counting_server(websocket):
         nonlocal connection_count
         connection_count += 1
+
+        await _do_auth_handshake(websocket)
 
         room_doc = Doc()
         room_doc.get("text", type=Text)

--- a/backend/tests/test_docker_config.py
+++ b/backend/tests/test_docker_config.py
@@ -57,6 +57,90 @@ class TestSupervisordConf:
     def test_lsp_points_to_correct_path(self):
         assert "/app/rsm-lsp/dist/server.js" in self.conf
 
+    def _multiplayer_env_line(self) -> str:
+        """Return the `environment=...` line of the multiplayer program."""
+        in_multiplayer = False
+        for line in self.conf.splitlines():
+            stripped = line.strip()
+            if stripped == "[program:multiplayer]":
+                in_multiplayer = True
+                continue
+            if in_multiplayer and stripped.startswith("[") and stripped.endswith("]"):
+                break
+            if in_multiplayer and stripped.startswith("environment="):
+                return stripped
+        raise AssertionError("[program:multiplayer] has no environment= directive")
+
+    def test_multiplayer_env_forwards_internal_shared_secret(self):
+        """supervisord's `environment=` replaces the inherited env wholesale,
+        so INTERNAL_SHARED_SECRET (the JWT-verify key for the WS auth
+        handshake) MUST be forwarded explicitly. Without it, every WS
+        connection 4401s and the editor goes offline.
+        """
+        env_line = self._multiplayer_env_line()
+        assert "INTERNAL_SHARED_SECRET=" in env_line, (
+            "supervisord.conf [program:multiplayer] must forward "
+            "INTERNAL_SHARED_SECRET — without it the JWT auth handshake "
+            "fails for every WS client. See PR #405."
+        )
+        assert "%(ENV_INTERNAL_SHARED_SECRET)s" in env_line, (
+            "INTERNAL_SHARED_SECRET must reference the parent-env value via "
+            "supervisord's %(ENV_*)s interpolation, not be hardcoded."
+        )
+
+    def test_multiplayer_env_forwards_backend_internal_url(self):
+        """multiplayer's auto-bootstrap calls POST /internal/collab/start on
+        the local backend. Without BACKEND_INTERNAL_URL it falls back to the
+        dev-only http://localhost:8000; in prod the backend listens on 8080.
+        """
+        env_line = self._multiplayer_env_line()
+        assert "BACKEND_INTERNAL_URL=" in env_line, (
+            "supervisord.conf [program:multiplayer] must set "
+            "BACKEND_INTERNAL_URL — the server.js default fallback points "
+            "at the wrong port for prod."
+        )
+        assert "localhost:8080" in env_line, (
+            "BACKEND_INTERNAL_URL must point at the prod backend port (8080)."
+        )
+
+
+class TestFlyToml:
+    fly = _read("backend/fly.toml")
+
+    def test_multiplayer_port_has_tls_handler(self):
+        """The frontend builds with VITE_MULTIPLAYER_URL=wss://...:1234, so
+        Fly's edge MUST terminate TLS on port 1234. Without the tls handler,
+        the wss:// handshake fails with `wrong version number` and the
+        editor never goes online.
+        """
+        # Find the [[services]] block whose internal_port is 1234, then its
+        # [[services.ports]] sub-block, and assert handlers includes "tls".
+        in_block = False
+        in_port_block = False
+        handlers_line: str | None = None
+        for line in self.fly.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("[[services]]"):
+                in_block = False
+                in_port_block = False
+            if "internal_port = 1234" in stripped:
+                in_block = True
+            if in_block and stripped.startswith("[[services.ports]]"):
+                in_port_block = True
+                continue
+            if in_port_block and stripped.startswith("handlers"):
+                handlers_line = stripped
+                break
+
+        assert handlers_line is not None, (
+            "backend/fly.toml port 1234 has no `handlers = [...]` directive. "
+            'Add `handlers = ["tls", "http"]` so Fly\'s edge terminates TLS '
+            "for the wss:// multiplayer URL."
+        )
+        assert "tls" in handlers_line, (
+            f'port 1234 handlers must include "tls", got: {handlers_line!r}'
+        )
+
 
 class TestHealthCheck:
     script = _read("docker/health-check.sh")

--- a/backend/tests/test_docker_config.py
+++ b/backend/tests/test_docker_config.py
@@ -142,6 +142,43 @@ class TestFlyToml:
         )
 
 
+class TestNetlifyPreviewRedirects:
+    """The per-PR preview (.github/workflows/preview.yml) uploads the prebuilt
+    frontend/dist directly via nwtgck/actions-netlify. That path does NOT read
+    netlify.toml, so the SPA history-mode fallback must ship as a `_redirects`
+    file inside the published bundle. Vite copies public/ verbatim into dist/,
+    so public/_redirects is the file that lands in the upload. Without it,
+    reloading any client-side route on the preview 404s. See PR #405.
+    """
+
+    def test_public_redirects_file_exists(self):
+        path = REPO_ROOT / "frontend" / "public" / "_redirects"
+        assert path.exists(), (
+            "frontend/public/_redirects is missing — the per-PR preview deploy "
+            "(direct dist/ upload) won't get the SPA fallback and every route "
+            "404s on reload."
+        )
+
+    def test_public_redirects_has_spa_fallback(self):
+        body = _read("frontend/public/_redirects")
+        rule = next(
+            (
+                line
+                for line in body.splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            ),
+            None,
+        )
+        assert rule is not None, "frontend/public/_redirects has no redirect rule"
+        fields = rule.split()
+        assert fields[:2] == ["/*", "/index.html"], (
+            f"SPA fallback must rewrite /* to /index.html, got: {rule!r}"
+        )
+        assert "200" in fields, (
+            f"SPA fallback must be a 200 rewrite (not a 301/302), got: {rule!r}"
+        )
+
+
 class TestHealthCheck:
     script = _read("docker/health-check.sh")
 

--- a/backend/tests/test_routes/test_routes_collab.py
+++ b/backend/tests/test_routes/test_routes_collab.py
@@ -49,17 +49,18 @@ async def test_collab_start_404_for_unknown_file(authenticated_client: AsyncClie
 
 
 @pytest.mark.asyncio
-async def test_collab_start_allows_commenter(
+async def test_collab_start_forbidden_for_commenter(
     client: AsyncClient,
     authenticated_user: dict,
     db_session: AsyncSession,
 ):
-    """A user with VIEW permission (e.g. a commenter) may start a collaboration session.
+    """A COMMENTER (VIEW permission) cannot mint a WS auth token via /collab/start.
 
-    The /collab/start gate widened from EDIT to VIEW once the multi-player
-    server gained per-token role checks: read-only roles still need to
-    establish the live read-only WebSocket connection, so they need a token.
-    The returned token's ``role`` claim carries the actual permission.
+    The multi-player server does not currently enforce role-based write
+    restrictions on Y.js frames, so any user holding a valid token can inject
+    updates that the backend persists. Until read-only enforcement lands
+    server-side, the /collab/start gate stays at ``require_edit`` to prevent
+    COMMENTER-role privilege escalation into write access.
     """
     file_id = await _create_file(db_session, authenticated_user["user_id"])
 
@@ -79,17 +80,12 @@ async def test_collab_start_allows_commenter(
         db=db_session,
     )
 
-    with patch("aris.routes.file.get_collaboration_manager") as mock_get:
-        mock_get.return_value.start_client = AsyncMock(return_value=True)
-        response = await client.post(
-            _collab_url(file_id, "start"),
-            headers={"Authorization": f"Bearer {viewer_token}"},
-        )
+    response = await client.post(
+        _collab_url(file_id, "start"),
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
 
-    assert response.status_code == status.HTTP_200_OK
-    body = response.json()
-    assert body["status"] == "ok"
-    assert body.get("token"), "collab/start must return a WS auth token"
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_routes/test_routes_collab.py
+++ b/backend/tests/test_routes/test_routes_collab.py
@@ -49,15 +49,20 @@ async def test_collab_start_404_for_unknown_file(authenticated_client: AsyncClie
 
 
 @pytest.mark.asyncio
-async def test_collab_start_forbidden_for_non_editor(
+async def test_collab_start_allows_commenter(
     client: AsyncClient,
     authenticated_user: dict,
     db_session: AsyncSession,
 ):
-    """A user without EDIT permission cannot start a collaboration session."""
+    """A user with VIEW permission (e.g. a commenter) may start a collaboration session.
+
+    The /collab/start gate widened from EDIT to VIEW once the multi-player
+    server gained per-token role checks: read-only roles still need to
+    establish the live read-only WebSocket connection, so they need a token.
+    The returned token's ``role`` claim carries the actual permission.
+    """
     file_id = await _create_file(db_session, authenticated_user["user_id"])
 
-    # Register a second user and give them only VIEW permission
     reg = await client.post(
         "/register",
         json={"email": "viewer@example.com", "name": "Viewer", "initials": "VW", "password": "pw123456"},
@@ -74,9 +79,38 @@ async def test_collab_start_forbidden_for_non_editor(
         db=db_session,
     )
 
+    with patch("aris.routes.file.get_collaboration_manager") as mock_get:
+        mock_get.return_value.start_client = AsyncMock(return_value=True)
+        response = await client.post(
+            _collab_url(file_id, "start"),
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body.get("token"), "collab/start must return a WS auth token"
+
+
+@pytest.mark.asyncio
+async def test_collab_start_forbidden_for_user_without_any_role(
+    client: AsyncClient,
+    authenticated_user: dict,
+    db_session: AsyncSession,
+):
+    """A user with no role on the file cannot start a session."""
+    file_id = await _create_file(db_session, authenticated_user["user_id"])
+
+    reg = await client.post(
+        "/register",
+        json={"email": "stranger@example.com", "name": "Stranger", "initials": "ST", "password": "pw123456"},
+    )
+    assert reg.status_code == 200
+    stranger_token = reg.json()["access_token"]
+
     response = await client.post(
         _collab_url(file_id, "start"),
-        headers={"Authorization": f"Bearer {viewer_token}"},
+        headers={"Authorization": f"Bearer {stranger_token}"},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -124,6 +158,30 @@ async def test_collab_start_calls_manager(
 
     assert response.status_code == status.HTTP_200_OK
     mock_manager.start_client.assert_called_once_with(file_id)
+
+
+@pytest.mark.asyncio
+async def test_collab_start_returns_valid_token(
+    authenticated_client: AsyncClient,
+    authenticated_user: dict,
+    db_session: AsyncSession,
+):
+    """The token returned by /collab/start must verify and carry the right claims."""
+    from aris.collaboration.auth import decode_collab_token
+
+    file_id = await _create_file(db_session, authenticated_user["user_id"])
+
+    with patch("aris.routes.file.get_collaboration_manager") as mock_get:
+        mock_get.return_value.start_client = AsyncMock(return_value=True)
+        response = await authenticated_client.post(_collab_url(file_id, "start"))
+
+    assert response.status_code == status.HTTP_200_OK
+    token = response.json()["token"]
+    payload = decode_collab_token(token)
+    assert payload is not None
+    assert payload["file_id"] == file_id
+    assert payload["role"] == "OWNER"  # creator is owner
+    assert payload["sub"] == str(authenticated_user["user_id"])
 
 
 @pytest.mark.asyncio

--- a/cli/cli/commands/edit.py
+++ b/cli/cli/commands/edit.py
@@ -15,6 +15,17 @@ from websockets import connect
 from cli.core import StudioAPI, build_room_url, console
 
 
+async def _authenticate_ws(ws: Any, token: str) -> None:
+    """Send the auth message and wait for the server's ack."""
+    await ws.send(json.dumps({"type": "auth", "token": token}))
+    raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
+    if isinstance(raw, bytes):
+        raise RuntimeError("multi-player auth handshake returned binary frame")
+    payload = json.loads(raw)
+    if payload.get("type") != "auth_ok":
+        raise RuntimeError(f"multi-player rejected auth: {payload!r}")
+
+
 def _compute_diff_ops(old: str, new: str) -> list[tuple]:
     """Compute minimal insert/delete/replace operations to transform old into new.
 
@@ -254,23 +265,44 @@ async def _apply_patch(ws: Any, file_id: int, patch_text: str) -> dict[str, Any]
     }
 
 
-def _run_edit(file_id: int, new_source: str) -> dict[str, Any]:
+def _start_collab(api: StudioAPI, file_id: int) -> str:
+    """Tell the backend to start its YDocClient and return the WS auth token."""
+    import requests
+
+    response = requests.post(
+        f"{api.base_url}/files/{file_id}/collab/start",
+        headers=api._get_headers(),
+        timeout=15,
+    )
+    response.raise_for_status()
+    data = response.json()
+    token = data.get("token") if isinstance(data, dict) else None
+    if not isinstance(token, str) or not token:
+        raise RuntimeError("collab/start did not return a token")
+    return token
+
+
+def _run_edit(file_id: int, new_source: str, api: StudioAPI) -> dict[str, Any]:
     """Connect to Y.js WebSocket, apply edit, disconnect."""
     url = build_room_url(file_id)
+    token = _start_collab(api, file_id)
 
     async def _do() -> dict[str, Any]:
         async with connect(url, open_timeout=10, close_timeout=5) as ws:
+            await _authenticate_ws(ws, token)
             return await _apply_edit(ws, file_id, new_source)
 
     return asyncio.run(_do())
 
 
-def _run_patch(file_id: int, patch_text: str) -> dict[str, Any]:
+def _run_patch(file_id: int, patch_text: str, api: StudioAPI) -> dict[str, Any]:
     """Connect to Y.js WebSocket, apply patch, disconnect."""
     url = build_room_url(file_id)
+    token = _start_collab(api, file_id)
 
     async def _do() -> dict[str, Any]:
         async with connect(url, open_timeout=10, close_timeout=5) as ws:
+            await _authenticate_ws(ws, token)
             return await _apply_patch(ws, file_id, patch_text)
 
     return asyncio.run(_do())
@@ -309,17 +341,17 @@ def edit(ctx: click.Context, source: str | None, patch: str | None, from_stdin: 
     try:
         if patch:
             patch_text = open(patch).read()  # noqa: SIM115
-            result = _run_patch(file_id, patch_text)
+            result = _run_patch(file_id, patch_text, api)
         elif source:
             new_source = open(source).read()  # noqa: SIM115
-            result = _run_edit(file_id, new_source)
+            result = _run_edit(file_id, new_source, api)
         elif from_stdin:
             content = click.get_text_stream("stdin").read()
             # Auto-detect: if it looks like a unified diff, treat as patch
             if content.lstrip().startswith("---") or content.lstrip().startswith("@@"):
-                result = _run_patch(file_id, content)
+                result = _run_patch(file_id, content, api)
             else:
-                result = _run_edit(file_id, content)
+                result = _run_edit(file_id, content, api)
     except ValueError as e:
         if as_json:
             click.echo(json.dumps({"status": "error", "error": str(e)}))

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -28,7 +28,11 @@ priority=100
 [program:multiplayer]
 command=/usr/bin/node /app/multi-player/server.js
 directory=/app/multi-player
-environment=MULTIPLAYER_PORT="1234",HOST="0.0.0.0"
+; supervisord's `environment=` replaces the inherited env wholesale, so
+; INTERNAL_SHARED_SECRET (the JWT-verify key for the WS auth handshake) and
+; BACKEND_INTERNAL_URL (used by auto-bootstrap) MUST be forwarded explicitly.
+; Without them every WS connection 4401s and the editor goes offline.
+environment=MULTIPLAYER_PORT="1234",HOST="0.0.0.0",INTERNAL_SHARED_SECRET="%(ENV_INTERNAL_SHARED_SECRET)s",BACKEND_INTERNAL_URL="http://localhost:8080"
 autostart=true
 autorestart=true
 startsecs=3

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,125 @@
+# Environments
+
+RSM Studio runs in four environments. They differ in how services are
+orchestrated and — importantly — where the `rsm` dependency comes from.
+
+| Environment | Purpose | Orchestration | Where it runs |
+|---|---|---|---|
+| **Dev** | Local development | Docker Compose (`docker/docker-compose.dev.yml`) | Developer's machine |
+| **Test (CI)** | Automated tests on every push / PR | Docker Compose for E2E; bare runners for unit | GitHub Actions |
+| **Staging (preview)** | Per-PR ephemeral deploy for human review | Single containerized image | Fly.io (`aris-backend-pr-N`) + Netlify |
+| **Prod** | The live service | Single containerized image | Fly.io (`aris-backend`) + Netlify |
+
+## The `rsm` dependency
+
+`rsm` ships in three pieces, and each environment sources them slightly
+differently. This is the most common source of "works here, not there"
+confusion, so it is spelled out explicitly.
+
+- **`rsm-lang`** — the Python package. Contains the RSM renderer and the
+  browser-served static assets (`rsm/static/*.js`, including `libraries.js`).
+- **`rsm-lsp`** — the Node/TypeScript language server. Has no npm publish
+  flow; the only way to deploy it is to build from source.
+- **`tree-sitter-rsm`** — the grammar. Ships a Node native addon and a
+  Python C extension.
+
+| Environment | `rsm-lang` (Python) | `rsm-lsp` (Node) | `tree-sitter-rsm` |
+|---|---|---|---|
+| **Dev** | host's local `../../rsm` checkout (volume mount, editable) | same mount, built on container start | same mount |
+| **Test (CI)** | `git clone aris-pub/rsm` main (editable) | same clone, built on container start | same clone |
+| **Staging** | `git clone aris-pub/rsm` main (editable, built into image) | same clone, built into image | same clone |
+| **Prod** | `git clone aris-pub/rsm` main (editable, built into image) | same clone, built into image | same clone |
+
+**Dev** uses whatever is on the developer's disk — including uncommitted
+edits. That is the point of a volume mount: you can change `rsm` and `studio`
+together without publishing anything.
+
+**Test, Staging, and Prod** all clone `aris-pub/rsm` at its `main` branch
+HEAD. None of them pull `rsm` from PyPI. A fix merged to `rsm` main reaches
+all three on their next build; it does **not** require a PyPI release.
+
+> Historical note: Staging and Prod used to install `rsm-lang` from PyPI
+> while building `rsm-lsp`/`tree-sitter-rsm` from the clone — an asymmetry
+> that meant Python-side `rsm` fixes silently failed to propagate. The
+> `backend/Dockerfile` now copies the cloned `rsm` into the image and
+> installs `rsm-lang` editable from it, matching Dev and CI.
+
+## Dev
+
+```bash
+just dev
+```
+
+- `docker/docker-compose.dev.yml` starts separate containers: `backend`,
+  `multiplayer`, `frontend`, `site`, `postgres`.
+- The host's `../../rsm` is volume-mounted to `/workspace/rsm`.
+- `docker/backend/docker-entrypoint.sh` runs `uv sync` against the mounted
+  `rsm`, then builds `tree-sitter-rsm` and `rsm-lsp` from it.
+- `uvicorn --reload` watches `/workspace/rsm`, so editing `rsm` on the host
+  hot-reloads the backend.
+- Process management: `docker/supervisord.dev.conf`.
+
+Tests run from **outside** the containers (see `.claude/CLAUDE.md`), mirroring
+how production receives external requests.
+
+## Test (CI)
+
+GitHub Actions, `.github/workflows/ci.yml`. Every job clones `aris-pub/rsm`
+main into `../rsm`.
+
+| Job | rsm usage |
+|---|---|
+| `unit-backend` | `uv sync` against the cloned `rsm` (editable); runs `pytest` |
+| `unit-frontend`, `unit-site` | only reads `tree-sitter-rsm`'s query files; no Python `rsm` at runtime |
+| `e2e-site`, `e2e-frontend`, `e2e-collab` | `COMPOSE_FILE=docker/docker-compose.dev.yml` — the cloned `rsm` is mounted into the same Docker Compose stack as Dev |
+
+The E2E jobs are deliberately identical to Dev: same compose file, same
+`Dockerfile.dev`, same entrypoint, same `supervisord.dev.conf`.
+
+## Staging (preview)
+
+`.github/workflows/preview.yml`. Every PR gets an ephemeral environment.
+
+- **Backend**: `aris-backend-pr-N.fly.dev` — a single Fly container built
+  from `backend/Dockerfile` (multi-stage, production-style).
+- **Frontend**: `pr-N--<netlify-site>.netlify.app`.
+- **Database**: a separate Fly Postgres app, `aris-backend-pr-N-db`.
+- The workflow clones `aris-pub/rsm` main into the build context; the
+  `Dockerfile` copies it into the image and installs `rsm-lang` editable
+  from it (see the rsm table above).
+- Process management: `docker/supervisord.conf` (the production variant).
+
+Staging exercises the **production build path** — the multi-stage
+`Dockerfile`, `supervisord.conf`, the single-container topology. This is
+deliberate: a bug that only manifests in the prod image (for example, a
+`supervisord.conf` that fails to forward an environment variable) will
+surface in Staging review rather than in Prod.
+
+See [preview-environments.md](preview-environments.md) for the per-PR
+lifecycle, URLs, and cleanup.
+
+## Prod
+
+The live service: `aris-backend.fly.dev` + the production Netlify site.
+
+- Built from the same `backend/Dockerfile` and `backend/fly.toml` as
+  Staging.
+- Deployed manually (`flyctl deploy -a aris-backend`) — there is no
+  push-to-deploy workflow.
+- Process management: `docker/supervisord.conf`.
+
+Because Prod and Staging share the build definition, a green Staging deploy
+is strong evidence that a Prod deploy of the same commit will behave
+identically.
+
+## Summary of differences
+
+| Aspect | Dev | Test (CI) | Staging | Prod |
+|---|---|---|---|---|
+| Orchestration | Docker Compose | Compose (E2E) / bare runner (unit) | single Fly container | single Fly container |
+| Build definition | `Dockerfile.dev` | `Dockerfile.dev` (E2E) | `backend/Dockerfile` | `backend/Dockerfile` |
+| Process manager config | `supervisord.dev.conf` | `supervisord.dev.conf` (E2E) | `supervisord.conf` | `supervisord.conf` |
+| `rsm` delivery | host volume mount | cloned, mounted (E2E) | cloned, baked into image | cloned, baked into image |
+| `rsm` source ref | host working tree | `aris-pub/rsm` main | `aris-pub/rsm` main | `aris-pub/rsm` main |
+| Hot reload | yes (`uvicorn --reload`) | no | no | no |
+| Deploy trigger | `just dev` | push / PR | PR open / push | manual `flyctl deploy` |

--- a/frontend/src/composables/authedWebSocket.js
+++ b/frontend/src/composables/authedWebSocket.js
@@ -212,7 +212,17 @@ export class AuthedWebSocket extends EventTarget {
   }
 }
 
+// Match the browser's WebSocket contract: these constants are accessible both
+// statically (Foo.OPEN) and via instance (someFoo.OPEN). y-websocket's
+// broadcastMessage compares ws.readyState === ws.OPEN on the instance, so the
+// prototype assignments are load-bearing — without them ws.OPEN is undefined
+// and every Y.Doc update is silently dropped.
 AuthedWebSocket.CONNECTING = READY_STATES.CONNECTING;
 AuthedWebSocket.OPEN = READY_STATES.OPEN;
 AuthedWebSocket.CLOSING = READY_STATES.CLOSING;
 AuthedWebSocket.CLOSED = READY_STATES.CLOSED;
+
+AuthedWebSocket.prototype.CONNECTING = READY_STATES.CONNECTING;
+AuthedWebSocket.prototype.OPEN = READY_STATES.OPEN;
+AuthedWebSocket.prototype.CLOSING = READY_STATES.CLOSING;
+AuthedWebSocket.prototype.CLOSED = READY_STATES.CLOSED;

--- a/frontend/src/composables/authedWebSocket.js
+++ b/frontend/src/composables/authedWebSocket.js
@@ -1,0 +1,181 @@
+/**
+ * Authenticated WebSocket wrapper for the Y.js multi-player server.
+ *
+ * The multi-player server requires `{type: 'auth', token: '<jwt>'}` as the
+ * first text frame and replies with `{type: 'auth_ok'}` before Y.js sync may
+ * proceed. This class wraps the browser's WebSocket so y-websocket's
+ * WebsocketProvider can treat it as a normal socket while we transparently
+ * perform the auth handshake.
+ *
+ * Strategy:
+ *   - On the underlying open event we send the auth JSON frame.
+ *   - We hold y-websocket's onopen callback until auth_ok arrives.
+ *   - Any send() y-websocket attempts before auth_ok is queued and flushed
+ *     immediately after auth_ok.
+ *   - The auth_ok frame is consumed by us — y-websocket never sees it.
+ */
+
+const READY_STATES = {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+};
+
+const AUTH_FAILED_CODE = 4401;
+
+export class AuthedWebSocket {
+  constructor(url, protocols) {
+    this._inner = new WebSocket(url, protocols);
+    this._inner.binaryType = "arraybuffer";
+    this._authed = false;
+    this._sendQueue = [];
+
+    this._userOnOpen = null;
+    this._userOnMessage = null;
+    this._userOnError = null;
+    this._userOnClose = null;
+
+    this._token = AuthedWebSocket._resolveToken(url);
+
+    this._inner.onopen = () => {
+      if (!this._token) {
+        try {
+          this._inner.close(AUTH_FAILED_CODE, "no-token");
+        } catch (_e) {
+          /* already closed */
+        }
+        return;
+      }
+      try {
+        this._inner.send(JSON.stringify({ type: "auth", token: this._token }));
+      } catch (_e) {
+        /* will surface via onclose */
+      }
+    };
+
+    this._inner.onmessage = (event) => {
+      if (!this._authed && typeof event.data === "string") {
+        let parsed;
+        try {
+          parsed = JSON.parse(event.data);
+        } catch (_e) {
+          parsed = null;
+        }
+        if (parsed && parsed.type === "auth_ok") {
+          this._authed = true;
+          const queue = this._sendQueue;
+          this._sendQueue = [];
+          for (const data of queue) {
+            try {
+              this._inner.send(data);
+            } catch (_e) {
+              /* surfaces via onclose */
+            }
+          }
+          if (this._userOnOpen) {
+            try {
+              this._userOnOpen(new Event("open"));
+            } catch (_e) {
+              /* user error */
+            }
+          }
+          return;
+        }
+        // Any other text frame before auth means the server failed us; let it
+        // close us via the normal onclose path. Don't forward to y-websocket.
+        return;
+      }
+      if (this._userOnMessage) this._userOnMessage(event);
+    };
+
+    this._inner.onerror = (event) => {
+      if (this._userOnError) this._userOnError(event);
+    };
+
+    this._inner.onclose = (event) => {
+      if (this._userOnClose) this._userOnClose(event);
+    };
+  }
+
+  /**
+   * Token lookup hook.
+   *
+   * EditorCodeMirror.vue (and any other consumer) calls
+   * AuthedWebSocket.registerToken(url, token) after /collab/start returns.
+   */
+  static _tokens = new Map();
+
+  static registerToken(url, token) {
+    AuthedWebSocket._tokens.set(url, token);
+  }
+
+  static clearToken(url) {
+    AuthedWebSocket._tokens.delete(url);
+  }
+
+  static _resolveToken(url) {
+    return AuthedWebSocket._tokens.get(url) ?? null;
+  }
+
+  get readyState() {
+    return this._inner.readyState;
+  }
+  get url() {
+    return this._inner.url;
+  }
+  get protocol() {
+    return this._inner.protocol;
+  }
+  get binaryType() {
+    return this._inner.binaryType;
+  }
+  set binaryType(v) {
+    this._inner.binaryType = v;
+  }
+  get bufferedAmount() {
+    return this._inner.bufferedAmount;
+  }
+
+  set onopen(fn) {
+    this._userOnOpen = fn;
+  }
+  get onopen() {
+    return this._userOnOpen;
+  }
+  set onmessage(fn) {
+    this._userOnMessage = fn;
+  }
+  get onmessage() {
+    return this._userOnMessage;
+  }
+  set onerror(fn) {
+    this._userOnError = fn;
+  }
+  get onerror() {
+    return this._userOnError;
+  }
+  set onclose(fn) {
+    this._userOnClose = fn;
+  }
+  get onclose() {
+    return this._userOnClose;
+  }
+
+  send(data) {
+    if (!this._authed) {
+      this._sendQueue.push(data);
+    } else {
+      this._inner.send(data);
+    }
+  }
+
+  close(code, reason) {
+    return this._inner.close(code, reason);
+  }
+}
+
+AuthedWebSocket.CONNECTING = READY_STATES.CONNECTING;
+AuthedWebSocket.OPEN = READY_STATES.OPEN;
+AuthedWebSocket.CLOSING = READY_STATES.CLOSING;
+AuthedWebSocket.CLOSED = READY_STATES.CLOSED;

--- a/frontend/src/composables/authedWebSocket.js
+++ b/frontend/src/composables/authedWebSocket.js
@@ -24,8 +24,40 @@ const READY_STATES = {
 
 const AUTH_FAILED_CODE = 4401;
 
-export class AuthedWebSocket {
+// An Event instance can only be dispatched once. The browser's WebSocket has
+// already fired the original event when it called our inner.on{message,close}
+// handler, so we forge a fresh one when forwarding to addEventListener
+// listeners. Errors fall back to a plain Event (CloseEvent/MessageEvent may be
+// unavailable in some non-browser environments).
+function _cloneMessageEvent(event) {
+  try {
+    return new MessageEvent("message", { data: event.data, origin: event.origin });
+  } catch (_e) {
+    const e = new Event("message");
+    e.data = event.data;
+    return e;
+  }
+}
+
+function _cloneCloseEvent(event) {
+  try {
+    return new CloseEvent("close", {
+      code: event.code,
+      reason: event.reason,
+      wasClean: event.wasClean,
+    });
+  } catch (_e) {
+    const e = new Event("close");
+    e.code = event.code;
+    e.reason = event.reason;
+    e.wasClean = event.wasClean;
+    return e;
+  }
+}
+
+export class AuthedWebSocket extends EventTarget {
   constructor(url, protocols) {
+    super();
     this._inner = new WebSocket(url, protocols);
     this._inner.binaryType = "arraybuffer";
     this._authed = false;
@@ -73,13 +105,15 @@ export class AuthedWebSocket {
               /* surfaces via onclose */
             }
           }
+          const openEvent = new Event("open");
           if (this._userOnOpen) {
             try {
-              this._userOnOpen(new Event("open"));
+              this._userOnOpen(openEvent);
             } catch (_e) {
               /* user error */
             }
           }
+          this.dispatchEvent(openEvent);
           return;
         }
         // Any other text frame before auth means the server failed us; let it
@@ -87,14 +121,17 @@ export class AuthedWebSocket {
         return;
       }
       if (this._userOnMessage) this._userOnMessage(event);
+      this.dispatchEvent(_cloneMessageEvent(event));
     };
 
     this._inner.onerror = (event) => {
       if (this._userOnError) this._userOnError(event);
+      this.dispatchEvent(new Event("error"));
     };
 
     this._inner.onclose = (event) => {
       if (this._userOnClose) this._userOnClose(event);
+      this.dispatchEvent(_cloneCloseEvent(event));
     };
   }
 

--- a/frontend/src/tests/composables/authedWebSocket.test.js
+++ b/frontend/src/tests/composables/authedWebSocket.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { AuthedWebSocket } from "@/composables/authedWebSocket";
+
+class MockInnerSocket {
+  constructor(url, protocols) {
+    this.url = url;
+    this.protocols = protocols;
+    this.binaryType = "blob";
+    this.readyState = 0;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    this.onclose = null;
+    this.sent = [];
+    this.closed = null;
+  }
+  send(data) {
+    this.sent.push(data);
+  }
+  close(code, reason) {
+    this.closed = { code, reason };
+    this.readyState = 3;
+  }
+}
+
+let lastInner = null;
+let origWebSocket;
+
+beforeEach(() => {
+  origWebSocket = globalThis.WebSocket;
+  globalThis.WebSocket = vi.fn().mockImplementation((url, protocols) => {
+    lastInner = new MockInnerSocket(url, protocols);
+    return lastInner;
+  });
+});
+
+afterEach(() => {
+  globalThis.WebSocket = origWebSocket;
+  lastInner = null;
+  AuthedWebSocket._tokens.clear();
+});
+
+describe("AuthedWebSocket — addEventListener compatibility (regression for std-kab28c)", () => {
+  it("exposes addEventListener / removeEventListener / dispatchEvent (EventTarget API)", () => {
+    const ws = new AuthedWebSocket("ws://localhost:1234/file-1-test");
+    expect(typeof ws.addEventListener).toBe("function");
+    expect(typeof ws.removeEventListener).toBe("function");
+    expect(typeof ws.dispatchEvent).toBe("function");
+  });
+
+  it("dispatches an 'error' event to addEventListener listeners when inner socket errors", () => {
+    const ws = new AuthedWebSocket("ws://localhost:1234/file-1-test");
+    const listener = vi.fn();
+    ws.addEventListener("error", listener);
+
+    lastInner.onerror(new Event("error"));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].type).toBe("error");
+  });
+
+  it("dispatches a 'close' event with code/reason preserved", () => {
+    const ws = new AuthedWebSocket("ws://localhost:1234/file-1-test");
+    const listener = vi.fn();
+    ws.addEventListener("close", listener);
+
+    lastInner.onclose({ code: 4401, reason: "auth-failed", wasClean: false });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const evt = listener.mock.calls[0][0];
+    expect(evt.type).toBe("close");
+    expect(evt.code).toBe(4401);
+    expect(evt.reason).toBe("auth-failed");
+  });
+
+  it("dispatches an 'open' event only after auth_ok arrives", () => {
+    AuthedWebSocket.registerToken("ws://localhost:1234/file-1-test", "tok-abc");
+    const ws = new AuthedWebSocket("ws://localhost:1234/file-1-test");
+    const listener = vi.fn();
+    ws.addEventListener("open", listener);
+
+    lastInner.onopen();
+    expect(listener).not.toHaveBeenCalled();
+    expect(lastInner.sent[0]).toBe(JSON.stringify({ type: "auth", token: "tok-abc" }));
+
+    lastInner.onmessage({ data: JSON.stringify({ type: "auth_ok" }) });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].type).toBe("open");
+  });
+
+  it("does not break setter API (used by y-websocket internally)", () => {
+    AuthedWebSocket.registerToken("ws://localhost:1234/file-1-test", "tok-abc");
+    const ws = new AuthedWebSocket("ws://localhost:1234/file-1-test");
+    const setterOpen = vi.fn();
+    const setterMsg = vi.fn();
+    ws.onopen = setterOpen;
+    ws.onmessage = setterMsg;
+
+    lastInner.onopen();
+    lastInner.onmessage({ data: JSON.stringify({ type: "auth_ok" }) });
+    expect(setterOpen).toHaveBeenCalledTimes(1);
+
+    // After auth, regular messages reach the setter
+    const dataFrame = { data: new ArrayBuffer(4) };
+    lastInner.onmessage(dataFrame);
+    expect(setterMsg).toHaveBeenCalledWith(dataFrame);
+  });
+
+  it("closes with 4401 when no token is registered", () => {
+    const ws = new AuthedWebSocket("ws://localhost:1234/file-1-test");
+    lastInner.onopen();
+    expect(lastInner.closed).toEqual({ code: 4401, reason: "no-token" });
+    // Wrapper exists; no auth frame sent
+    expect(lastInner.sent).toEqual([]);
+    expect(ws.readyState).toBe(3);
+  });
+});

--- a/frontend/src/tests/composables/authedWebSocket.test.js
+++ b/frontend/src/tests/composables/authedWebSocket.test.js
@@ -115,4 +115,20 @@ describe("AuthedWebSocket — addEventListener compatibility (regression for std
     expect(lastInner.sent).toEqual([]);
     expect(ws.readyState).toBe(3);
   });
+
+  it("exposes CONNECTING/OPEN/CLOSING/CLOSED constants on both the class and instances", () => {
+    // y-websocket's broadcastMessage does `ws.readyState === ws.OPEN` on the
+    // instance. Standard WebSocket inherits these via the prototype; if we
+    // expose them only as statics, every Y.Doc update is silently dropped.
+    expect(AuthedWebSocket.CONNECTING).toBe(0);
+    expect(AuthedWebSocket.OPEN).toBe(1);
+    expect(AuthedWebSocket.CLOSING).toBe(2);
+    expect(AuthedWebSocket.CLOSED).toBe(3);
+
+    const ws = new AuthedWebSocket("ws://localhost:1234/file-1-test");
+    expect(ws.CONNECTING).toBe(0);
+    expect(ws.OPEN).toBe(1);
+    expect(ws.CLOSING).toBe(2);
+    expect(ws.CLOSED).toBe(3);
+  });
 });

--- a/frontend/src/tests/e2e/yjs-helpers.js
+++ b/frontend/src/tests/e2e/yjs-helpers.js
@@ -77,6 +77,25 @@ export async function createAuthenticatedContext(browser, { token, refreshToken,
   return { context, page };
 }
 
+// Open an additional page within an existing authenticated context. The shared
+// context means both pages live in the same browser session and share
+// BroadcastChannel + storage — required to reproduce same-browser multi-tab
+// behaviour (which goes through y-websocket's BroadcastChannel in addition to
+// the WebSocket relay).
+export async function openSecondTab(context, { token, refreshToken, userData }) {
+  const page = await context.newPage();
+  await page.goto("/", { waitUntil: "commit" });
+  await page.evaluate(
+    ({ tok, refTok, user }) => {
+      localStorage.setItem("accessToken", tok);
+      localStorage.setItem("refreshToken", refTok);
+      localStorage.setItem("user", JSON.stringify(user));
+    },
+    { tok: token, refTok: refreshToken, user: userData }
+  );
+  return page;
+}
+
 // ─── Editor helpers ───────────────────────────────────────────────────────────
 
 export async function openFileInEditor(page, fileId, { retries = 1 } = {}) {

--- a/frontend/src/tests/e2e/yjs-multi-tab-same-browser.spec.js
+++ b/frontend/src/tests/e2e/yjs-multi-tab-same-browser.spec.js
@@ -1,0 +1,209 @@
+/**
+ * E2E regression: Y.js multi-tab in the SAME BROWSER with REAL KEYBOARD input.
+ *
+ * Why this test exists:
+ *   yjs-multi-tab.spec.js uses `browser.newContext()` per tab, which means each
+ *   tab is an isolated browser session. y-websocket's BroadcastChannel does
+ *   not bridge isolated contexts, so those tests only exercise the WebSocket
+ *   relay path.
+ *
+ *   In the real world a user opens two tabs in the same Chrome window. Both
+ *   tabs share a context, so y-websocket's BroadcastChannel is active in
+ *   addition to the WebSocket relay. That path needs its own coverage.
+ *
+ *   On 2026-05-18, a manual review of PR #405 (multi-player WS auth) flagged
+ *   that step-2 of the review checklist ("Open the same file in two tabs in
+ *   the same browser, type in both") left tab 1 with a frozen editor and a
+ *   cascade of CodeMirror "No tile at position undefined" errors in the
+ *   console. The existing test suite did not catch this — separate-context
+ *   sync passed, while same-context sync was broken.
+ *
+ * What this test guarantees:
+ *   - Sync works between two pages of the same context.
+ *   - After a remote (BroadcastChannel-delivered) edit lands, the receiving
+ *     tab's editor is still interactive — `view.state.selection.main.head` is
+ *     a real number, the CodeMirror DOM accepts clicks, and a subsequent
+ *     keyboard keystroke makes it into the document.
+ *   - No "No tile at position undefined" (or any CodeMirror measure-cycle
+ *     error) shows up on the page console during the interaction.
+ *
+ * Tag: @collab
+ */
+
+import { test, expect } from "./fixtures.js";
+import {
+  loginUser,
+  createTestFile,
+  deleteTestFile,
+  createAuthenticatedContext,
+  openSecondTab,
+  openFileInEditor,
+  clearEditor,
+  getEditorContent,
+  waitForSync,
+  cleanupYjs,
+} from "./yjs-helpers.js";
+
+function attachConsoleCapture(page) {
+  const errors = [];
+  page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+  });
+  return errors;
+}
+
+test.describe("Y.js multi-tab — SAME browser context, real keyboard @collab", () => {
+  let auth;
+
+  test.beforeAll(async ({ request }) => {
+    auth = await loginUser(request);
+  });
+
+  test("two tabs in one context: keyboard input in tab B does not freeze tab A's editor", async ({
+    browser,
+    request,
+  }) => {
+    test.setTimeout(60000);
+    const fileId = await createTestFile(request, auth.token, auth.userData.id);
+    const tabA = await createAuthenticatedContext(browser, auth);
+    const tabBPage = await openSecondTab(tabA.context, auth);
+
+    const errorsA = attachConsoleCapture(tabA.page);
+    const errorsB = attachConsoleCapture(tabBPage);
+
+    try {
+      await openFileInEditor(tabA.page, fileId);
+      await openFileInEditor(tabBPage, fileId);
+
+      await clearEditor(tabA.page);
+      await tabBPage.waitForFunction(
+        () => window.__cmView.state.doc.length === 0,
+        {},
+        { timeout: 5000 }
+      );
+
+      // Real keyboard input in tab B (mirrors what a human types).
+      await tabBPage.click(".cm-content");
+      await tabBPage.keyboard.type("hello from tab B", { delay: 30 });
+
+      // Tab A receives the edit via BroadcastChannel + WebSocket.
+      await waitForSync(tabA.page, "hello from tab B");
+
+      // CRITICAL: tab A's selection must still be a valid number so the
+      // CodeMirror measure cycle (updateSelection → domAtPos → resolveBlock)
+      // does not throw "No tile at position undefined".
+      const selA = await tabA.page.evaluate(() => {
+        const main = window.__cmView.state.selection.main;
+        return {
+          anchor: main.anchor,
+          head: main.head,
+          from: main.from,
+          to: main.to,
+          docLen: window.__cmView.state.doc.length,
+        };
+      });
+      expect(typeof selA.anchor).toBe("number");
+      expect(typeof selA.head).toBe("number");
+      expect(Number.isFinite(selA.anchor)).toBe(true);
+      expect(Number.isFinite(selA.head)).toBe(true);
+      expect(selA.anchor).toBeGreaterThanOrEqual(0);
+      expect(selA.anchor).toBeLessThanOrEqual(selA.docLen);
+
+      // Tab A's editor must still be interactive: clicking + typing should
+      // produce visible changes. If updateSelection had been throwing in a
+      // measure-cycle loop, the editor would be frozen here.
+      await tabA.page.click(".cm-content");
+      await tabA.page.keyboard.type(" + reply from A", { delay: 30 });
+      await tabA.page.waitForFunction(
+        () => window.__cmView.state.doc.toString().includes("reply from A"),
+        {},
+        { timeout: 5000 }
+      );
+      await waitForSync(tabBPage, "reply from A");
+
+      const contentA = await getEditorContent(tabA.page);
+      const contentB = await getEditorContent(tabBPage);
+      expect(contentA).toBe(contentB);
+      expect(contentA).toContain("hello from tab B");
+      expect(contentA).toContain("reply from A");
+
+      // The screenshot in the PR review showed dozens of these in the console.
+      // Any single occurrence is a regression of the bug we're locking down.
+      const tileErrors = [...errorsA, ...errorsB].filter((e) => e.includes("No tile at position"));
+      expect(tileErrors, `Unexpected CodeMirror tile errors:\n${tileErrors.join("\n")}`).toEqual(
+        []
+      );
+    } finally {
+      await cleanupYjs(tabA.page);
+      await cleanupYjs(tabBPage);
+      await tabBPage.close();
+      await tabA.context.close();
+      await deleteTestFile(request, auth.token, fileId);
+    }
+  });
+
+  test("two tabs in one context: simultaneous keyboard typing keeps both editors interactive", async ({
+    browser,
+    request,
+  }) => {
+    test.setTimeout(60000);
+    const fileId = await createTestFile(request, auth.token, auth.userData.id);
+    const tabA = await createAuthenticatedContext(browser, auth);
+    const tabBPage = await openSecondTab(tabA.context, auth);
+
+    const errorsA = attachConsoleCapture(tabA.page);
+    const errorsB = attachConsoleCapture(tabBPage);
+
+    try {
+      await openFileInEditor(tabA.page, fileId);
+      await openFileInEditor(tabBPage, fileId);
+
+      await clearEditor(tabA.page);
+      await tabBPage.waitForFunction(
+        () => window.__cmView.state.doc.length === 0,
+        {},
+        { timeout: 5000 }
+      );
+
+      // Type in tab A first, then tab B — alternating, like a real user
+      // switching tabs. This is what the manual review did.
+      await tabA.page.click(".cm-content");
+      await tabA.page.keyboard.type("AAAA", { delay: 30 });
+      await waitForSync(tabBPage, "AAAA");
+
+      await tabBPage.click(".cm-content");
+      await tabBPage.keyboard.type("BBBB", { delay: 30 });
+      await waitForSync(tabA.page, "BBBB");
+
+      // Back to tab A — the bug presented as "I can't type or even click on
+      // the source editor on tab 1 anymore". This is the exact failure mode.
+      await tabA.page.click(".cm-content");
+      await tabA.page.keyboard.type("CCCC", { delay: 30 });
+      await tabA.page.waitForFunction(
+        () => window.__cmView.state.doc.toString().includes("CCCC"),
+        {},
+        { timeout: 5000 }
+      );
+      await waitForSync(tabBPage, "CCCC");
+
+      const contentA = await getEditorContent(tabA.page);
+      const contentB = await getEditorContent(tabBPage);
+      expect(contentA).toBe(contentB);
+      for (const needle of ["AAAA", "BBBB", "CCCC"]) {
+        expect(contentA).toContain(needle);
+      }
+
+      const tileErrors = [...errorsA, ...errorsB].filter((e) => e.includes("No tile at position"));
+      expect(tileErrors, `Unexpected CodeMirror tile errors:\n${tileErrors.join("\n")}`).toEqual(
+        []
+      );
+    } finally {
+      await cleanupYjs(tabA.page);
+      await cleanupYjs(tabBPage);
+      await tabBPage.close();
+      await tabA.context.close();
+      await deleteTestFile(request, auth.token, fileId);
+    }
+  });
+});

--- a/frontend/src/tests/e2e/yjs-multi-user.spec.js
+++ b/frontend/src/tests/e2e/yjs-multi-user.spec.js
@@ -161,7 +161,14 @@ test.describe("Multi-User Collaboration @collab", () => {
     }
   });
 
-  test("should allow COMMENTER to view but not edit", async ({ browser, request }) => {
+  // Skipped: /collab/start is currently gated on require_edit to prevent
+  // privilege escalation. The multi-player server does not enforce role-based
+  // write-frame filtering yet, so any client with a valid token can inject
+  // Y.js updates. Until server-side write-frame filtering lands (follow-up
+  // bead), COMMENTER cannot establish a read-only WebSocket at all.
+  // This test asserts read-only participation, which will be restored once
+  // the server enforces write restrictions per token role.
+  test.skip("should allow COMMENTER to view but not edit", async ({ browser, request }) => {
     test.setTimeout(60000);
 
     const fileId = await createTestFile(request, ownerAuth.token, ownerAuth.userData.id);

--- a/frontend/src/views/workspace/EditorCodeMirror.vue
+++ b/frontend/src/views/workspace/EditorCodeMirror.vue
@@ -33,6 +33,7 @@
   import { yCollab, yUndoManagerKeymap } from "y-codemirror.next";
   import * as Y from "yjs";
   import { WebsocketProvider } from "y-websocket";
+  import { AuthedWebSocket } from "@/composables/authedWebSocket";
   import { useLSPClient } from "@/composables/useLSPClient";
   import { semanticTokensExtension, requestSemanticTokens } from "@/composables/useSemanticTokens";
   import { rsmKeymap } from "@/composables/useRSMCommands";
@@ -134,6 +135,11 @@
     }
 
     if (provider.value) {
+      try {
+        AuthedWebSocket.clearToken(`${serverUrl.value}/${provider.value.roomname}`);
+      } catch (_e) {
+        /* ignore */
+      }
       provider.value.destroy();
       provider.value = null;
     }
@@ -169,7 +175,7 @@
   // Setup Y.js and WebSocket when file changes
   watch(
     [() => file.value?.id, editorContainer],
-    ([fileId, container]) => {
+    async ([fileId, container]) => {
       if (!fileId || !container) return;
 
       // Cleanup previous instance
@@ -183,16 +189,38 @@
       ytext.value = ydoc.value.getText("text");
       if (parentYtext) parentYtext.value = ytext.value;
 
-      // Create WebSocket provider
-      provider.value = new WebsocketProvider(serverUrl.value, roomName.value, ydoc.value);
+      // Tell the backend to start its Y.js client and get a short-lived WS auth
+      // token. The multi-player server requires the token as the first frame on
+      // the WebSocket — without one we'd be rejected with code 4401.
+      activeCollabFileId.value = fileId;
+      let token = null;
+      try {
+        const startResp = await api.post(`/files/${fileId}/collab/start`);
+        token = startResp?.data?.token ?? null;
+        if (!token) {
+          console.error(`[Collab] /collab/start for file ${fileId} returned no token`);
+        }
+      } catch (err) {
+        console.error(
+          `[Collab] Failed to start backend client for file ${fileId}:`,
+          err?.response?.status,
+          err?.response?.data || err.message
+        );
+      }
+
+      // Bail if the file or watcher changed while we awaited the token.
+      if (file.value?.id !== fileId) return;
+
+      const wsUrl = `${serverUrl.value}/${roomName.value}`;
+      if (token) AuthedWebSocket.registerToken(wsUrl, token);
+
+      // Create WebSocket provider with our authed wrapper as the polyfill so
+      // y-websocket sees a normal socket while we handle the auth handshake.
+      provider.value = new WebsocketProvider(serverUrl.value, roomName.value, ydoc.value, {
+        WebSocketPolyfill: AuthedWebSocket,
+      });
       awareness.value = provider.value.awareness;
       awareness.value.setLocalStateField("user", userInfo.value);
-
-      // Tell the backend to start its Y.js client for this file
-      activeCollabFileId.value = fileId;
-      api.post(`/files/${fileId}/collab/start`).catch((err) => {
-        console.error(`[Collab] Failed to start backend client for file ${fileId}:`, err?.response?.status, err?.response?.data || err.message);
-      });
 
       // Log WebSocket errors only
       provider.value.ws?.addEventListener("error", (error) => {
@@ -207,6 +235,24 @@
       // Log connection errors
       provider.value.on("connection-error", (event) => {
         console.error("[Y.js] Connection error:", event);
+      });
+
+      // Refresh the WS auth token before each reconnect; the token is short-lived
+      // (5 min) and y-websocket would otherwise reconnect with a stale one and
+      // be rejected with code 4401.
+      provider.value.on("connection-close", async (closeEvent) => {
+        if (file.value?.id !== fileId) return;
+        try {
+          const refresh = await api.post(`/files/${fileId}/collab/start`);
+          const fresh = refresh?.data?.token;
+          if (fresh) AuthedWebSocket.registerToken(wsUrl, fresh);
+        } catch (err) {
+          console.error(
+            `[Collab] Failed to refresh token for file ${fileId}:`,
+            err?.response?.status,
+            err?.response?.data || err.message
+          );
+        }
       });
 
       provider.value.once("synced", async () => {
@@ -430,7 +476,6 @@
   .cm-container :deep(.cm-cursor) {
     border-left-color: var(--extra-dark);
   }
-
 </style>
 
 <!-- Semantic token highlighting from tree-sitter-rsm (unscoped so tok-* classes reach CodeMirror DOM) -->

--- a/multi-player/package-lock.json
+++ b/multi-player/package-lock.json
@@ -8,6 +8,7 @@
       "name": "aris-multiplayer-server",
       "version": "1.0.0",
       "dependencies": {
+        "jsonwebtoken": "^9.0.2",
         "ws": "^8.18.0",
         "y-websocket": "^2.0.4"
       },
@@ -952,6 +953,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1030,6 +1037,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/encoding-down": {
@@ -1184,6 +1200,49 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/level": {
@@ -1363,6 +1422,48 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -1391,7 +1492,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1568,8 +1668,19 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/multi-player/package.json
+++ b/multi-player/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "jsonwebtoken": "^9.0.2",
     "ws": "^8.18.0",
     "y-websocket": "^2.0.4"
   },

--- a/multi-player/server.auth.test.js
+++ b/multi-player/server.auth.test.js
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import jwt from 'jsonwebtoken';
+import {
+  awaitAuthFrame,
+  handleConnection,
+  resetBootstrapState,
+  validateAuthForDocName,
+} from './server.js';
+
+/**
+ * Tests for the multi-player server's WebSocket auth handshake.
+ *
+ * Connection contract:
+ *   1. Client opens WS.
+ *   2. Within 5s, client sends `{type:'auth', token:'<jwt>'}` text frame.
+ *   3. Server verifies signature + exp; checks file_id matches docName
+ *      (unless role='backend'); replies `{type:'auth_ok'}`.
+ *   4. Y.js sync proceeds normally.
+ *   On any failure the server closes the socket with code 4401.
+ */
+
+const SECRET = 'test-secret';
+
+function makeMockWs() {
+  const ws = new EventEmitter();
+  ws.close = vi.fn();
+  ws.send = vi.fn();
+  ws.readyState = 1;
+  ws.OPEN = 1;
+  ws.removeListener = ws.off ?? EventEmitter.prototype.removeListener.bind(ws);
+  return ws;
+}
+
+function mintToken(claims, ttlSecs = 60) {
+  const now = Math.floor(Date.now() / 1000);
+  return jwt.sign(
+    { iat: now, exp: now + ttlSecs, ...claims },
+    SECRET,
+    { algorithm: 'HS256' },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// awaitAuthFrame
+// ---------------------------------------------------------------------------
+
+describe('awaitAuthFrame', () => {
+  it('resolves with the decoded payload on a valid token', async () => {
+    const ws = makeMockWs();
+    const token = mintToken({ sub: '7', file_id: 1, role: 'EDITOR' });
+
+    const p = awaitAuthFrame(ws, { secret: SECRET, timeoutMs: 1000 });
+    ws.emit('message', JSON.stringify({ type: 'auth', token }));
+    const payload = await p;
+    expect(payload.role).toBe('EDITOR');
+    expect(payload.file_id).toBe(1);
+  });
+
+  it('rejects with auth-timeout if no message arrives in time', async () => {
+    const ws = makeMockWs();
+    await expect(
+      awaitAuthFrame(ws, { secret: SECRET, timeoutMs: 30 }),
+    ).rejects.toThrow(/auth-timeout/);
+  });
+
+  it('rejects when the first message is not auth-typed JSON', async () => {
+    const ws = makeMockWs();
+    const p = awaitAuthFrame(ws, { secret: SECRET, timeoutMs: 1000 });
+    ws.emit('message', JSON.stringify({ type: 'sync', data: 'whatever' }));
+    await expect(p).rejects.toThrow(/auth-missing/);
+  });
+
+  it('rejects when the first message is binary (non-JSON)', async () => {
+    const ws = makeMockWs();
+    const p = awaitAuthFrame(ws, { secret: SECRET, timeoutMs: 1000 });
+    ws.emit('message', Buffer.from([0x00, 0x01, 0x02]));
+    await expect(p).rejects.toThrow(/auth-invalid|auth-missing/);
+  });
+
+  it('rejects expired tokens', async () => {
+    const ws = makeMockWs();
+    const expired = mintToken({ sub: '7', file_id: 1, role: 'EDITOR' }, -10);
+    const p = awaitAuthFrame(ws, { secret: SECRET, timeoutMs: 1000 });
+    ws.emit('message', JSON.stringify({ type: 'auth', token: expired }));
+    await expect(p).rejects.toThrow(/auth-invalid/);
+  });
+
+  it('rejects tokens signed with the wrong secret', async () => {
+    const ws = makeMockWs();
+    const bad = jwt.sign(
+      { sub: '7', file_id: 1, role: 'EDITOR', exp: Math.floor(Date.now() / 1000) + 60 },
+      'WRONG-SECRET',
+      { algorithm: 'HS256' },
+    );
+    const p = awaitAuthFrame(ws, { secret: SECRET, timeoutMs: 1000 });
+    ws.emit('message', JSON.stringify({ type: 'auth', token: bad }));
+    await expect(p).rejects.toThrow(/auth-invalid/);
+  });
+
+  it('rejects when the socket closes before sending auth', async () => {
+    const ws = makeMockWs();
+    const p = awaitAuthFrame(ws, { secret: SECRET, timeoutMs: 1000 });
+    ws.emit('close');
+    await expect(p).rejects.toThrow(/closed-before-auth/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAuthForDocName
+// ---------------------------------------------------------------------------
+
+describe('validateAuthForDocName', () => {
+  it('accepts a matching file_id for normal roles', () => {
+    expect(validateAuthForDocName({ role: 'EDITOR', file_id: 42 }, 'file-42-local')).toBe(null);
+    expect(validateAuthForDocName({ role: 'OWNER', file_id: 7 }, 'file-7-local')).toBe(null);
+    expect(validateAuthForDocName({ role: 'COMMENTER', file_id: 1 }, 'file-1-prod')).toBe(null);
+  });
+
+  it('rejects mismatched file_id', () => {
+    expect(
+      validateAuthForDocName({ role: 'EDITOR', file_id: 5 }, 'file-42-local'),
+    ).toBe('auth-file-mismatch');
+  });
+
+  it('accepts backend role for any docName', () => {
+    expect(validateAuthForDocName({ role: 'backend', file_id: 999 }, 'file-1-local')).toBe(null);
+  });
+
+  it('rejects malformed payloads', () => {
+    expect(validateAuthForDocName(null, 'file-1-local')).toMatch(/auth-invalid/);
+    expect(validateAuthForDocName({}, 'file-1-local')).toMatch(/auth-invalid/);
+    expect(validateAuthForDocName({ role: 'EDITOR' }, 'not-a-room')).toBe('auth-bad-docname');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleConnection auth integration
+// ---------------------------------------------------------------------------
+
+describe('handleConnection auth integration', () => {
+  let opts;
+
+  beforeEach(() => {
+    resetBootstrapState();
+    opts = {
+      fetch: vi.fn().mockResolvedValue({ ok: true, status: 200 }),
+      backendUrl: 'http://localhost:8000',
+      secret: SECRET,
+      authSecret: SECRET,
+      docs: new Map(),
+      totalClientCount: () => 0,
+    };
+  });
+
+  afterEach(() => {
+    resetBootstrapState();
+  });
+
+  function makeReq(docName) {
+    return {
+      url: `/${docName}`,
+      headers: { host: 'localhost:1234' },
+    };
+  }
+
+  it('closes 4401 when no auth message arrives within timeout', async () => {
+    const ws = makeMockWs();
+    opts.authTimeoutMs = 30;
+
+    await handleConnection(ws, makeReq('file-1-local'), opts);
+
+    expect(ws.close).toHaveBeenCalledWith(4401, 'auth-failed');
+  });
+
+  it('closes 4401 when token file_id does not match docName', async () => {
+    const ws = makeMockWs();
+    opts.authTimeoutMs = 200;
+    const token = mintToken({ sub: '7', file_id: 999, role: 'EDITOR' });
+
+    const p = handleConnection(ws, makeReq('file-1-local'), opts);
+    setImmediate(() => ws.emit('message', JSON.stringify({ type: 'auth', token })));
+    await p;
+
+    expect(ws.close).toHaveBeenCalledWith(4401, 'auth-failed');
+  });
+
+  it('closes 4401 when token is expired', async () => {
+    const ws = makeMockWs();
+    opts.authTimeoutMs = 200;
+    const token = mintToken({ sub: '7', file_id: 1, role: 'EDITOR' }, -1);
+
+    const p = handleConnection(ws, makeReq('file-1-local'), opts);
+    setImmediate(() => ws.emit('message', JSON.stringify({ type: 'auth', token })));
+    await p;
+
+    expect(ws.close).toHaveBeenCalledWith(4401, 'auth-failed');
+  });
+
+  it('closes 4401 when token has wrong signature', async () => {
+    const ws = makeMockWs();
+    opts.authTimeoutMs = 200;
+    const token = jwt.sign(
+      { sub: '7', file_id: 1, role: 'EDITOR', exp: Math.floor(Date.now() / 1000) + 60 },
+      'wrong-secret',
+      { algorithm: 'HS256' },
+    );
+
+    const p = handleConnection(ws, makeReq('file-1-local'), opts);
+    setImmediate(() => ws.emit('message', JSON.stringify({ type: 'auth', token })));
+    await p;
+
+    expect(ws.close).toHaveBeenCalledWith(4401, 'auth-failed');
+  });
+
+  it('sends auth_ok and tags the role for a backend token', async () => {
+    const ws = makeMockWs();
+    // No file_id check needed for backend, but bootstrap shouldn't happen
+    // either (backend is itself the persistence peer).
+    opts.authTimeoutMs = 200;
+    const token = mintToken({ sub: 'backend', file_id: 1, role: 'backend' });
+
+    // Stub setupWSConnection by causing the docs map to never need it.
+    // We can't easily mock the y-websocket import; instead we just verify
+    // that auth_ok was sent and close was NOT called.
+    const p = handleConnection(ws, makeReq('file-1-local'), opts);
+    setImmediate(() => ws.emit('message', JSON.stringify({ type: 'auth', token })));
+
+    // handleConnection will call setupWSConnection which may throw because
+    // our ws is a mock — that's fine; we just need to verify auth_ok was sent
+    // first and 4401 was never called.
+    try {
+      await p;
+    } catch (_e) { /* setupWSConnection failure */ }
+
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'auth_ok' }));
+    expect(ws.close).not.toHaveBeenCalledWith(4401, 'auth-failed');
+    expect(ws._role).toBe('backend');
+  });
+});

--- a/multi-player/server.js
+++ b/multi-player/server.js
@@ -17,8 +17,11 @@
  *         when a non-backend client joins a room with no backend present.
  *
  * Connection Roles:
- * - Backend identifies itself via `?role=backend` query parameter.
- * - All other connections are treated as frontends (browser / CLI / agent).
+ * - Every client must present a short-lived JWT as the first WS frame (see
+ *   `awaitAuthFrame`). The token's `role` claim ('backend' | 'OWNER' |
+ *   'EDITOR' | 'COMMENTER') is what drives cleanup behaviour; non-backend
+ *   tokens additionally have their `file_id` claim cross-checked against the
+ *   docName so a token minted for file A can't be used to join room file B.
  *
  * Cleanup Logic:
  * - When the backend disconnects (hot-reload, crash), leave frontends alone.
@@ -30,6 +33,89 @@
 
 import { WebSocketServer } from 'ws';
 import { setupWSConnection, docs } from 'y-websocket/bin/utils';
+import jwt from 'jsonwebtoken';
+
+// ---------------------------------------------------------------------------
+// WebSocket auth
+// ---------------------------------------------------------------------------
+
+const AUTH_TIMEOUT_MS = 5000;
+const AUTH_CLOSE_CODE = 4401;
+
+/**
+ * Read the first WebSocket frame and verify the auth JWT.
+ *
+ * Resolves with the decoded token payload on success. Rejects with an Error
+ * whose `.message` is suitable for a 4401 close reason on any failure.
+ */
+export function awaitAuthFrame(ws, opts) {
+  const timeoutMs = opts.timeoutMs ?? AUTH_TIMEOUT_MS;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error('auth-timeout'));
+    }, timeoutMs);
+    if (typeof timer.unref === 'function') timer.unref();
+
+    const onMessage = (data) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      try {
+        const text = typeof data === 'string' ? data : data.toString('utf8');
+        const msg = JSON.parse(text);
+        if (msg.type !== 'auth' || typeof msg.token !== 'string') {
+          reject(new Error('auth-missing'));
+          return;
+        }
+        const payload = jwt.verify(msg.token, opts.secret, { algorithms: ['HS256'] });
+        resolve(payload);
+      } catch (err) {
+        reject(new Error(`auth-invalid:${err && err.message ? err.message : 'unknown'}`));
+      }
+    };
+
+    const onClose = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error('closed-before-auth'));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      timer = null;
+      ws.removeListener('message', onMessage);
+      ws.removeListener('close', onClose);
+    };
+
+    ws.once('message', onMessage);
+    ws.once('close', onClose);
+  });
+}
+
+/**
+ * Validate a decoded auth payload against the docName.
+ *
+ * - For role='backend', any file_id is acceptable (system trust).
+ * - For all other roles, the token's file_id must match the docName's id.
+ *
+ * Returns null on success or an error string on failure.
+ */
+export function validateAuthForDocName(payload, docName) {
+  if (!payload || typeof payload !== 'object') return 'auth-invalid';
+  const role = payload.role;
+  if (typeof role !== 'string') return 'auth-invalid-role';
+  if (role === 'backend') return null;
+
+  const fileId = parseFileIdFromDocName(docName);
+  if (fileId === null) return 'auth-bad-docname';
+  if (payload.file_id !== fileId) return 'auth-file-mismatch';
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Auto-bootstrap state
@@ -159,8 +245,44 @@ export async function ensureBackendForRoom(docName, opts) {
 export async function handleConnection(ws, req, opts) {
   const url = new URL(req.url, `http://${req.headers.host}`);
   const docName = url.pathname.slice(1);
-  const role = url.searchParams.get('role');
-  ws._role = role === 'backend' ? 'backend' : 'frontend';
+
+  // -------------------------------------------------------------------------
+  // Auth: first frame must be {type: 'auth', token: '<jwt>'}.
+  //
+  // The Y.js docName alone names no permission — anyone who can reach the
+  // socket could otherwise enumerate rooms and read/inject updates. Hold off
+  // on setupWSConnection (which joins the room and starts relaying) until the
+  // token verifies.
+  // -------------------------------------------------------------------------
+  let authPayload;
+  try {
+    authPayload = await awaitAuthFrame(ws, {
+      secret: opts.authSecret,
+      timeoutMs: opts.authTimeoutMs,
+    });
+  } catch (err) {
+    console.warn(`[Y.js Server] Auth failed for ${docName}: ${err.message}`);
+    try { ws.close(AUTH_CLOSE_CODE, 'auth-failed'); } catch (_e) { /* already closed */ }
+    return;
+  }
+
+  const validationErr = validateAuthForDocName(authPayload, docName);
+  if (validationErr) {
+    console.warn(`[Y.js Server] Auth rejected for ${docName}: ${validationErr}`);
+    try { ws.close(AUTH_CLOSE_CODE, 'auth-failed'); } catch (_e) { /* already closed */ }
+    return;
+  }
+
+  ws._role = authPayload.role === 'backend' ? 'backend' : 'frontend';
+  ws._authRole = authPayload.role;
+  ws._authUserId = authPayload.sub;
+
+  try {
+    ws.send(JSON.stringify({ type: 'auth_ok' }));
+  } catch (err) {
+    console.warn(`[Y.js Server] Failed to send auth_ok for ${docName}: ${err.message}`);
+    return;
+  }
 
   let needsBootstrap = false;
   if (ws._role !== 'backend') {
@@ -291,6 +413,7 @@ if (!isTestEnv) {
       fetch: (url, init) => fetch(url, init),
       backendUrl: BACKEND_INTERNAL_URL,
       secret: SECRET,
+      authSecret: SECRET,
       docs,
       totalClientCount: () => wss.clients.size,
     }).catch((err) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ importers:
         specifier: ^6.2.3
         version: 6.2.3
       '@codemirror/state':
-        specifier: 6.6.0
-        version: 6.6.0
+        specifier: 6.5.4
+        version: 6.5.4
       '@codemirror/view':
-        specifier: 6.43.1
-        version: 6.43.1
+        specifier: 6.39.11
+        version: 6.39.11
       '@floating-ui/vue':
         specifier: ^1.1.6
         version: 1.1.11(vue@3.5.34(typescript@5.9.3))
@@ -59,20 +59,20 @@ importers:
         specifier: ^4.5.0
         version: 4.6.4(vue@3.5.34(typescript@5.9.3))
       ws:
-        specifier: ^8.21.0
-        version: 8.21.0
+        specifier: ^8.19.0
+        version: 8.19.0
       y-codemirror.next:
         specifier: ^0.3.5
-        version: 0.3.5(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)(yjs@13.6.31)
+        version: 0.3.5(@codemirror/state@6.5.4)(@codemirror/view@6.39.11)(yjs@13.6.30)
       y-protocols:
         specifier: ^1.0.7
-        version: 1.0.7(yjs@13.6.31)
+        version: 1.0.7(yjs@13.6.30)
       y-websocket:
         specifier: ^2.1.0
-        version: 2.1.0(yjs@13.6.31)
+        version: 2.1.0(yjs@13.6.30)
       yjs:
-        specifier: ^13.6.31
-        version: 13.6.31
+        specifier: ^13.6.29
+        version: 13.6.30
     devDependencies:
       '@babel/core':
         specifier: ^7.27.4
@@ -81,8 +81,8 @@ importers:
         specifier: ^7.27.5
         version: 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.6.1))
       '@babel/plugin-syntax-import-assertions':
-        specifier: ^7.29.7
-        version: 7.29.7(@babel/core@7.29.0)
+        specifier: ^7.26.0
+        version: 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx':
         specifier: ^7.25.9
         version: 7.28.6(@babel/core@7.29.0)
@@ -90,8 +90,8 @@ importers:
         specifier: ^9.39.2
         version: 9.39.4
       '@playwright/test':
-        specifier: ^1.61.0
-        version: 1.61.1
+        specifier: ^1.53.1
+        version: 1.58.2
       '@storybook/addon-a11y':
         specifier: ^8.6.14
         version: 8.6.18(storybook@8.6.18(prettier@3.8.3))
@@ -138,14 +138,14 @@ importers:
         specifier: ^10.1.2
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-prettier:
-        specifier: ^5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
+        specifier: ^5.5.0
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
       eslint-plugin-storybook:
         specifier: ^0.11.6
         version: 0.11.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.1(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1)))
+        version: 10.9.1(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
       globals:
         specifier: ^16.0.0
         version: 16.5.0
@@ -183,17 +183,20 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.46.1)(yaml@2.8.2)
       vue-eslint-parser:
-        specifier: ^10.4.1
-        version: 10.4.1(eslint@9.39.4(jiti@2.6.1))
+        specifier: ^10.1.3
+        version: 10.4.0(eslint@9.39.4(jiti@2.6.1))
 
   multi-player:
     dependencies:
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.3
       ws:
         specifier: ^8.18.0
         version: 8.19.0
       y-websocket:
         specifier: ^2.0.4
-        version: 2.1.0(yjs@13.6.31)
+        version: 2.1.0(yjs@13.6.30)
     devDependencies:
       vitest:
         specifier: ^2.1.8
@@ -209,7 +212,7 @@ importers:
         version: 0.11.13(@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3)))(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
       '@nuxt/test-utils':
         specifier: ^3.19.1
-        version: 3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4)
+        version: 3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4)
       '@tabler/icons-vue':
         specifier: ^3.34.0
         version: 3.40.0(vue@3.5.30(typescript@5.9.3))
@@ -267,7 +270,7 @@ importers:
         version: 9.1.20(eslint@9.39.4(jiti@2.6.1))(storybook@8.6.18(prettier@3.8.3))(typescript@5.9.3)
       eslint-plugin-vue:
         specifier: ^10.2.0
-        version: 10.6.2(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1)))
+        version: 10.6.2(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
       globals:
         specifier: ^16.2.0
         version: 16.5.0
@@ -365,10 +368,6 @@ packages:
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-plugin-utils@7.29.7':
-    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-replace-supers@7.28.6':
     resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
@@ -419,12 +418,6 @@ packages:
 
   '@babel/plugin-syntax-import-assertions@7.28.6':
     resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-assertions@7.29.7':
-    resolution: {integrity: sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -530,11 +523,14 @@ packages:
   '@codemirror/search@6.6.0':
     resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
 
+  '@codemirror/state@6.5.4':
+    resolution: {integrity: sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==}
+
   '@codemirror/state@6.6.0':
     resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
 
-  '@codemirror/view@6.43.1':
-    resolution: {integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==}
+  '@codemirror/view@6.39.11':
+    resolution: {integrity: sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1492,17 +1488,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@pkgr/core@0.3.6':
-    resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@playwright/test@1.61.1':
-    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2630,6 +2617,9 @@ packages:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -3105,6 +3095,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   editorconfig@1.0.7:
     resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
     engines: {node: '>=14'}
@@ -3244,20 +3237,6 @@ packages:
 
   eslint-plugin-prettier@5.5.5:
     resolution: {integrity: sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      '@types/eslint': '>=8.0.0'
-      eslint: '>=8.0.0'
-      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
-      prettier: '>=3.0.0'
-    peerDependenciesMeta:
-      '@types/eslint':
-        optional: true
-      eslint-config-prettier:
-        optional: true
-
-  eslint-plugin-prettier@5.5.6:
-    resolution: {integrity: sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       '@types/eslint': '>=8.0.0'
@@ -4034,8 +4013,18 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jstransformer@1.0.0:
     resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4145,14 +4134,35 @@ packages:
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -4596,18 +4606,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5303,10 +5303,6 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  synckit@0.11.13:
-    resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
@@ -5935,8 +5931,8 @@ packages:
   vue-component-type-helpers@3.2.6:
     resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
-  vue-component-type-helpers@3.3.6:
-    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
+  vue-component-type-helpers@3.2.9:
+    resolution: {integrity: sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -5957,8 +5953,8 @@ packages:
     peerDependencies:
       vue: '>=2'
 
-  vue-eslint-parser@10.4.1:
-    resolution: {integrity: sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==}
+  vue-eslint-parser@10.4.0:
+    resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -6090,18 +6086,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -6178,8 +6162,8 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
-  yjs@13.6.31:
-    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+  yjs@13.6.30:
+    resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
@@ -6322,8 +6306,6 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-plugin-utils@7.29.7': {}
-
   '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -6377,11 +6359,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -6471,25 +6448,25 @@ snapshots:
   '@codemirror/autocomplete@6.20.1':
     dependencies:
       '@codemirror/language': 6.12.2
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.11
       '@lezer/common': 1.5.1
 
   '@codemirror/collab@6.1.1':
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
 
   '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/view': 6.39.11
       '@lezer/common': 1.5.1
 
   '@codemirror/language@6.12.2':
     dependencies:
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.11
       '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
@@ -6497,8 +6474,8 @@ snapshots:
 
   '@codemirror/lint@6.9.5':
     dependencies:
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.11
       crelt: 1.0.6
 
   '@codemirror/lsp-client@6.2.3':
@@ -6506,25 +6483,29 @@ snapshots:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.2
       '@codemirror/lint': 6.9.5
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.11
       '@lezer/highlight': 1.2.3
       marked: 15.0.12
       vscode-languageserver-protocol: 3.17.5
 
   '@codemirror/search@6.6.0':
     dependencies:
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.11
       crelt: 1.0.6
+
+  '@codemirror/state@6.5.4':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
 
   '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.43.1':
+  '@codemirror/view@6.39.11':
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -7066,7 +7047,7 @@ snapshots:
       vite-plugin-inspect: 11.3.3(@nuxt/kit@3.21.2(magicast@0.3.5))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))
       vite-plugin-vue-tracer: 1.3.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
       which: 5.0.0
-      ws: 8.21.0
+      ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7276,7 +7257,7 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/test-utils@3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4)':
+  '@nuxt/test-utils@3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4)':
     dependencies:
       '@clack/prompts': 1.0.0-alpha.9
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
@@ -7304,7 +7285,7 @@ snapshots:
       tinyexec: 1.0.4
       ufo: 1.6.3
       unplugin: 2.3.11
-      vitest-environment-nuxt: 1.0.1(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4)
+      vitest-environment-nuxt: 1.0.1(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4)
       vue: 3.5.34(typescript@5.9.3)
     optionalDependencies:
       '@playwright/test': 1.58.2
@@ -7312,7 +7293,7 @@ snapshots:
       '@vue/test-utils': 2.4.6
       happy-dom: 17.6.3
       jsdom: 26.1.0
-      playwright-core: 1.61.1
+      playwright-core: 1.58.2
       vitest: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - crossws
@@ -7500,15 +7481,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@pkgr/core@0.3.6': {}
-
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
-
-  '@playwright/test@1.61.1':
-    dependencies:
-      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7835,7 +7810,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
       util: 0.12.5
-      ws: 8.21.0
+      ws: 8.19.0
     optionalDependencies:
       prettier: 3.8.3
     transitivePeerDependencies:
@@ -7960,7 +7935,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.6
+      vue-component-type-helpers: 3.2.9
 
   '@tabler/icons-vue@3.40.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -8174,7 +8149,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.46.1)(yaml@2.8.2)
-      ws: 8.21.0
+      ws: 8.19.0
     optionalDependencies:
       playwright: 1.58.2
     transitivePeerDependencies:
@@ -8479,7 +8454,7 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
+      eslint-plugin-prettier: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
       prettier: 3.8.3
     transitivePeerDependencies:
       - '@types/eslint'
@@ -8854,6 +8829,8 @@ snapshots:
 
   buffer-crc32@1.0.0: {}
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -9005,8 +8982,8 @@ snapshots:
       '@codemirror/language': 6.12.2
       '@codemirror/lint': 6.9.5
       '@codemirror/search': 6.6.0
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.11
 
   color-convert@2.0.1:
     dependencies:
@@ -9345,6 +9322,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   editorconfig@1.0.7:
     dependencies:
       '@one-ini/wasm': 0.1.1
@@ -9543,15 +9524,6 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3):
-    dependencies:
-      eslint: 9.39.4(jiti@2.6.1)
-      prettier: 3.8.3
-      prettier-linter-helpers: 1.0.1
-      synckit: 0.11.13
-    optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
-
   eslint-plugin-storybook@0.11.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@storybook/csf': 0.1.13
@@ -9571,7 +9543,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-vue@10.6.2(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1))):
+  eslint-plugin-vue@10.6.2(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       eslint: 9.39.4(jiti@2.6.1)
@@ -9579,10 +9551,10 @@ snapshots:
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
-      vue-eslint-parser: 10.4.1(eslint@9.39.4(jiti@2.6.1))
+      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.6.1))
       xml-name-validator: 4.0.0
 
-  eslint-plugin-vue@10.9.1(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1))):
+  eslint-plugin-vue@10.9.1(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       eslint: 9.39.4(jiti@2.6.1)
@@ -9590,7 +9562,7 @@ snapshots:
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
-      vue-eslint-parser: 10.4.1(eslint@9.39.4(jiti@2.6.1))
+      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.6.1))
       xml-name-validator: 4.0.0
 
   eslint-scope@5.1.1:
@@ -10345,7 +10317,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.21.0
+      ws: 8.19.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -10370,10 +10342,34 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
   jstransformer@1.0.0:
     dependencies:
       is-promise: 2.2.2
       promise: 7.3.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -10508,11 +10504,25 @@ snapshots:
 
   lodash.defaults@4.2.0: {}
 
+  lodash.includes@4.3.0: {}
+
   lodash.isarguments@3.1.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
 
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.uniq@4.5.0: {}
 
@@ -11127,17 +11137,9 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
-  playwright-core@1.61.1: {}
-
   playwright@1.58.2:
     dependencies:
       playwright-core: 1.58.2
-    optionalDependencies:
-      fsevents: 2.3.2
-
-  playwright@1.61.1:
-    dependencies:
-      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -11470,7 +11472,7 @@ snapshots:
       devtools-protocol: 0.0.1581282
       typed-query-selector: 2.12.1
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.21.0
+      ws: 8.19.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -11941,10 +11943,6 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
-
-  synckit@0.11.13:
-    dependencies:
-      '@pkgr/core': 0.3.6
 
   system-architecture@0.1.0: {}
 
@@ -12461,9 +12459,9 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.2
 
-  vitest-environment-nuxt@1.0.1(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4):
+  vitest-environment-nuxt@1.0.1(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4):
     dependencies:
-      '@nuxt/test-utils': 3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4)
+      '@nuxt/test-utils': 3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4)
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -12591,7 +12589,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.6: {}
 
-  vue-component-type-helpers@3.3.6: {}
+  vue-component-type-helpers@3.2.9: {}
 
   vue-demi@0.14.10(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -12615,7 +12613,7 @@ snapshots:
       vue: 3.5.34(typescript@5.9.3)
       vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.34(typescript@5.9.3))
 
-  vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1)):
+  vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
@@ -12746,8 +12744,6 @@ snapshots:
 
   ws@8.19.0: {}
 
-  ws@8.21.0: {}
-
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
@@ -12767,34 +12763,34 @@ snapshots:
   xtend@4.0.2:
     optional: true
 
-  y-codemirror.next@0.3.5(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)(yjs@13.6.31):
+  y-codemirror.next@0.3.5(@codemirror/state@6.5.4)(@codemirror/view@6.39.11)(yjs@13.6.30):
     dependencies:
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.11
       lib0: 0.2.117
-      yjs: 13.6.31
+      yjs: 13.6.30
 
-  y-leveldb@0.1.2(yjs@13.6.31):
+  y-leveldb@0.1.2(yjs@13.6.30):
     dependencies:
       level: 6.0.1
       lib0: 0.2.117
-      yjs: 13.6.31
+      yjs: 13.6.30
     optional: true
 
-  y-protocols@1.0.7(yjs@13.6.31):
+  y-protocols@1.0.7(yjs@13.6.30):
     dependencies:
       lib0: 0.2.117
-      yjs: 13.6.31
+      yjs: 13.6.30
 
-  y-websocket@2.1.0(yjs@13.6.31):
+  y-websocket@2.1.0(yjs@13.6.30):
     dependencies:
       lib0: 0.2.117
       lodash.debounce: 4.0.8
-      y-protocols: 1.0.7(yjs@13.6.31)
-      yjs: 13.6.31
+      y-protocols: 1.0.7(yjs@13.6.30)
+      yjs: 13.6.30
     optionalDependencies:
       ws: 6.2.3
-      y-leveldb: 0.1.2(yjs@13.6.31)
+      y-leveldb: 0.1.2(yjs@13.6.30)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12824,7 +12820,7 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
 
-  yjs@13.6.31:
+  yjs@13.6.30:
     dependencies:
       lib0: 0.2.117
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ importers:
         specifier: ^6.2.3
         version: 6.2.3
       '@codemirror/state':
-        specifier: 6.5.4
-        version: 6.5.4
+        specifier: 6.6.0
+        version: 6.6.0
       '@codemirror/view':
-        specifier: 6.39.11
-        version: 6.39.11
+        specifier: 6.43.1
+        version: 6.43.1
       '@floating-ui/vue':
         specifier: ^1.1.6
         version: 1.1.11(vue@3.5.34(typescript@5.9.3))
@@ -59,20 +59,20 @@ importers:
         specifier: ^4.5.0
         version: 4.6.4(vue@3.5.34(typescript@5.9.3))
       ws:
-        specifier: ^8.19.0
-        version: 8.19.0
+        specifier: ^8.21.0
+        version: 8.21.0
       y-codemirror.next:
         specifier: ^0.3.5
-        version: 0.3.5(@codemirror/state@6.5.4)(@codemirror/view@6.39.11)(yjs@13.6.30)
+        version: 0.3.5(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)(yjs@13.6.31)
       y-protocols:
         specifier: ^1.0.7
-        version: 1.0.7(yjs@13.6.30)
+        version: 1.0.7(yjs@13.6.31)
       y-websocket:
         specifier: ^2.1.0
-        version: 2.1.0(yjs@13.6.30)
+        version: 2.1.0(yjs@13.6.31)
       yjs:
-        specifier: ^13.6.29
-        version: 13.6.30
+        specifier: ^13.6.31
+        version: 13.6.31
     devDependencies:
       '@babel/core':
         specifier: ^7.27.4
@@ -81,8 +81,8 @@ importers:
         specifier: ^7.27.5
         version: 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.6.1))
       '@babel/plugin-syntax-import-assertions':
-        specifier: ^7.26.0
-        version: 7.28.6(@babel/core@7.29.0)
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx':
         specifier: ^7.25.9
         version: 7.28.6(@babel/core@7.29.0)
@@ -90,8 +90,8 @@ importers:
         specifier: ^9.39.2
         version: 9.39.4
       '@playwright/test':
-        specifier: ^1.53.1
-        version: 1.58.2
+        specifier: ^1.61.0
+        version: 1.61.1
       '@storybook/addon-a11y':
         specifier: ^8.6.14
         version: 8.6.18(storybook@8.6.18(prettier@3.8.3))
@@ -138,14 +138,14 @@ importers:
         specifier: ^10.1.2
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-prettier:
-        specifier: ^5.5.0
-        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
+        specifier: ^5.5.6
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
       eslint-plugin-storybook:
         specifier: ^0.11.6
         version: 0.11.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.1(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
+        version: 10.9.1(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1)))
       globals:
         specifier: ^16.0.0
         version: 16.5.0
@@ -183,8 +183,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.46.1)(yaml@2.8.2)
       vue-eslint-parser:
-        specifier: ^10.1.3
-        version: 10.4.0(eslint@9.39.4(jiti@2.6.1))
+        specifier: ^10.4.1
+        version: 10.4.1(eslint@9.39.4(jiti@2.6.1))
 
   multi-player:
     dependencies:
@@ -196,7 +196,7 @@ importers:
         version: 8.19.0
       y-websocket:
         specifier: ^2.0.4
-        version: 2.1.0(yjs@13.6.30)
+        version: 2.1.0(yjs@13.6.31)
     devDependencies:
       vitest:
         specifier: ^2.1.8
@@ -212,7 +212,7 @@ importers:
         version: 0.11.13(@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3)))(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
       '@nuxt/test-utils':
         specifier: ^3.19.1
-        version: 3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4)
+        version: 3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4)
       '@tabler/icons-vue':
         specifier: ^3.34.0
         version: 3.40.0(vue@3.5.30(typescript@5.9.3))
@@ -270,7 +270,7 @@ importers:
         version: 9.1.20(eslint@9.39.4(jiti@2.6.1))(storybook@8.6.18(prettier@3.8.3))(typescript@5.9.3)
       eslint-plugin-vue:
         specifier: ^10.2.0
-        version: 10.6.2(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
+        version: 10.6.2(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1)))
       globals:
         specifier: ^16.2.0
         version: 16.5.0
@@ -368,6 +368,10 @@ packages:
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-replace-supers@7.28.6':
     resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
@@ -418,6 +422,12 @@ packages:
 
   '@babel/plugin-syntax-import-assertions@7.28.6':
     resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-assertions@7.29.7':
+    resolution: {integrity: sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -523,14 +533,11 @@ packages:
   '@codemirror/search@6.6.0':
     resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
 
-  '@codemirror/state@6.5.4':
-    resolution: {integrity: sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==}
-
   '@codemirror/state@6.6.0':
     resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
 
-  '@codemirror/view@6.39.11':
-    resolution: {integrity: sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==}
+  '@codemirror/view@6.43.1':
+    resolution: {integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1488,8 +1495,17 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@pkgr/core@0.3.6':
+    resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3249,6 +3265,20 @@ packages:
       eslint-config-prettier:
         optional: true
 
+  eslint-plugin-prettier@5.5.6:
+    resolution: {integrity: sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+
   eslint-plugin-storybook@0.11.6:
     resolution: {integrity: sha512-3WodYD6Bs9ACqnB+TP2TuLh774c/nacAjxSKOP9bHJ2c8rf+nrhocxjjeAWNmO9IPkFIzTKlcl0vNXI2yYpVOw==}
     engines: {node: '>= 18'}
@@ -4606,8 +4636,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5303,6 +5343,10 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  synckit@0.11.13:
+    resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
@@ -5931,8 +5975,8 @@ packages:
   vue-component-type-helpers@3.2.6:
     resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
-  vue-component-type-helpers@3.2.9:
-    resolution: {integrity: sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==}
+  vue-component-type-helpers@3.3.6:
+    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -5953,8 +5997,8 @@ packages:
     peerDependencies:
       vue: '>=2'
 
-  vue-eslint-parser@10.4.0:
-    resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
+  vue-eslint-parser@10.4.1:
+    resolution: {integrity: sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -6086,6 +6130,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -6162,8 +6218,8 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
-  yjs@13.6.30:
-    resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
@@ -6306,6 +6362,8 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -6359,6 +6417,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -6448,25 +6511,25 @@ snapshots:
   '@codemirror/autocomplete@6.20.1':
     dependencies:
       '@codemirror/language': 6.12.2
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.11
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.1
 
   '@codemirror/collab@6.1.1':
     dependencies:
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
 
   '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.39.11
+      '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.1
 
   '@codemirror/language@6.12.2':
     dependencies:
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.11
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
@@ -6474,8 +6537,8 @@ snapshots:
 
   '@codemirror/lint@6.9.5':
     dependencies:
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.11
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
       crelt: 1.0.6
 
   '@codemirror/lsp-client@6.2.3':
@@ -6483,29 +6546,25 @@ snapshots:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.2
       '@codemirror/lint': 6.9.5
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.11
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
       '@lezer/highlight': 1.2.3
       marked: 15.0.12
       vscode-languageserver-protocol: 3.17.5
 
   '@codemirror/search@6.6.0':
     dependencies:
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.11
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
       crelt: 1.0.6
-
-  '@codemirror/state@6.5.4':
-    dependencies:
-      '@marijn/find-cluster-break': 1.0.2
 
   '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.39.11':
+  '@codemirror/view@6.43.1':
     dependencies:
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -7047,7 +7106,7 @@ snapshots:
       vite-plugin-inspect: 11.3.3(@nuxt/kit@3.21.2(magicast@0.3.5))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))
       vite-plugin-vue-tracer: 1.3.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
       which: 5.0.0
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7257,7 +7316,7 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/test-utils@3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4)':
+  '@nuxt/test-utils@3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4)':
     dependencies:
       '@clack/prompts': 1.0.0-alpha.9
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
@@ -7285,7 +7344,7 @@ snapshots:
       tinyexec: 1.0.4
       ufo: 1.6.3
       unplugin: 2.3.11
-      vitest-environment-nuxt: 1.0.1(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4)
+      vitest-environment-nuxt: 1.0.1(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4)
       vue: 3.5.34(typescript@5.9.3)
     optionalDependencies:
       '@playwright/test': 1.58.2
@@ -7293,7 +7352,7 @@ snapshots:
       '@vue/test-utils': 2.4.6
       happy-dom: 17.6.3
       jsdom: 26.1.0
-      playwright-core: 1.58.2
+      playwright-core: 1.61.1
       vitest: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - crossws
@@ -7481,9 +7540,15 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@pkgr/core@0.3.6': {}
+
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7810,7 +7875,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
       util: 0.12.5
-      ws: 8.19.0
+      ws: 8.21.0
     optionalDependencies:
       prettier: 3.8.3
     transitivePeerDependencies:
@@ -7935,7 +8000,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.9.3)
-      vue-component-type-helpers: 3.2.9
+      vue-component-type-helpers: 3.3.6
 
   '@tabler/icons-vue@3.40.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -8149,7 +8214,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.46.1)(yaml@2.8.2)
-      ws: 8.19.0
+      ws: 8.21.0
     optionalDependencies:
       playwright: 1.58.2
     transitivePeerDependencies:
@@ -8454,7 +8519,7 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-prettier: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
+      eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
       prettier: 3.8.3
     transitivePeerDependencies:
       - '@types/eslint'
@@ -8982,8 +9047,8 @@ snapshots:
       '@codemirror/language': 6.12.2
       '@codemirror/lint': 6.9.5
       '@codemirror/search': 6.6.0
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.11
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
 
   color-convert@2.0.1:
     dependencies:
@@ -9524,6 +9589,15 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
 
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      prettier: 3.8.3
+      prettier-linter-helpers: 1.0.1
+      synckit: 0.11.13
+    optionalDependencies:
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
+
   eslint-plugin-storybook@0.11.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@storybook/csf': 0.1.13
@@ -9543,7 +9617,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-vue@10.6.2(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1))):
+  eslint-plugin-vue@10.6.2(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       eslint: 9.39.4(jiti@2.6.1)
@@ -9551,10 +9625,10 @@ snapshots:
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
-      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.6.1))
+      vue-eslint-parser: 10.4.1(eslint@9.39.4(jiti@2.6.1))
       xml-name-validator: 4.0.0
 
-  eslint-plugin-vue@10.9.1(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1))):
+  eslint-plugin-vue@10.9.1(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       eslint: 9.39.4(jiti@2.6.1)
@@ -9562,7 +9636,7 @@ snapshots:
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
-      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.6.1))
+      vue-eslint-parser: 10.4.1(eslint@9.39.4(jiti@2.6.1))
       xml-name-validator: 4.0.0
 
   eslint-scope@5.1.1:
@@ -10317,7 +10391,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.19.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -11137,9 +11211,17 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
+  playwright-core@1.61.1: {}
+
   playwright@1.58.2:
     dependencies:
       playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -11472,7 +11554,7 @@ snapshots:
       devtools-protocol: 0.0.1581282
       typed-query-selector: 2.12.1
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -11943,6 +12025,10 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  synckit@0.11.13:
+    dependencies:
+      '@pkgr/core': 0.3.6
 
   system-architecture@0.1.0: {}
 
@@ -12459,9 +12545,9 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.2
 
-  vitest-environment-nuxt@1.0.1(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4):
+  vitest-environment-nuxt@1.0.1(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4):
     dependencies:
-      '@nuxt/test-utils': 3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.58.2)(typescript@5.9.3)(vitest@3.2.4)
+      '@nuxt/test-utils': 3.23.0(@playwright/test@1.58.2)(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(jsdom@26.1.0)(magicast@0.5.2)(playwright-core@1.61.1)(typescript@5.9.3)(vitest@3.2.4)
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -12589,7 +12675,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.6: {}
 
-  vue-component-type-helpers@3.2.9: {}
+  vue-component-type-helpers@3.3.6: {}
 
   vue-demi@0.14.10(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -12613,7 +12699,7 @@ snapshots:
       vue: 3.5.34(typescript@5.9.3)
       vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.34(typescript@5.9.3))
 
-  vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)):
+  vue-eslint-parser@10.4.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
@@ -12744,6 +12830,8 @@ snapshots:
 
   ws@8.19.0: {}
 
+  ws@8.21.0: {}
+
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
@@ -12763,34 +12851,34 @@ snapshots:
   xtend@4.0.2:
     optional: true
 
-  y-codemirror.next@0.3.5(@codemirror/state@6.5.4)(@codemirror/view@6.39.11)(yjs@13.6.30):
+  y-codemirror.next@0.3.5(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)(yjs@13.6.31):
     dependencies:
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.11
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
       lib0: 0.2.117
-      yjs: 13.6.30
+      yjs: 13.6.31
 
-  y-leveldb@0.1.2(yjs@13.6.30):
+  y-leveldb@0.1.2(yjs@13.6.31):
     dependencies:
       level: 6.0.1
       lib0: 0.2.117
-      yjs: 13.6.30
+      yjs: 13.6.31
     optional: true
 
-  y-protocols@1.0.7(yjs@13.6.30):
+  y-protocols@1.0.7(yjs@13.6.31):
     dependencies:
       lib0: 0.2.117
-      yjs: 13.6.30
+      yjs: 13.6.31
 
-  y-websocket@2.1.0(yjs@13.6.30):
+  y-websocket@2.1.0(yjs@13.6.31):
     dependencies:
       lib0: 0.2.117
       lodash.debounce: 4.0.8
-      y-protocols: 1.0.7(yjs@13.6.30)
-      yjs: 13.6.30
+      y-protocols: 1.0.7(yjs@13.6.31)
+      yjs: 13.6.31
     optionalDependencies:
       ws: 6.2.3
-      y-leveldb: 0.1.2(yjs@13.6.30)
+      y-leveldb: 0.1.2(yjs@13.6.31)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12820,7 +12908,7 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
 
-  yjs@13.6.30:
+  yjs@13.6.31:
     dependencies:
       lib0: 0.2.117
 

--- a/scripts/smoke-test-preview.py
+++ b/scripts/smoke-test-preview.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""End-to-end smoke test for preview deployments.
+
+Verifies the multi-player WebSocket auth handshake works against a deployed
+backend. Catches deploy-config drift like:
+
+  - INTERNAL_SHARED_SECRET not forwarded to the multi-player process
+    (every WS connection 4401s; editor goes offline).
+  - port 1234 missing a TLS handler in fly.toml (wss:// handshake fails
+    before auth even runs).
+  - /collab/start route returning a token the multi-player can't verify
+    (secret mismatch between backend and multi-player processes).
+
+Usage:
+    python smoke-test-preview.py <backend-url>
+
+    e.g.  python smoke-test-preview.py https://aris-backend-pr-405.fly.dev
+
+Exits 0 if the round-trip works, non-zero with a diagnostic message
+otherwise. Designed to run as the final CI step after a preview deploy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import sys
+from urllib.parse import urlparse
+
+import httpx
+import websockets
+
+
+async def run(backend_url: str, env: str = "prod") -> int:
+    parsed = urlparse(backend_url)
+    if parsed.scheme != "https":
+        print(f"FAIL: backend_url must be https://, got {backend_url!r}")
+        return 2
+    ws_url_base = f"wss://{parsed.netloc}:1234"
+
+    suffix = secrets.token_hex(4)
+    email = f"smoke-{suffix}@aris.pub"
+    password = f"pw{secrets.token_hex(12)}"
+
+    async with httpx.AsyncClient(base_url=backend_url, timeout=30.0) as client:
+        print(f"[register] {email}")
+        r = await client.post(
+            "/register",
+            json={
+                "email": email,
+                "name": "Smoke",
+                "initials": "SM",
+                "password": password,
+            },
+        )
+        if r.status_code != 200:
+            print(f"FAIL: /register returned {r.status_code}: {r.text[:200]}")
+            return 1
+        access_token = r.json()["access_token"]
+
+        print("[create file]")
+        r = await client.post(
+            "/files",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={
+                "title": "smoke",
+                "abstract": "",
+                "source": ":manuscript:\n\n  smoke\n\n::",
+            },
+        )
+        if r.status_code != 200:
+            print(f"FAIL: POST /files returned {r.status_code}: {r.text[:200]}")
+            return 1
+        file_id = r.json()["id"]
+
+        print("[collab/start]")
+        r = await client.post(
+            f"/files/{file_id}/collab/start",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        if r.status_code != 200:
+            print(f"FAIL: /collab/start returned {r.status_code}: {r.text[:200]}")
+            return 1
+        body = r.json()
+        token = body.get("token")
+        if not isinstance(token, str) or not token:
+            print(f"FAIL: /collab/start did not return a token: {body!r}")
+            return 1
+
+    room = f"file-{file_id}-{env}"
+    ws_url = f"{ws_url_base}/{room}"
+    print(f"[ws connect] {ws_url}")
+    try:
+        async with websockets.connect(
+            ws_url, open_timeout=10, close_timeout=5
+        ) as ws:
+            await ws.send(json.dumps({"type": "auth", "token": token}))
+            raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
+            try:
+                payload = json.loads(
+                    raw if isinstance(raw, str) else raw.decode("utf-8")
+                )
+            except json.JSONDecodeError:
+                print(f"FAIL: first WS frame was not JSON: {raw[:120]!r}")
+                return 1
+            if payload.get("type") != "auth_ok":
+                print(f"FAIL: expected auth_ok, got {payload!r}")
+                return 1
+            print("PASS: auth handshake completed")
+            return 0
+    except websockets.exceptions.ConnectionClosed as e:
+        print(f"FAIL: WS closed code={e.code} reason={e.reason!r}")
+        return 1
+    except Exception as e:  # noqa: BLE001
+        print(f"FAIL: {type(e).__name__}: {e}")
+        return 1
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: smoke-test-preview.py <backend-url>")
+        return 2
+    return asyncio.run(run(sys.argv[1]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds short-lived JWT authentication for the Y.js multi-player WebSocket server, then fixes the deploy-config gaps that auth surfaced once it ran on a real Fly deploy.

### 1. Multi-player WebSocket auth
- Previously anyone reaching the public Fly TCP port (1234) could enumerate rooms like `file-{id}-prod` and inject Y.js updates the backend persisted.
- Backend mints a 5-minute JWT on `POST /files/{id}/collab/start` (gate widened `require_edit` → `require_view`). Client presents it as the first WS frame; multi-player verifies signature + exp + that `file_id` matches the docName before yielding to Y.js sync. Wrong/missing/expired tokens close with code 4401.
- Wired through backend `YDocClient`, the CLI `studio edit` command, and frontend `EditorCodeMirror.vue` via an `AuthedWebSocket` wrapper that holds y-websocket's `onopen` until `auth_ok` and queues sync sends meanwhile.

### 2. Deploy-config fixes
- **`docker/supervisord.conf`**: the prod multi-player process now receives `INTERNAL_SHARED_SECRET` + `BACKEND_INTERNAL_URL`. supervisord's `environment=` replaces the inherited env wholesale; without these every WS auth 4401'd on prod-style deploys.
- **`backend/fly.toml`**: port 1234 now has `handlers = ["tls", "http"]` so Fly's edge terminates TLS for the `wss://` multi-player URL.
- **`backend/Dockerfile`**: installs `rsm-lang` editable from the cloned `aris-pub/rsm` checkout (absolute `/rsm` path) instead of PyPI — staging + prod now source all three rsm pieces from GH main, identical to dev/CI.
- **`frontend/netlify.toml` + `site/netlify.toml`**: Netlify's automatic `deploy-preview-N--` URL was built without the per-PR backend URL, so it pointed at the **production** backend. The `[context.deploy-preview]` build now publishes an inert static notice instead of the app — closing a "preview frontend talks to prod" hazard. The repo's real per-PR previews remain the `pr-N--` aliases from `preview.yml`.

### 3. Tests + docs
- `backend/tests/test_docker_config.py`: regression asserts for the supervisord secret + fly.toml TLS handler.
- `scripts/smoke-test-preview.py` + a `preview.yml` step: end-to-end WS-auth smoke test that fails the deploy if the editor would be Offline.
- `docs/environments.md`: documents the four environments (dev / test / staging / prod) and how each sources rsm. Linked from the README.

Closes std-kab28c.

## Test plan
- [x] `multi-player/server.auth.test.js`, `backend/tests/test_collaboration/test_auth.py` — auth handshake + every failure mode.
- [x] `test_routes_collab.py`, `test_yjs_client_role.py`, `test_yjs_client_crdt.py` updated for the handshake.
- [x] `test_docker_config.py` — supervisord + fly.toml regression asserts.
- [x] Preview smoke test verifies the WS handshake end-to-end on every deploy.
- [x] Verified on the live `pr-405` preview: editor Online, `auth_ok` completes, `rsm-lang` served from the clone (`/rsm/rsm/__init__.py`).
- [x] Verified `deploy-preview-405--` now serves the inert notice, not a prod-pointing app.
- [ ] Human review against the `pr-405--rsm-studio-frontend.netlify.app` preview — see the "Needs human review" comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)