### PR TITLE
fix(workspace): make cmd+click source navigation reliable (std-9hfk)

### DIFF
--- a/frontend/src/composables/useSourcePreviewNav.js
+++ b/frontend/src/composables/useSourcePreviewNav.js
@@ -10,7 +10,41 @@
 
 import { toRaw } from "vue";
 
+import { toast } from "@/utils/toast.js";
+
 const HIGHLIGHT_DURATION = 2000;
+const RETRY_MAX_ATTEMPTS = 14; // ~2s total with RETRY_DELAY_MS
+const RETRY_DELAY_MS = 150;
+
+/**
+ * Call `requestFn` and, if it resolves falsy, retry with a fixed delay up to
+ * `maxAttempts` times, returning the first truthy result (or null if exhausted).
+ *
+ * rsm/nodePosition and rsm/nodeAtPosition both resolve against the LSP server's
+ * nodeid<->source index, which is (re)built asynchronously on document open and
+ * after each recompile. During that window the request returns null even though
+ * the client is connected — first call null, a later call resolves. With no
+ * per-document "index ready" signal from the server, this bounded retry keeps
+ * source<->preview navigation from silently no-op'ing on a cold or racy server.
+ * This is the fallback layer; the deterministic fix is an rsm/indexReady
+ * notification the client can await (tracked in std-* follow-up). A resolving
+ * request returns on the first attempt (no delay); only unresolved ones retry.
+ *
+ * Exported (not a closure) so the retry contract is unit-testable with fake timers.
+ */
+export async function lspRequestWithRetry(
+  requestFn,
+  { maxAttempts = RETRY_MAX_ATTEMPTS, delayMs = RETRY_DELAY_MS } = {}
+) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    const result = await requestFn();
+    if (result) return result;
+  }
+  return null;
+}
 
 /**
  * @param {Object} options
@@ -20,6 +54,10 @@ const HIGHLIGHT_DURATION = 2000;
  * @param {import('vue').Ref} options.manuscriptRef - ManuscriptWrapper template ref
  */
 export function useSourcePreviewNav({ lspClient, documentUri, cmView, manuscriptRef }) {
+  // Monotonic token so that when several nav requests are in flight during a cold
+  // index window, only the most recent one applies its scroll/highlight (the last
+  // to *resolve* is otherwise not the last one *clicked*).
+  let navToken = 0;
 
   async function lspRequest(method, params) {
     const client = toRaw(lspClient?.value);
@@ -31,6 +69,14 @@ export function useSourcePreviewNav({ lspClient, documentUri, cmView, manuscript
     }
   }
 
+  // Wrap lspRequest with the bounded retry, but fast-path out when there is no LSP
+  // client at all: retrying can't summon one, so an LSP-less environment must not
+  // pay the full ~2s budget on every interaction.
+  async function requestWithRetry(method, params) {
+    if (!toRaw(lspClient?.value)) return null;
+    return lspRequestWithRetry(() => lspRequest(method, params));
+  }
+
   /**
    * Click-to-source: given a nodeid from the preview, scroll the editor
    * to the corresponding source line.
@@ -39,11 +85,23 @@ export function useSourcePreviewNav({ lspClient, documentUri, cmView, manuscript
     const uri = documentUri?.value;
     if (!uri) return;
 
-    const pos = await lspRequest("rsm/nodePosition", {
+    const token = ++navToken;
+    const pos = await requestWithRetry("rsm/nodePosition", {
       textDocument: { uri },
       nodeid,
     });
-    if (!pos) return;
+    // A newer click superseded this one while we were retrying — drop it so the
+    // last-clicked element wins the scroll.
+    if (token !== navToken) return;
+    if (!pos) {
+      // The element had a nodeid but the LSP never resolved it within the retry
+      // budget. Break the silence (silent no-op was the original bug) — but only
+      // when an LSP client exists; with no LSP, staying quiet is correct.
+      if (toRaw(lspClient?.value)) {
+        toast.info("Couldn't jump to the source for this element.");
+      }
+      return;
+    }
 
     const view = toRaw(cmView?.value);
     if (!view) return;
@@ -95,7 +153,7 @@ export function useSourcePreviewNav({ lspClient, documentUri, cmView, manuscript
     const cursor = view.state.selection.main.head;
     const line = view.state.doc.lineAt(cursor);
 
-    const result = await lspRequest("rsm/nodeAtPosition", {
+    const result = await requestWithRetry("rsm/nodeAtPosition", {
       textDocument: { uri },
       line: line.number - 1,
       character: cursor - line.from,

--- a/frontend/src/tests/composables/useSourcePreviewNav.test.js
+++ b/frontend/src/tests/composables/useSourcePreviewNav.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { lspRequestWithRetry } from "@/composables/useSourcePreviewNav.js";
+
+/**
+ * Unit contract for the bounded retry that fixes std-9hfk: rsm/nodePosition
+ * returns null while the LSP is (re)building its nodeid index, and the source<->
+ * preview navigation must retry instead of silently giving up on the first null.
+ * These are deterministic (fake timers) so they don't depend on real LSP timing.
+ */
+describe("lspRequestWithRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Drive a retry call to completion while advancing the fake delay timers.
+  async function runToCompletion(promise) {
+    await vi.runAllTimersAsync();
+    return promise;
+  }
+
+  it("returns the first truthy result without any delay", async () => {
+    const requestFn = vi.fn().mockResolvedValue({ startLine: 4 });
+    const result = await runToCompletion(
+      lspRequestWithRetry(requestFn, { maxAttempts: 14, delayMs: 150 })
+    );
+    expect(result).toEqual({ startLine: 4 });
+    expect(requestFn).toHaveBeenCalledTimes(1); // resolved on attempt 1, no retry
+  });
+
+  it("retries on null and returns once a later attempt resolves", async () => {
+    const requestFn = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ nodeid: 3 });
+    const result = await runToCompletion(
+      lspRequestWithRetry(requestFn, { maxAttempts: 14, delayMs: 150 })
+    );
+    expect(result).toEqual({ nodeid: 3 });
+    expect(requestFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up after maxAttempts and returns null", async () => {
+    const requestFn = vi.fn().mockResolvedValue(null);
+    const result = await runToCompletion(
+      lspRequestWithRetry(requestFn, { maxAttempts: 5, delayMs: 150 })
+    );
+    expect(result).toBeNull();
+    expect(requestFn).toHaveBeenCalledTimes(5); // exactly maxAttempts, no more
+  });
+
+  it("treats any falsy result as a retry signal", async () => {
+    const requestFn = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce({ ok: true });
+    const result = await runToCompletion(
+      lspRequestWithRetry(requestFn, { maxAttempts: 14, delayMs: 150 })
+    );
+    expect(result).toEqual({ ok: true });
+    expect(requestFn).toHaveBeenCalledTimes(4);
+  });
+});

