### PR TITLE
test(e2e): wait for viewer render in auto-compile initial-content check

### DIFF
--- a/frontend/src/tests/e2e/content/auto-compile-codemirror.spec.js
+++ b/frontend/src/tests/e2e/content/auto-compile-codemirror.spec.js
@@ -123,10 +123,12 @@ test.describe("CodeMirror Auto-Compilation @auth", () => {
     });
     await page.waitForSelector('[data-testid="manuscript-container"]', { timeout: 5000 });
 
-    // Verify initial content
-    const initialContent = await page.textContent('[data-testid="manuscript-viewer"]');
-    expect(initialContent).toContain("Hello");
-    expect(initialContent).not.toContain("World");
+    // Verify initial content. The container mounts before the viewer's compiled
+    // HTML is painted, so assert against the viewer with auto-retry rather than
+    // reading textContent once (which races the render and intermittently sees empty).
+    const viewer = page.locator('[data-testid="manuscript-viewer"]');
+    await expect(viewer).toContainText("Hello");
+    await expect(viewer).not.toContainText("World");
 
     // Open CodeMirror editor
     await page.click('[data-testid="workspace-sidebar"] .sb-item:has-text("source") button');


### PR DESCRIPTION
## Summary

Cherry-pick of commit \`451f3ab5\` (Leo Torres, 2026-05-31) from branch \`std-kab28c\` (PR #405), extracted as a standalone fix so it can land on main without waiting for #405's larger multi-player-auth changes to be ready.

## The bug

\`e2e-frontend (firefox, auth-content)\` has been failing on every main-push CI run since 2026-05-12 (~7 weeks). Root cause is a read-too-early race in one test:

\`\`\`js
await page.waitForSelector('[data-testid="manuscript-container"]', { timeout: 5000 });
const initialContent = await page.textContent('[data-testid="manuscript-viewer"]');
expect(initialContent).toContain("Hello");   // fails: initialContent === ""
\`\`\`

The container mounts before the compiled HTML is painted into the viewer child. \`page.textContent()\` reads once with no retry, races the paint, and returns empty. Firefox is deterministically slower on this paint than Chromium in CI, so Firefox fails every run.

## The fix

Switch to Playwright's auto-retrying \`locator().toContainText()\`:

\`\`\`js
const viewer = page.locator('[data-testid="manuscript-viewer"]');
await expect(viewer).toContainText("Hello");
await expect(viewer).not.toContainText("World");
\`\`\`

## Test plan

- [x] Cherry-pick applies cleanly from origin/main
- [ ] CI green (specifically firefox auth-content, which should now pass)

## Note

PR #405 (\`std-kab28c\`) still needs its own review for the multi-player WebSocket auth feature. This PR extracts only the test fix so main can go green independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZfTQx3v4o3aK8V8fi86ot