### PR TITLE
ci(deps): add dependabot npm entry for /multi-player

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,11 +42,12 @@ updates:
     # `pnpm install --frozen-lockfile` failed with ERR_PNPM_OUTDATED_LOCKFILE
     # before a single test ran (see PRs #413, #419, #423-#431).
     # Group only minor and patch bumps; majors arrive as individual, reviewable
-    # PRs. y-websocket 2.x -> 3.x (in multi-player) must not land before the
-    # Y.js beta-blocker P0s (std-7jxsk5, std-jmnni0). multi-player is also
-    # installed via `npm ci` from multi-player/package-lock.json in the backend
-    # image; until std-94x9 unifies it on pnpm, hand-regenerate that lock on any
-    # multi-player bump.
+    # PRs (y-websocket 2.x -> 3.x in particular needs deliberate review). This
+    # entry covers multi-player as a workspace member (its CI unit tests), but
+    # NOT the multi-player/package-lock.json the backend image installs from via
+    # `npm ci` — that lockfile is maintained by the /multi-player entry below, so
+    # a multi-player dep bump may produce two PRs (pnpm workspace lock + npm image
+    # lock); merge whichever fits and close the other.
     groups:
       npm-deps:
         patterns:
@@ -54,6 +55,28 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Enable version updates for the multi-player node service. The backend image
+  # bundles it and installs its deps standalone via `npm ci` from
+  # multi-player/package-lock.json. The pnpm-root entry above never touches that
+  # npm lockfile, so without this entry ws / jsonwebtoken / y-websocket would stop
+  # getting security updates in the shipped image. (multi-player/package-lock.json
+  # is a real, consumed lockfile — unlike the stray frontend one removed in #432.)
+  - package-ecosystem: "npm"
+    directory: "/multi-player"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "leotrs"
+    labels:
+      - "dependencies"
+      - "multi-player"
+    commit-message:
+      prefix: "multiplayer"
+      include: "scope"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Since #432 pointed the npm ecosystem at the pnpm workspace root, dependabot regenerates the root `pnpm-lock.yaml` but never touches `multi-player/package-lock.json` — the lockfile the **backend image** installs multi-player from via `npm ci`. That left **ws** (internet-facing WS transport) and **jsonwebtoken** (auth) without security updates in the shipped image.

This adds a `/multi-player` npm entry so that lockfile is maintained. A multi-player dep bump may now open two PRs (pnpm workspace lock + npm image lock); merge whichever fits and close the other — the accepted cost of the dual install context.

Chosen over converting multi-player to pnpm (**std-94x9, closed**): that would rework the prod backend image build context for a 3-dep standalone service, which isn't worth the deploy risk to fix a cosmetic dual-lockfile smell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)