--- a/frontend/src/tests/e2e/content/source-preview-nav.spec.js
+++ b/frontend/src/tests/e2e/content/source-preview-nav.spec.js
@@ -1,0 +1,129 @@
+/**
+ * E2E regression for std-9hfk: Cmd+click on rendered output → source highlight.
+ *
+ * Bug: cmd+click worked intermittently and appeared to "work once then silently
+ * fail". Root cause: rsm/nodePosition returns null while the LSP is still building
+ * its nodeid->source index (on cold open and after each recompile), and
+ * navigateToSource bailed silently on the first null. Whichever click landed
+ * during an index (re)build did nothing, with no highlight and no error. The fix
+ * retries nodePosition briefly so cmd+click is reliable.
+ *
+ * This test drives several consecutive cmd+clicks — including the FIRST one, which
+ * is the most likely to hit a cold index — and asserts each highlights the source.
+ *
+ * Requires the LSP server (DEV backend with supervisord); skips otherwise.
+ *
+ * Tag: @auth
+ */
+
+import { test, expect } from "../fixtures.js";
+import {
+  loginUser,
+  createTestFile,
+  deleteTestFile,
+  createAuthenticatedContext,
+  openFileInEditor,
+  cleanupYjs,
+} from "../yjs-helpers.js";
+import { getTimeouts } from "../utils/timeout-constants.js";
+
+test.describe("Source-preview cmd+click navigation @auth", () => {
+  const rsm =
+    "# Cmd Click Nav\n\nFirst paragraph of content.\n\nSecond distinct paragraph.\n\n:theorem:\nA theorem body here.\n:/theorem:";
+
+  let auth;
+  let fileId;
+  let lspAvailable = false;
+
+  test.beforeAll(async ({ request }) => {
+    auth = await loginUser(request);
+    fileId = await createTestFile(request, auth.token, auth.userData.id, rsm);
+
+    const devBackendPort = process.env.BACKEND_PORT || "8000";
+    try {
+      const response = await fetch(`http://localhost:${devBackendPort}/health`);
+      const health = await response.json();
+      lspAvailable = health.checks?.services?.status === "healthy";
+    } catch {
+      lspAvailable = false;
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (fileId) await deleteTestFile(request, auth.token, fileId);
+  });
+
+  test("cmd+click highlights source on every click, including the first @auth", async ({
+    browser,
+  }) => {
+    // In CI the dev backend must have a healthy LSP (supervisord). A missing LSP
+    // there is a real failure, not a reason to report green with zero coverage —
+    // so fail loudly in CI and only skip locally.
+    if (!lspAvailable && process.env.CI) {
+      throw new Error("LSP unavailable in CI: expected supervisord LSP services healthy");
+    }
+    test.skip(!lspAvailable, "LSP not available (requires DEV backend with supervisord)");
+
+    const timeouts = getTimeouts();
+    const { context, page } = await createAuthenticatedContext(browser, auth);
+
+    try {
+      await openFileInEditor(page, fileId);
+      await page.waitForFunction(
+        () => typeof window.__cmView !== "undefined",
+        {},
+        { timeout: 10000 }
+      );
+      // Manuscript rendered with multiple addressable nodes.
+      await page.waitForFunction(
+        () => document.querySelectorAll("[data-nodeid]").length > 1,
+        {},
+        { timeout: 15000 }
+      );
+
+      // Select rendered CONTENT nodes (not positional index, which can land on a
+      // structural node with no source mapping). data-nodeid only exists in the
+      // rendered manuscript (never the source editor, which holds the same text),
+      // and .last() picks the deepest match — the paragraph itself, not an
+      // ancestor section. These paragraphs definitely map to source lines.
+      const first = page
+        .locator("[data-nodeid]", { hasText: "First paragraph of content." })
+        .last();
+      const second = page
+        .locator("[data-nodeid]", { hasText: "Second distinct paragraph." })
+        .last();
+
+      // cmd+click a rendered element and assert the source highlight appears. The
+      // retry window is ~2s, so allow generous time for the (cold) first click.
+      async function cmdClickHighlights(locator, label) {
+        await page.evaluate(() =>
+          document
+            .querySelectorAll(".cm-synctarget-line")
+            .forEach((el) => el.classList.remove("cm-synctarget-line"))
+        );
+        await locator.click({ modifiers: ["Meta"] });
+        // The retry budget is ~2s; use the CI-scaled heavy-operation ceiling so a
+        // slow-but-succeeding cold index on a loaded runner isn't misread as failure.
+        await page.waitForFunction(
+          () => document.querySelectorAll(".cm-synctarget-line").length > 0,
+          {},
+          { timeout: timeouts.heavyOperation }
+        );
+        const count = await page.evaluate(
+          () => document.querySelectorAll(".cm-synctarget-line").length
+        );
+        expect(count, `source should highlight on ${label}`).toBeGreaterThan(0);
+      }
+
+      // First click — the one that used to silently no-op on a cold LSP index.
+      await cmdClickHighlights(first, "first click (cold index)");
+      // A different content node.
+      await cmdClickHighlights(second, "second click, different node");
+      // The same node again — must still work (the reported "same element" case).
+      await cmdClickHighlights(first, "third click, repeat node");
+    } finally {
+      await cleanupYjs(page);
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## The bug

Cmd/Ctrl+click on a rendered manuscript element should highlight the corresponding source line in the editor. It worked intermittently and read as **"works once, then silently fails until reload."**

## Root cause (instrumented live-app repro)

Clicking the *same* element 3× in a row: click 1 → `rsm/nodePosition` returns **null** → silent bail, no highlight; clicks 2 & 3 → valid → highlight. So it's not order-dependent — the LSP custom request **returns null while the server is (re)building its nodeid→source index**, which happens on **cold document open *and* after every recompile**, and `navigateToSource` bailed silently on the first null. Whichever click landed during an index (re)build did nothing, no error. That's why it *felt* like "works once, breaks after" — the dead click was just the one that hit a rebuild (e.g. right after an edit). The delegating listener being lost on re-render (the original hypothesis) was ruled out.

## Fix

Client-side resilience. The **deterministic** fix — an `rsm/indexReady` notification the client can await — lives in the rsm-lsp repo and is tracked in **std-vp3i**, with this retry as its permanent fallback layer.

- **Bounded retry (~2s)** around `rsm/nodePosition` and `rsm/nodeAtPosition` until the index resolves. Warm requests return on attempt 1 (no delay). Hoisted to an exported `lspRequestWithRetry(requestFn, opts)` so the contract is unit-testable.
- **No-LSP fast path** — bail immediately when there's no client, so an LSP-less environment doesn't pay the retry budget per interaction.
- **Latest-wins guard** — a nav token so rapid clicks during a cold window don't fight over the scroll; the last-clicked element wins.
- **Quiet failure signal** — `toast.info("Couldn't jump to the source for this element.")` on give-up, *only* when an LSP client exists (silence was the original bug); non-blaming wording since the client can't distinguish "not indexed yet" from "no mapping".

## Tests

- **Vitest unit test** for `lspRequestWithRetry` — first-non-null / retry-then-resolve / give-up-after-N / falsy-retry, deterministic with fake timers.
- **e2e regression** — 3 consecutive cmd+clicks (cold-first, different node, repeat), **content-node selection by text** (not brittle `nth()`), **CI-scaled timeout**, and **fail-not-skip** when the LSP is unavailable in CI.

Verified: unit 4/4, e2e 1/1, eslint clean, against the live stack.

## Reviewed by architecture, QA, and RX experts

Follow-ups filed: **std-vp3i** (real fix: rsm/indexReady + version-stamped answers — also closes a latent *wrong-highlight* gap the retry can't cover), **std-d634** (measure cold index-build time; widen budget if >~2s), **std-fda7** (delayed pending cue).

Closes std-9hfk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)