### PR TITLE
fix(deploy): rsm-lsp build installs devDeps; TEST_USER_* not required at boot

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,9 +23,13 @@ RUN cd rsm/tree-sitter-rsm && rm -rf prebuilds build \
     && if [ ! -f binding.gyp ]; then npx -y tree-sitter-cli generate; fi \
     && npx node-gyp rebuild
 
-# Install rsm-lsp production deps (creates symlink for file: dep)
+# Install rsm-lsp deps INCLUDING devDependencies: the build script is `tsc`
+# and typescript is a devDependency, so an --omit=dev install leaves tsc absent
+# and `npm run build` fails with "tsc: not found". Installing in-container
+# (rather than relying on a host node_modules copied in via the source COPY
+# below) keeps native bindings correct for linux.
 COPY rsm/packages/rsm-lsp/package*.json ./rsm/packages/rsm-lsp/
-RUN cd rsm/packages/rsm-lsp && npm ci --omit=dev
+RUN cd rsm/packages/rsm-lsp && npm ci
 
 # Copy source files for multiplayer and rsm-lsp
 COPY studio/multi-player/ ./multi-player/

--- a/backend/aris/config.py
+++ b/backend/aris/config.py
@@ -65,11 +65,13 @@ class Settings(BaseSettings):
     )
     """Expiration time in minutes for JWT refresh tokens (default: 129600 = 90 days)."""
 
-    TEST_USER_EMAIL: str = Field(..., json_schema_extra={"env": "TEST_USER_EMAIL"})
-    """Test user email for visual tests."""
+    TEST_USER_EMAIL: str = Field("", json_schema_extra={"env": "TEST_USER_EMAIL"})
+    """Test user email for visual/e2e tests. Optional: only read on deploy-preview
+    origins (see routes/auth.py), never on prod, so it must not be a required field
+    that would crash prod boot when unset."""
 
-    TEST_USER_PASSWORD: str = Field(..., json_schema_extra={"env": "TEST_USER_PASSWORD"})
-    """Password for test user."""
+    TEST_USER_PASSWORD: str = Field("", json_schema_extra={"env": "TEST_USER_PASSWORD"})
+    """Password for test user. Optional for the same reason as TEST_USER_EMAIL."""
 
     TEST_USER2_EMAIL: str = Field("testuser2@aris.pub", json_schema_extra={"env": "TEST_USER2_EMAIL"})
     """Second test user email for multi-user tests."""


### PR DESCRIPTION
Two latent bugs exposed by a from-scratch prod backend deploy on 2026-07-02.

## 1. `tsc: not found` in the rsm-lsp build

`backend/Dockerfile` installed rsm-lsp deps with `npm ci --omit=dev`. But rsm-lsp's `build` script is `tsc`, and `typescript` is a **devDependency**, so `npm run build` failed with `tsc: not found` (exit 127) on any build that does not happen to carry a host `node_modules` into the context.

The prior working path relied on the host's `rsm-lsp/node_modules` being copied in via the source `COPY`, which also risks shipping darwin-arch native bindings into the linux image (the Dockerfile already has a hack at lines 34-37 to patch exactly that for `tree-sitter-rsm`).

Fix: `npm ci` (including devDeps) so the build is self-contained and arch-correct.

## 2. Prod crash-loop on `TEST_USER_*`

`backend/aris/config.py` declared `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` as required `Field(...)` with no default. They are read **only** on deploy-preview origins (`routes/auth.py`, gated by `_DEPLOY_PREVIEW_RE`), never on prod. Being required, they crashed prod boot with a pydantic `ValidationError` when unset.

Prod is currently only booting because inert dummy values were set as Fly secrets as a stopgap. Fix: default both to `""`. Preview envs still set real values.

## Follow-up once merged

Unset the stopgap `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` Fly secrets on `aris-backend`.

Surfaced while shipping the multi-player WS auth fix (#405) to prod for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZfTQx3v4o3aK8V8fi86ot