### PR TITLE
fix(test): update test_render OUTPUT for rsm-lang 1.5.0 handrail id emission

### DIFF
--- a/backend/tests/test_routes/test_routes_render.py
+++ b/backend/tests/test_routes/test_routes_render.py
@@ -16,7 +16,7 @@ OUTPUT = """
 
 <section class="level-1">
 
-<div class="paragraph hr hr-hidden" tabindex=0 data-nodeid="1">
+<div id="n1" class="paragraph hr hr-hidden" tabindex=0 data-nodeid="1">
 
 <div class="hr-collapse-zone">
 <div class="hr-spacer"></div>


### PR DESCRIPTION
## Summary

- rsm-lang 1.5.0 (via rsm commit c814a97 "feat: reversible in-document jumps via native browser Back (hash nav)") started emitting a synthetic `id="n{nodeid}"` on every handrail block, making them hash-addressable
- The `test_render` OUTPUT constant expected the pre-1.5.0 shape without the id
- One-line fix: add `id="n1"` on the paragraph handrail div to match the current renderer

## Context

Diagnosed while investigating PR #414 CI failure. The `test_render` failure on #414 is orthogonal to the CI-actions bumps in that PR; it is caused by rsm-lang 1.5.0 (released 2026-06-29). Landing this fix on main unblocks #414.

## Test plan

- [x] `pytest backend/tests/test_routes/test_routes_render.py::test_render` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZfTQx3v4o3aK8V8fi86ot