### PR TITLE
fix(security): close broken object-level authorization (IDOR) holes

### DIFF
--- a/backend/aris/authorization.py
+++ b/backend/aris/authorization.py
@@ -277,3 +277,26 @@ async def require_manage(
     role = await get_user_role_for_file(file_id, user.id, db)  # type: ignore[arg-type]
     assert role is not None, "Role must exist after permission check passes"
     return role
+
+
+async def require_self(
+    user_id: int,
+    user: User = Depends(current_user),
+) -> User:
+    """FastAPI dependency: require the path ``user_id`` to be the caller.
+
+    Endpoints namespaced by ``/users/{user_id}`` get a router-level
+    ``Depends(current_user)`` that only proves the caller is logged in, not that
+    they are acting on their own account. Without this guard any authenticated
+    user can substitute another user's ``user_id`` and read or mutate that
+    account (IDOR). Returns the authenticated user so handlers can use it.
+
+    Raises
+    ------
+    HTTPException
+        403 if the authenticated user's id differs from the path ``user_id``.
+
+    """
+    if user.id != user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return user

--- a/backend/aris/crud/permissions.py
+++ b/backend/aris/crud/permissions.py
@@ -50,7 +50,7 @@ async def create_permission(
 
 
 async def update_permission_role(
-    permission_id: int, new_role: FileRole, db: AsyncSession
+    permission_id: int, file_id: int, new_role: FileRole, db: AsyncSession
 ) -> Optional[FilePermission]:
     """Update the role of an existing permission.
 
@@ -58,6 +58,10 @@ async def update_permission_role(
     ----------
     permission_id : int
         Permission ID to update.
+    file_id : int
+        File ID the permission must belong to. Scoping the lookup to the file
+        prevents cross-resource modification (an owner of one file must not be
+        able to update a permission that belongs to a different file).
     new_role : FileRole
         New role to assign.
     db : AsyncSession
@@ -66,12 +70,13 @@ async def update_permission_role(
     Returns
     -------
     Optional[FilePermission]
-        Updated permission record, or None if not found.
+        Updated permission record, or None if not found for this file.
 
     """
     stmt = select(FilePermission).where(
         and_(
             FilePermission.id == permission_id,
+            FilePermission.file_id == file_id,
             FilePermission.deleted_at.is_(None),
         )
     )
@@ -87,7 +92,7 @@ async def update_permission_role(
 
 
 async def revoke_permission(
-    permission_id: int, db: AsyncSession
+    permission_id: int, file_id: int, db: AsyncSession
 ) -> Optional[FilePermission]:
     """Revoke a permission (soft delete).
 
@@ -95,18 +100,23 @@ async def revoke_permission(
     ----------
     permission_id : int
         Permission ID to revoke.
+    file_id : int
+        File ID the permission must belong to. Scoping the lookup to the file
+        prevents cross-resource revocation (an owner of one file must not be
+        able to revoke a permission that belongs to a different file).
     db : AsyncSession
         Database session.
 
     Returns
     -------
     Optional[FilePermission]
-        Revoked permission record, or None if not found.
+        Revoked permission record, or None if not found for this file.
 
     """
     stmt = select(FilePermission).where(
         and_(
             FilePermission.id == permission_id,
+            FilePermission.file_id == file_id,
             FilePermission.deleted_at.is_(None),
         )
     )

--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -375,16 +375,19 @@ async def collab_start(
 
 
 @router.post("/{file_id}/collab/stop")
-async def collab_stop(file_id: int):
+async def collab_stop(
+    file_id: int,
+    user_role: FileRole = Depends(require_edit),
+):
     """Signal that the collaborative editor has closed for this file.
 
     Called by the frontend when the CodeMirror editor unmounts. Stops the backend
     Y.js client cleanly after persisting any remaining changes.
 
-    No file existence check: the file may have already been deleted (e.g. test
-    teardown deletes the file before the browser context finishes closing), and we
-    still need to stop the Y.js client. Authentication is enforced by the router-level
-    dependency.
+    Gate is ``require_edit`` (mirrors ``collab_start``): stopping a file's live
+    collaboration client is a privileged operation, so only users with write
+    access may do it. Requiring the file to exist means a stop for an
+    already-deleted file now returns 404 instead of silently succeeding.
     """
     manager = get_collaboration_manager()
     await manager.stop_client(file_id)
@@ -392,11 +395,17 @@ async def collab_stop(file_id: int):
 
 
 @router.post("/{file_id}/collab/flush")
-async def collab_flush(file_id: int):
+async def collab_flush(
+    file_id: int,
+    user_role: FileRole = Depends(require_edit),
+):
     """Flush the Y.js client's content to the database immediately.
 
     Called before export to ensure the DB has the latest content without
     competing with the Y.js save loop.
+
+    Gate is ``require_edit`` (mirrors ``collab_start``): only users with write
+    access may force a flush of a file's live collaboration client.
     """
     manager = get_collaboration_manager()
     client = manager.clients.get(file_id)

--- a/backend/aris/routes/file_annotations.py
+++ b/backend/aris/routes/file_annotations.py
@@ -328,7 +328,15 @@ async def get_annotation_messages(
     if not await has_permission(annotation.file_id, user.id, PermissionLevel.VIEW, db):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    query = select(AnnotationMessage).where(AnnotationMessage.annotation_id == annotation_id)
+    # Privacy: can only see own private annotations or shared ones
+    if annotation.owner_id != user.id and annotation.visibility != AnnotationVisibility.SHARED:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+
+    query = (
+        select(AnnotationMessage)
+        .options(selectinload(AnnotationMessage.owner))
+        .where(AnnotationMessage.annotation_id == annotation_id)
+    )
 
     if not include_deleted:
         query = query.where(AnnotationMessage.deleted_at.is_(None))
@@ -344,8 +352,10 @@ async def get_annotation_message(
     user: User = Depends(current_user),
     db: AsyncSession = Depends(get_db)
 ):
-    query = select(AnnotationMessage).where(
-        and_(AnnotationMessage.id == message_id, AnnotationMessage.deleted_at.is_(None))
+    query = (
+        select(AnnotationMessage)
+        .options(selectinload(AnnotationMessage.owner))
+        .where(and_(AnnotationMessage.id == message_id, AnnotationMessage.deleted_at.is_(None)))
     )
     result = await db.execute(query)
     message = result.scalar_one_or_none()
@@ -357,8 +367,15 @@ async def get_annotation_message(
     result = await db.execute(query_annotation)
     annotation = cast(Optional[Annotation], result.scalar_one_or_none())
 
-    if annotation and not await has_permission(annotation.file_id, user.id, PermissionLevel.VIEW, db):
+    if not annotation:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+
+    if not await has_permission(annotation.file_id, user.id, PermissionLevel.VIEW, db):
         raise HTTPException(status_code=403, detail="Access denied")
+
+    # Privacy: can only see own private annotations or shared ones
+    if annotation.owner_id != user.id and annotation.visibility != AnnotationVisibility.SHARED:
+        raise HTTPException(status_code=404, detail="Annotation not found")
 
     return message
 

--- a/backend/aris/routes/permissions.py
+++ b/backend/aris/routes/permissions.py
@@ -191,7 +191,7 @@ async def update_collaborator(
         404 if permission not found.
 
     """
-    permission = await update_permission_role(permission_id, request.role, db)
+    permission = await update_permission_role(permission_id, file_id, request.role, db)
     if not permission:
         raise HTTPException(status_code=404, detail="Permission not found")
 
@@ -237,6 +237,6 @@ async def remove_collaborator(
         404 if permission not found.
 
     """
-    permission = await revoke_permission(permission_id, db)
+    permission = await revoke_permission(permission_id, file_id, db)
     if not permission:
         raise HTTPException(status_code=404, detail="Permission not found")

--- a/backend/aris/routes/render.py
+++ b/backend/aris/routes/render.py
@@ -5,7 +5,9 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, current_user
+from ..authorization import PermissionLevel, has_permission
 from ..deps import get_db
+from ..exceptions import forbidden_exception
 from ..logging_config import get_logger
 
 
@@ -64,5 +66,12 @@ async def render_private(data: FileRenderObject, db: AsyncSession = Depends(get_
     Renders the request body's RSM source for a specific file with access to
     uploaded assets. This endpoint is render-only: it does NOT write source to
     the database. The Y.js collaboration loop is the sole writer of files.source.
+
+    ``file_id`` arrives in the body, so the ``require_view`` path dependency
+    cannot be used; the VIEW check is enforced inline. Without it, any
+    authenticated caller could pass another user's ``file_id`` and receive that
+    file's private assets embedded in the rendered HTML.
     """
+    if not await has_permission(data.file_id, user.id, PermissionLevel.VIEW, db):
+        raise forbidden_exception("You do not have access to this file")
     return await crud.render_with_assets(data.source, data.file_id, db, user.id)

--- a/backend/aris/routes/tag.py
+++ b/backend/aris/routes/tag.py
@@ -3,7 +3,9 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, current_user, get_db
-from ..exceptions import bad_request_exception, not_found_exception
+from ..authorization import require_self
+from ..exceptions import bad_request_exception, forbidden_exception, not_found_exception
+from ..models import User
 
 
 router = APIRouter(prefix="/users", tags=["users", "tags"], dependencies=[Depends(current_user)])
@@ -38,7 +40,12 @@ class TagCreate(BaseModel):
     response_model=TagRetrieveOrUpdate,
     status_code=status.HTTP_201_CREATED,
 )
-async def create_tag(user_id: int, tag: TagCreate, db: AsyncSession = Depends(get_db)):
+async def create_tag(
+    user_id: int,
+    tag: TagCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
+):
     """Create a new tag for the user."""
     user = await crud.get_user(user_id, db)
     if user is None:
@@ -51,15 +58,25 @@ async def create_tag(user_id: int, tag: TagCreate, db: AsyncSession = Depends(ge
 
 
 @router.get("/{user_id}/tags", response_model=list[TagRetrieveOrUpdate])
-async def get_user_tags(user_id: int, db: AsyncSession = Depends(get_db)):
+async def get_user_tags(
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
+):
     """Get all tags for a user."""
     tags = await crud.get_user_tags(user_id, db)
     return tags
 
 
 @router.put("/{user_id}/tags/{_id}", response_model=TagRetrieveOrUpdate)
-async def update_tag(tag: TagRetrieveOrUpdate, db: AsyncSession = Depends(get_db)):
+async def update_tag(
+    tag: TagRetrieveOrUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(current_user),
+):
     """Update the name of a tag."""
+    if tag.user_id != current_user.id:
+        raise forbidden_exception("Not authorized")
     if tag.id not in (t["id"] for t in await crud.get_user_tags(tag.user_id, db)):
         raise not_found_exception("Tag", tag.id)
     try:
@@ -70,7 +87,12 @@ async def update_tag(tag: TagRetrieveOrUpdate, db: AsyncSession = Depends(get_db
 
 
 @router.delete("/{user_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_tag(tag_id: int, user_id: int, db: AsyncSession = Depends(get_db)):
+async def delete_tag(
+    tag_id: int,
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
+):
     """Delete a tag for a user."""
     if tag_id not in (t["id"] for t in await crud.get_user_tags(user_id, db)):
         raise not_found_exception("Tag", tag_id)
@@ -82,7 +104,12 @@ async def delete_tag(tag_id: int, user_id: int, db: AsyncSession = Depends(get_d
 
 
 @router.get("/{user_id}/files/{file_id}/tags")
-async def get_user_file_tags(user_id: int, file_id: int, db: AsyncSession = Depends(get_db)):
+async def get_user_file_tags(
+    user_id: int,
+    file_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
+):
     """Get a user's tags assigned to the file."""
     try:
         result = await crud.get_user_file_tags(user_id, file_id, db)
@@ -93,7 +120,11 @@ async def get_user_file_tags(user_id: int, file_id: int, db: AsyncSession = Depe
 
 @router.post("/{user_id}/files/{file_id}/tags/{tag_id}")
 async def add_tag_to_file(
-    user_id: int, file_id: int, tag_id: int, db: AsyncSession = Depends(get_db)
+    user_id: int,
+    file_id: int,
+    tag_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
 ):
     """Assign a tag to a file."""
     try:
@@ -105,7 +136,11 @@ async def add_tag_to_file(
 
 @router.delete("/{user_id}/files/{file_id}/tags/{tag_id}")
 async def remove_tag_from_file(
-    user_id: int, file_id: int, tag_id: int, db: AsyncSession = Depends(get_db)
+    user_id: int,
+    file_id: int,
+    tag_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
 ):
     """Remove a tag from a file."""
     try:

--- a/backend/aris/routes/user.py
+++ b/backend/aris/routes/user.py
@@ -4,18 +4,19 @@ import re
 import time
 from collections import defaultdict, deque
 from datetime import UTC, datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from .. import crud, current_user, get_db
+from ..authorization import require_self, require_view
 from ..config import settings
 from ..exceptions import bad_request_exception, not_found_exception
-from ..models import ProfilePicture, User
+from ..models import AvatarColor, FileRole, ProfilePicture, User
 from ..security import hash_password, verify_password
 from ..services.email import get_email_service
 
@@ -42,8 +43,31 @@ router = APIRouter(prefix="/users", tags=["users"], dependencies=[Depends(curren
 #     return await crud.get_users(db)
 
 
-@router.get("/{user_id}")
-async def get_user(user_id: int, db: AsyncSession = Depends(get_db)):
+class UserResponse(BaseModel):
+    """Public-safe representation of a user.
+
+    Restricts the serialized output to non-sensitive fields. Returning the raw
+    ``User`` ORM object would otherwise leak ``password_hash`` and
+    ``email_verification_token`` to the client.
+    """
+
+    id: int
+    name: str
+    email: str
+    initials: Optional[str] = None
+    avatar_color: Optional[AvatarColor] = None
+    email_verified: bool
+    created_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/{user_id}", response_model=UserResponse)
+async def get_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
+):
     """Retrieve a specific user by ID.
 
     Parameters
@@ -52,15 +76,19 @@ async def get_user(user_id: int, db: AsyncSession = Depends(get_db)):
         The unique identifier of the user to retrieve.
     db : AsyncSession
         SQLAlchemy async database session dependency.
+    current_user : User
+        The authenticated caller; ``require_self`` enforces that the path
+        ``user_id`` matches the caller (403 otherwise).
 
     Returns
     -------
-    User
-        The user object if found.
+    UserResponse
+        The user's non-sensitive profile fields.
 
     Raises
     ------
     HTTPException
+        403 error if the caller requests a user other than themselves.
         404 error if user is not found or has been deleted.
 
     Notes
@@ -127,11 +155,12 @@ class PasswordChange(BaseModel):
         return v
 
 
-@router.put("/{user_id}")
+@router.put("/{user_id}", response_model=UserResponse)
 async def update_user(
     user_id: int,
     update: UserUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
 ):
     """Update user profile information.
 
@@ -169,6 +198,7 @@ async def change_password(
     user_id: int,
     password_data: PasswordChange,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
 ):
     """Change user password.
 
@@ -218,6 +248,7 @@ async def change_password(
 async def send_verification_email(
     user_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
 ):
     """Send email verification link to user.
 
@@ -326,7 +357,11 @@ async def verify_email(
 
 
 @router.delete("/{user_id}")
-async def soft_delete_user(user_id: int, db: AsyncSession = Depends(get_db)):
+async def soft_delete_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
+):
     """Soft delete a user account.
 
     Parameters
@@ -362,6 +397,7 @@ async def get_user_files(
     user_id: int,
     with_tags: bool = True,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
 ):
     """Retrieve all files owned by a user.
 
@@ -418,6 +454,8 @@ async def get_user_file(
     with_tags: bool = True,
     with_minimap: bool = True,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_self),
+    _: FileRole = Depends(require_view),
 ):
     """Retrieve a specific file owned by a user.
 

--- a/backend/tests/test_crud/test_crud_permissions.py
+++ b/backend/tests/test_crud/test_crud_permissions.py
@@ -119,7 +119,7 @@ async def test_get_file_collaborators_excludes_deleted(db_session: AsyncSession,
     )
 
     # Revoke permission
-    await revoke_permission(permission.id, db_session)
+    await revoke_permission(permission.id, file.id, db_session)
 
     collaborators = await get_file_collaborators(file.id, db_session)
 
@@ -143,7 +143,7 @@ async def test_update_permission_role_editor_to_commenter(db_session: AsyncSessi
         db=db_session,
     )
 
-    updated = await update_permission_role(permission.id, FileRole.COMMENTER, db_session)
+    updated = await update_permission_role(permission.id, file.id, FileRole.COMMENTER, db_session)
 
     assert updated.id == permission.id
     assert updated.role == FileRole.COMMENTER
@@ -164,7 +164,7 @@ async def test_update_permission_role_commenter_to_editor(db_session: AsyncSessi
         db=db_session,
     )
 
-    updated = await update_permission_role(permission.id, FileRole.EDITOR, db_session)
+    updated = await update_permission_role(permission.id, file.id, FileRole.EDITOR, db_session)
 
     assert updated.role == FileRole.EDITOR
 
@@ -172,7 +172,7 @@ async def test_update_permission_role_commenter_to_editor(db_session: AsyncSessi
 @pytest.mark.asyncio
 async def test_update_permission_role_returns_none_for_nonexistent(db_session: AsyncSession):
     """Test updating nonexistent permission returns None."""
-    updated = await update_permission_role(99999, FileRole.EDITOR, db_session)
+    updated = await update_permission_role(99999, 99999, FileRole.EDITOR, db_session)
     assert updated is None
 
 
@@ -191,7 +191,7 @@ async def test_revoke_permission_soft_deletes(db_session: AsyncSession, test_use
         db=db_session,
     )
 
-    revoked = await revoke_permission(permission.id, db_session)
+    revoked = await revoke_permission(permission.id, file.id, db_session)
 
     assert revoked is not None
     assert revoked.id == permission.id
@@ -201,5 +201,5 @@ async def test_revoke_permission_soft_deletes(db_session: AsyncSession, test_use
 @pytest.mark.asyncio
 async def test_revoke_permission_returns_none_for_nonexistent(db_session: AsyncSession):
     """Test revoking nonexistent permission returns None."""
-    result = await revoke_permission(99999, db_session)
+    result = await revoke_permission(99999, 99999, db_session)
     assert result is None

--- a/backend/tests/test_routes/test_email_verification.py
+++ b/backend/tests/test_routes/test_email_verification.py
@@ -167,11 +167,13 @@ class TestSendVerificationEndpoint:
     async def test_send_verification_user_not_found(
         self, client: AsyncClient, authenticated_user, auth_headers
     ):
+        # ``require_self`` forbids targeting any id other than the caller's
+        # (IDOR guard), so a foreign/nonexistent id yields 403 before not-found.
         response = await client.post(
             f"/users/{TestConstants.NONEXISTENT_ID}/send-verification",
             headers=auth_headers,
         )
-        assert response.status_code == 404
+        assert response.status_code == 403
 
     async def test_send_verification_no_email_when_service_disabled(
         self, client: AsyncClient, db_session

--- a/backend/tests/test_routes/test_render_private.py
+++ b/backend/tests/test_routes/test_render_private.py
@@ -3,7 +3,9 @@
 from httpx import AsyncClient
 from sqlalchemy import text
 
-from aris.models.models import File, FileAsset
+from aris.crud.file import create_file
+from aris.crud.permissions import create_permission
+from aris.models.models import FileAsset, FileRole
 
 
 class TestRenderPrivate:
@@ -17,13 +19,17 @@ class TestRenderPrivate:
         )
         assert response.status_code == 401
 
-    async def test_render_private_with_auth_no_assets(self, client: AsyncClient, authenticated_user):
+    async def test_render_private_with_auth_no_assets(self, client: AsyncClient, authenticated_user, db_session):
         """Test private render with authenticated user but no assets."""
         headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
 
+        file = await create_file(
+            source="test ", owner_id=authenticated_user['user_id'], db=db_session
+        )
+
         response = await client.post(
             "/render/private",
-            json={"source": " test content ", "file_id": 999},
+            json={"source": " test content ", "file_id": file.id},
             headers=headers
         )
 
@@ -34,11 +40,10 @@ class TestRenderPrivate:
         """Test private render with assets available."""
         headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
 
-        # Create a file first
-        file = File(owner_id=authenticated_user['user_id'], source="test ")
-        db_session.add(file)
-        await db_session.commit()
-        await db_session.refresh(file)
+        # Create a file first (grants the creator an OWNER permission row)
+        file = await create_file(
+            source="test ", owner_id=authenticated_user['user_id'], db=db_session
+        )
 
         # Create a file asset
         asset = FileAsset(
@@ -84,11 +89,10 @@ class TestRenderPrivate:
         """Test that private endpoint can access assets while public cannot."""
         headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
 
-        # Create a file first
-        file = File(owner_id=authenticated_user['user_id'], source="test ")
-        db_session.add(file)
-        await db_session.commit()
-        await db_session.refresh(file)
+        # Create a file first (grants the creator an OWNER permission row)
+        file = await create_file(
+            source="test ", owner_id=authenticated_user['user_id'], db=db_session
+        )
 
         # Create a file asset
         asset = FileAsset(
@@ -137,10 +141,9 @@ class TestRenderPrivate:
         """
         headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
 
-        file = File(owner_id=authenticated_user['user_id'], source="original source")
-        db_session.add(file)
-        await db_session.commit()
-        await db_session.refresh(file)
+        file = await create_file(
+            source="original source", owner_id=authenticated_user['user_id'], db=db_session
+        )
         file_id = file.id
 
         response = await client.post(
@@ -170,10 +173,9 @@ class TestRenderPrivate:
         Regression test for std-83utdw: the endpoint used to UPDATE
         files.source for any authenticated caller, regardless of permissions.
         """
-        file = File(owner_id=authenticated_user['user_id'], source="owner content")
-        db_session.add(file)
-        await db_session.commit()
-        await db_session.refresh(file)
+        file = await create_file(
+            source="owner content", owner_id=authenticated_user['user_id'], db=db_session
+        )
         file_id = file.id
 
         attacker_headers = {
@@ -192,3 +194,69 @@ class TestRenderPrivate:
         row = result.fetchone()
         assert row is not None
         assert row[0] == "owner content"
+
+    async def test_render_private_forbidden_without_access(
+        self,
+        client: AsyncClient,
+        authenticated_user,
+        second_authenticated_user,
+        db_session,
+    ):
+        """A non-owner without any permission cannot read another user's assets.
+
+        Regression test: /render/private resolved ALL of the target file's
+        private assets into the returned HTML with no permission check, so any
+        authenticated caller could pass another user's file_id and receive their
+        private assets (IDOR / cross-user asset disclosure). A caller WITH view
+        access still gets a 200 with the asset embedded.
+        """
+        file = await create_file(
+            source="owner content", owner_id=authenticated_user['user_id'], db=db_session
+        )
+
+        asset = FileAsset(
+            filename="secret_asset.html",
+            mime_type="text/html",
+            content="<div>Secret Asset</div>",
+            file_id=file.id,
+            owner_id=authenticated_user['user_id'],
+        )
+        db_session.add(asset)
+        await db_session.commit()
+
+        rsm_source = """
+:figure:{
+  :path: secret_asset.html
+}
+::
+"""
+
+        attacker_headers = {
+            "Authorization": f"Bearer {second_authenticated_user['token']}"
+        }
+
+        # No permission -> 403, and no asset content leaks.
+        forbidden = await client.post(
+            "/render/private",
+            json={"source": rsm_source, "file_id": file.id},
+            headers=attacker_headers,
+        )
+        assert forbidden.status_code == 403
+        assert "Secret Asset" not in forbidden.text
+
+        # Grant VIEW (COMMENTER) access -> 200 with the asset embedded.
+        await create_permission(
+            file_id=file.id,
+            user_id=second_authenticated_user['user_id'],
+            role=FileRole.COMMENTER,
+            granted_by=authenticated_user['user_id'],
+            db=db_session,
+        )
+
+        allowed = await client.post(
+            "/render/private",
+            json={"source": rsm_source, "file_id": file.id},
+            headers=attacker_headers,
+        )
+        assert allowed.status_code == 200
+        assert "Secret Asset" in allowed.json()

--- a/backend/tests/test_routes/test_routes_collab.py
+++ b/backend/tests/test_routes/test_routes_collab.py
@@ -4,7 +4,7 @@ POST /files/{id}/collab/start  — frontend signals editor is open
 POST /files/{id}/collab/stop   — frontend signals editor is closed
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import status
@@ -213,16 +213,17 @@ async def test_collab_stop_requires_auth(client: AsyncClient, authenticated_user
 
 
 @pytest.mark.asyncio
-async def test_collab_stop_succeeds_for_unknown_file(authenticated_client: AsyncClient):
-    """Stop is idempotent even when the file no longer exists in the database.
+async def test_collab_stop_404_for_unknown_file(authenticated_client: AsyncClient):
+    """Stop rejects unknown files with 404.
 
-    This matters because the frontend fires /collab/stop during onBeforeUnmount,
-    which can race with the file being deleted (e.g. in test teardown).
+    The ``require_edit`` gate (mirroring /collab/start) checks file existence
+    before running the handler, so a stop for a file that does not exist is a
+    404 rather than a silent success.
     """
     with patch("aris.routes.file.get_collaboration_manager") as mock_get:
         mock_get.return_value.stop_client = AsyncMock(return_value=False)
         response = await authenticated_client.post(_collab_url(99999, "stop"))
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.asyncio
@@ -259,3 +260,95 @@ async def test_collab_stop_when_not_running_is_fine(
         response = await authenticated_client.post(_collab_url(file_id, "stop"))
 
     assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.asyncio
+async def test_collab_stop_forbidden_for_user_without_permission(
+    client: AsyncClient,
+    authenticated_user: dict,
+    db_session: AsyncSession,
+):
+    """A user with no role on the file cannot stop its collab client.
+
+    Regression test: /collab/stop was previously only login-gated, so any
+    authenticated user could stop the Y.js client of any file (IDOR).
+    """
+    file_id = await _create_file(db_session, authenticated_user["user_id"])
+
+    reg = await client.post(
+        "/register",
+        json={"email": "stranger@example.com", "name": "Stranger", "initials": "ST", "password": "pw123456"},
+    )
+    assert reg.status_code == 200
+    stranger_token = reg.json()["access_token"]
+
+    with patch("aris.routes.file.get_collaboration_manager") as mock_get:
+        mock_get.return_value.stop_client = AsyncMock(return_value=True)
+        response = await client.post(
+            _collab_url(file_id, "stop"),
+            headers={"Authorization": f"Bearer {stranger_token}"},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------------------------------------------------------------
+# /collab/flush
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_collab_flush_requires_auth(client: AsyncClient, authenticated_user, db_session):
+    file_id = await _create_file(db_session, authenticated_user["user_id"])
+    response = await client.post(_collab_url(file_id, "flush"))
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_collab_flush_saves_for_owner(
+    authenticated_client: AsyncClient,
+    authenticated_user: dict,
+    db_session: AsyncSession,
+):
+    """The file owner can flush; the client's content is persisted."""
+    file_id = await _create_file(db_session, authenticated_user["user_id"])
+
+    mock_client = MagicMock()
+    mock_client.text = "content"
+    mock_client._save_to_db = AsyncMock()
+
+    with patch("aris.routes.file.get_collaboration_manager") as mock_get:
+        mock_get.return_value.clients = {file_id: mock_client}
+        response = await authenticated_client.post(_collab_url(file_id, "flush"))
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_client._save_to_db.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_collab_flush_forbidden_for_user_without_permission(
+    client: AsyncClient,
+    authenticated_user: dict,
+    db_session: AsyncSession,
+):
+    """A user with no role on the file cannot flush its collab client.
+
+    Regression test: /collab/flush was previously only login-gated, so any
+    authenticated user could force-persist any file's Y.js client (IDOR).
+    """
+    file_id = await _create_file(db_session, authenticated_user["user_id"])
+
+    reg = await client.post(
+        "/register",
+        json={"email": "stranger@example.com", "name": "Stranger", "initials": "ST", "password": "pw123456"},
+    )
+    assert reg.status_code == 200
+    stranger_token = reg.json()["access_token"]
+
+    with patch("aris.routes.file.get_collaboration_manager") as mock_get:
+        mock_get.return_value.clients = {}
+        response = await client.post(
+            _collab_url(file_id, "flush"),
+            headers={"Authorization": f"Bearer {stranger_token}"},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/tests/test_routes/test_routes_file_annotations.py
+++ b/backend/tests/test_routes/test_routes_file_annotations.py
@@ -1,6 +1,8 @@
 """Test annotation routes — CRUD, privacy filters, ownership rules, shared constraints."""
 
+import pytest
 from httpx import AsyncClient
+from sqlalchemy import text
 
 
 ANCHOR_DATA = {
@@ -716,3 +718,147 @@ async def test_delete_message_allowed_on_private_annotation(
 
     resp = await client.delete(f"/annotations/messages/{msg_id}", headers=headers)
     assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Message-read privacy (IDOR: another user's PRIVATE annotation notes)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_messages_of_other_users_private_annotation_returns_404(
+    client: AsyncClient,
+    authenticated_user,
+    second_authenticated_user,
+):
+    """User2 with file VIEW cannot read notes on user1's private annotation."""
+    h1 = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    h2 = {"Authorization": f"Bearer {second_authenticated_user['token']}"}
+
+    file_id = await _create_file(client, h1, authenticated_user["user_id"])
+    await _share_file(client, h1, file_id, second_authenticated_user["user_id"])
+    ann = await _create_annotation(client, h1, file_id)  # private
+
+    msg_resp = await client.post(
+        f"/annotations/{ann['id']}/messages",
+        headers=h1,
+        json={"content": "Secret note"},
+    )
+    assert msg_resp.status_code == 201
+
+    resp = await client.get(f"/annotations/{ann['id']}/messages", headers=h2)
+    assert resp.status_code == 404
+
+
+async def test_list_messages_of_shared_annotation_readable_by_other_user(
+    client: AsyncClient,
+    authenticated_user,
+    second_authenticated_user,
+):
+    """User2 with file VIEW can still read notes on user1's shared annotation."""
+    h1 = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    h2 = {"Authorization": f"Bearer {second_authenticated_user['token']}"}
+
+    file_id = await _create_file(client, h1, authenticated_user["user_id"])
+    await _share_file(client, h1, file_id, second_authenticated_user["user_id"])
+    ann = await _create_annotation(client, h1, file_id, visibility="shared")
+
+    msg_resp = await client.post(
+        f"/annotations/{ann['id']}/messages",
+        headers=h1,
+        json={"content": "Shared note"},
+    )
+    assert msg_resp.status_code == 201
+
+    resp = await client.get(f"/annotations/{ann['id']}/messages", headers=h2)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+async def test_get_single_message_of_other_users_private_annotation_returns_404(
+    client: AsyncClient,
+    authenticated_user,
+    second_authenticated_user,
+):
+    """User2 with file VIEW cannot read a single note on user1's private annotation."""
+    h1 = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    h2 = {"Authorization": f"Bearer {second_authenticated_user['token']}"}
+
+    file_id = await _create_file(client, h1, authenticated_user["user_id"])
+    await _share_file(client, h1, file_id, second_authenticated_user["user_id"])
+    ann = await _create_annotation(client, h1, file_id)  # private
+
+    msg_resp = await client.post(
+        f"/annotations/{ann['id']}/messages",
+        headers=h1,
+        json={"content": "Secret note"},
+    )
+    assert msg_resp.status_code == 201
+    msg_id = msg_resp.json()["id"]
+
+    resp = await client.get(f"/annotations/messages/{msg_id}", headers=h2)
+    assert resp.status_code == 404
+
+
+async def test_get_single_message_of_shared_annotation_readable_by_other_user(
+    client: AsyncClient,
+    authenticated_user,
+    second_authenticated_user,
+):
+    """User2 with file VIEW can still read a single note on user1's shared annotation."""
+    h1 = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    h2 = {"Authorization": f"Bearer {second_authenticated_user['token']}"}
+
+    file_id = await _create_file(client, h1, authenticated_user["user_id"])
+    await _share_file(client, h1, file_id, second_authenticated_user["user_id"])
+    ann = await _create_annotation(client, h1, file_id, visibility="shared")
+
+    msg_resp = await client.post(
+        f"/annotations/{ann['id']}/messages",
+        headers=h1,
+        json={"content": "Shared note"},
+    )
+    assert msg_resp.status_code == 201
+    msg_id = msg_resp.json()["id"]
+
+    resp = await client.get(f"/annotations/messages/{msg_id}", headers=h2)
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "Shared note"
+
+
+async def test_get_single_message_with_missing_annotation_returns_404(
+    client: AsyncClient,
+    authenticated_user,
+    db_session,
+    is_postgresql,
+):
+    """An orphaned message (parent annotation gone) must not leak to anyone.
+
+    Hard-deletes the parent annotation row to simulate a message whose
+    annotation is missing. PostgreSQL enforces the FK, so this cannot be
+    reproduced there; the endpoint fix is exercised on SQLite (local).
+    """
+    if is_postgresql:
+        pytest.skip(
+            "FK enforcement prevents hard-deleting a referenced annotation on PostgreSQL"
+        )
+
+    headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    file_id = await _create_file(client, headers, authenticated_user["user_id"])
+    ann = await _create_annotation(client, headers, file_id)
+
+    msg_resp = await client.post(
+        f"/annotations/{ann['id']}/messages",
+        headers=headers,
+        json={"content": "Note on soon-orphaned annotation"},
+    )
+    assert msg_resp.status_code == 201
+    msg_id = msg_resp.json()["id"]
+
+    # Hard-delete the parent annotation row, orphaning the message.
+    await db_session.execute(
+        text("DELETE FROM annotation WHERE id = :id"), {"id": ann["id"]}
+    )
+    await db_session.commit()
+
+    resp = await client.get(f"/annotations/messages/{msg_id}", headers=headers)
+    assert resp.status_code == 404

--- a/backend/tests/test_routes/test_routes_health.py
+++ b/backend/tests/test_routes/test_routes_health.py
@@ -11,7 +11,7 @@ async def test_health_check_healthy(client):
     data = response.json()
     # In CI, may be degraded due to short JWT_SECRET_KEY, but should not be unhealthy
     assert data["status"] in ["healthy", "degraded"]
-    assert data["message"] in ["RSM Studio API is healthy", "RSM Studio API is degraded but functional"]
+    assert data["message"] in ["RSM Studio API is healthy", "RSM Studio API is degraded"]
     assert "checks" in data
     assert "timestamp" in data
     

--- a/backend/tests/test_routes/test_routes_permissions.py
+++ b/backend/tests/test_routes/test_routes_permissions.py
@@ -383,3 +383,93 @@ async def test_add_collaborator_sends_invitation_email(
 
     assert response.status_code == status.HTTP_201_CREATED
     mock_email_service.send_invitation_email.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_collaborator_cross_file_forbidden(
+    authenticated_client: AsyncClient,
+    authenticated_client2: AsyncClient,
+    authenticated_user: dict,
+    second_authenticated_user: dict,
+    db_session: AsyncSession,
+):
+    """Cross-resource IDOR: owner of file B cannot update a permission on file A.
+
+    user1 owns file A with a collaborator permission row. user2 owns a separate
+    file B (so passes require_manage for B). user2 targets file A's permission
+    id through file B's endpoint and must get a 404, leaving file A untouched.
+    """
+    file_a = await create_file(
+        source="# File A", owner_id=authenticated_user["user_id"], db=db_session
+    )
+    permission_a = await create_permission(
+        file_id=file_a.id,
+        user_id=second_authenticated_user["user_id"],
+        role=FileRole.EDITOR,
+        granted_by=authenticated_user["user_id"],
+        db=db_session,
+    )
+
+    file_b = await create_file(
+        source="# File B", owner_id=second_authenticated_user["user_id"], db=db_session
+    )
+
+    # user2 owns file B, so require_manage(file_b) passes, but permission_a
+    # belongs to file A which user2 does not own.
+    response = await authenticated_client2.put(
+        f"/files/{file_b.id}/permissions/{permission_a.id}",
+        json={"role": "COMMENTER"},
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # File A's permission row must be unchanged.
+    await db_session.refresh(permission_a)
+    assert permission_a.role == FileRole.EDITOR
+
+
+@pytest.mark.asyncio
+async def test_revoke_collaborator_cross_file_forbidden(
+    authenticated_client: AsyncClient,
+    authenticated_client2: AsyncClient,
+    authenticated_user: dict,
+    second_authenticated_user: dict,
+    db_session: AsyncSession,
+):
+    """Cross-resource IDOR: owner of file B cannot revoke a permission on file A.
+
+    user1 owns file A with a collaborator permission row. user2 owns a separate
+    file B (so passes require_manage for B). user2 targets file A's permission
+    id through file B's endpoint and must get a 404, leaving file A untouched.
+    """
+    file_a = await create_file(
+        source="# File A", owner_id=authenticated_user["user_id"], db=db_session
+    )
+    permission_a = await create_permission(
+        file_id=file_a.id,
+        user_id=second_authenticated_user["user_id"],
+        role=FileRole.EDITOR,
+        granted_by=authenticated_user["user_id"],
+        db=db_session,
+    )
+
+    file_b = await create_file(
+        source="# File B", owner_id=second_authenticated_user["user_id"], db=db_session
+    )
+
+    response = await authenticated_client2.delete(
+        f"/files/{file_b.id}/permissions/{permission_a.id}"
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # File A's permission row must not be soft-deleted.
+    await db_session.refresh(permission_a)
+    assert permission_a.deleted_at is None
+
+    # And the collaborator is still listed on file A for its owner.
+    list_response = await authenticated_client.get(f"/files/{file_a.id}/permissions")
+    collaborators = list_response.json()
+    assert any(
+        c["permission_id"] == permission_a.id for c in collaborators
+    )

--- a/backend/tests/test_routes/test_routes_tag.py
+++ b/backend/tests/test_routes/test_routes_tag.py
@@ -76,7 +76,11 @@ async def test_create_tag_with_auth(client: AsyncClient, authenticated_user):
 
 
 async def test_create_tag_nonexistent_user(client: AsyncClient, authenticated_user):
-    """Test creating a tag for a nonexistent user."""
+    """Creating a tag under another user's id is forbidden before any user lookup.
+
+    The require_self guard rejects the mismatched path user_id (IDOR), so a caller
+    can no longer probe whether an arbitrary user exists via this endpoint.
+    """
     headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
     response = await client.post(
         "/users/99999/tags",
@@ -86,8 +90,8 @@ async def test_create_tag_nonexistent_user(client: AsyncClient, authenticated_us
             "color": "#FF0000",
         },
     )
-    assert response.status_code == 404
-    assert "User with id 99999 not found" == response.json()["detail"]
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Forbidden"
 
 
 async def test_create_tag_invalid_data(client: AsyncClient, authenticated_user):
@@ -332,8 +336,8 @@ async def test_create_tag_invalid_names(authenticated_user, client: AsyncClient)
 
 async def test_update_tag_not_owned(sample_tag, client: AsyncClient):
     """
-    Test updating a tag with a user_id different from the authenticated user's.
-    Expect 404 Not Found because tag doesn't belong to the user.
+    Test updating a tag with a body user_id different from the authenticated user's.
+    Expect 403 Forbidden: the body-based ownership check rejects the mismatch (IDOR).
     """
     headers = {"Authorization": f"Bearer {sample_tag['token']}"}
     tag = sample_tag["tag"]
@@ -346,9 +350,8 @@ async def test_update_tag_not_owned(sample_tag, client: AsyncClient):
         headers=headers,
         json=fake_tag,
     )
-    assert response.status_code == 404
-    # The exact tag ID will vary based on the test data, so check for the pattern
-    assert "Tag with id" in response.json()["detail"] and "not found" in response.json()["detail"]
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not authorized"
 
 
 
@@ -514,3 +517,79 @@ async def test_delete_tag_crud_error(
     )
     assert response.status_code == 400
     assert response.json()["detail"] == f"Error deleting tag: {tag_data['id']}"
+
+
+# Cross-user authorization tests (IDOR / broken object-level authorization)
+#
+# The router only enforces "logged in", not "acting on your own account". These
+# tests assert that user2 cannot read or mutate user1's (test_user) tag resources.
+# The require_self guard (and, for update, the body-based ownership check) rejects
+# the request with 403 before any object lookup, so the target tag/file id need not
+# exist: the 403 can only originate from the authorization guard, which is exactly
+# what these tests verify.
+
+
+async def test_create_tag_cross_user_forbidden(authenticated_client2, test_user):
+    """user2 cannot create a tag under another user's id."""
+    response = await authenticated_client2.post(
+        f"/users/{test_user.id}/tags",
+        json={"name": "Evil Tag", "color": "#000000"},
+    )
+    assert response.status_code == 403
+
+
+async def test_get_user_tags_cross_user_forbidden(authenticated_client2, test_user):
+    """user2 cannot list another user's tags."""
+    response = await authenticated_client2.get(f"/users/{test_user.id}/tags")
+    assert response.status_code == 403
+
+
+async def test_update_tag_cross_user_forbidden(authenticated_client2, test_user):
+    """user2 cannot update a tag by scoping the request body to another user's id."""
+    response = await authenticated_client2.put(
+        f"/users/{test_user.id}/tags/1",
+        json={
+            "id": 1,
+            "user_id": test_user.id,
+            "name": "Hijacked",
+            "color": "#000000",
+        },
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not authorized"
+
+
+async def test_delete_tag_cross_user_forbidden(authenticated_client2, test_user):
+    """user2 cannot delete a tag under another user's id."""
+    response = await authenticated_client2.delete(f"/users/{test_user.id}/tags/1")
+    assert response.status_code == 403
+
+
+async def test_get_user_file_tags_cross_user_forbidden(
+    authenticated_client2, test_user, test_file
+):
+    """user2 cannot read tags on another user's file."""
+    response = await authenticated_client2.get(
+        f"/users/{test_user.id}/files/{test_file.id}/tags"
+    )
+    assert response.status_code == 403
+
+
+async def test_add_tag_to_file_cross_user_forbidden(
+    authenticated_client2, test_user, test_file
+):
+    """user2 cannot assign a tag on another user's file."""
+    response = await authenticated_client2.post(
+        f"/users/{test_user.id}/files/{test_file.id}/tags/1"
+    )
+    assert response.status_code == 403
+
+
+async def test_remove_tag_from_file_cross_user_forbidden(
+    authenticated_client2, test_user, test_file
+):
+    """user2 cannot remove a tag from another user's file."""
+    response = await authenticated_client2.delete(
+        f"/users/{test_user.id}/files/{test_file.id}/tags/1"
+    )
+    assert response.status_code == 403

--- a/backend/tests/test_routes/test_routes_user.py
+++ b/backend/tests/test_routes/test_routes_user.py
@@ -64,10 +64,14 @@ class TestUserEndpoints:
         assert data["initials"] == TestConstants.DEFAULT_USER_INITIALS
 
     async def test_get_user_not_found(self, client: AsyncClient, auth_headers):
-        """Test getting non-existent user."""
+        """Requesting any other/nonexistent user id is forbidden (IDOR guard).
+
+        With ``require_self`` the endpoint no longer discloses whether a foreign
+        user id exists: any id other than the caller's returns 403 before the
+        not-found path is reached.
+        """
         response = await client.get(f"/users/{TestConstants.NONEXISTENT_ID}", headers=auth_headers)
-        assert response.status_code == 404
-        assert response.json()["detail"] == f"User with id {TestConstants.NONEXISTENT_ID} not found"
+        assert response.status_code == 403
 
     async def test_update_user_success(self, client: AsyncClient, authenticated_user, auth_headers):
         """Test updating user details."""
@@ -155,17 +159,17 @@ class TestPasswordChange:
         assert response.status_code == 422
 
     async def test_change_password_user_not_found(self, client: AsyncClient, auth_headers):
-        """Test password change for non-existent user."""
+        """Changing another/nonexistent user's password is forbidden (IDOR guard)."""
         password_data = {
             "current_password": TestConstants.TEST_PASSWORD,
             "new_password": "newpassword456"
         }
         response = await client.post(
-            f"/users/{TestConstants.NONEXISTENT_ID}/change-password", 
-            headers=auth_headers, 
+            f"/users/{TestConstants.NONEXISTENT_ID}/change-password",
+            headers=auth_headers,
             json=password_data
         )
-        assert response.status_code == 404
+        assert response.status_code == 403
 
     async def test_change_password_unauthorized(self, client: AsyncClient, authenticated_user):
         """Test password change without authentication."""
@@ -193,12 +197,12 @@ class TestEmailVerification:
         assert "verification email sent" in response.json()["message"].lower()
 
     async def test_send_verification_email_user_not_found(self, client: AsyncClient, auth_headers):
-        """Test sending verification email for non-existent user."""
+        """Sending verification email for another/nonexistent user is forbidden (IDOR guard)."""
         response = await client.post(
             f"/users/{TestConstants.NONEXISTENT_ID}/send-verification",
             headers=auth_headers
         )
-        assert response.status_code == 404
+        assert response.status_code == 403
 
     async def test_send_verification_email_already_verified(self, client: AsyncClient, authenticated_user, auth_headers, db_session):
         """Test sending verification email when already verified."""
@@ -281,7 +285,11 @@ class TestUserEndpoints2:
     """Additional test class for user endpoints."""
 
     async def test_update_user_not_found(self, client: AsyncClient, auth_headers):
-        """Test updating non-existent user."""
+        """Updating another/nonexistent user is forbidden (IDOR guard).
+
+        ``require_self`` short-circuits with 403 before the not-found path,
+        preventing account-takeover via a substituted user id.
+        """
         update_data = {
             "name": TestConstants.UPDATED_NAME,
             "initials": TestConstants.UPDATED_INITIALS,
@@ -290,8 +298,7 @@ class TestUserEndpoints2:
         response = await client.put(
             f"/users/{TestConstants.NONEXISTENT_ID}", headers=auth_headers, json=update_data
         )
-        assert response.status_code == 404
-        assert response.json()["detail"] == f"User with id {TestConstants.NONEXISTENT_ID} not found"
+        assert response.status_code == 403
 
     async def test_update_user_without_auth(self, client: AsyncClient):
         """Test updating user without authentication."""
@@ -312,12 +319,11 @@ class TestUserEndpoints2:
         assert response.json()["message"] == f"User {authenticated_user['user_id']} soft deleted"
 
     async def test_soft_delete_user_not_found(self, client: AsyncClient, auth_headers):
-        """Test soft deleting non-existent user."""
+        """Deleting another/nonexistent user is forbidden (IDOR guard)."""
         response = await client.delete(
             f"/users/{TestConstants.NONEXISTENT_ID}", headers=auth_headers
         )
-        assert response.status_code == 404
-        assert response.json()["detail"] == f"User with id {TestConstants.NONEXISTENT_ID} not found"
+        assert response.status_code == 403
 
     async def test_soft_delete_user_without_auth(self, client: AsyncClient):
         """Test soft deleting user without authentication."""
@@ -354,12 +360,11 @@ class TestUserFiles:
         assert response.status_code == 401
 
     async def test_get_user_files_user_not_found(self, client: AsyncClient, auth_headers):
-        """Test getting files for non-existent user."""
+        """Listing another/nonexistent user's files is forbidden (IDOR guard)."""
         response = await client.get(
             f"/users/{TestConstants.NONEXISTENT_ID}/files", headers=auth_headers
         )
-        assert response.status_code == 404
-        assert response.json()["detail"] == f"User with id {TestConstants.NONEXISTENT_ID} not found"
+        assert response.status_code == 403
 
     async def test_get_user_file_success(
         self, client: AsyncClient, authenticated_user, auth_headers
@@ -392,23 +397,27 @@ class TestUserFiles:
         assert response.status_code == 401
 
     async def test_get_user_file_user_not_found(self, client: AsyncClient, auth_headers):
-        """Test getting file for non-existent user."""
+        """Getting a file scoped to another/nonexistent user id is forbidden (IDOR guard)."""
         response = await client.get(
             f"/users/{TestConstants.NONEXISTENT_ID}/files/1", headers=auth_headers
         )
-        assert response.status_code == 404
-        assert response.json()["detail"] == f"User with id {TestConstants.NONEXISTENT_ID} not found"
+        assert response.status_code == 403
 
     async def test_get_user_file_file_not_found(
         self, client: AsyncClient, authenticated_user, auth_headers
     ):
-        """Test getting non-existent file."""
+        """Getting a non-existent file (as self) returns 404 from the file-access guard.
+
+        ``require_view`` verifies the file exists and the caller can view it, so a
+        missing file id now yields its generic 404 ("File not found") rather than
+        the handler's per-id message.
+        """
         response = await client.get(
             f"/users/{authenticated_user['user_id']}/files/{TestConstants.NONEXISTENT_ID}",
             headers=auth_headers,
         )
         assert response.status_code == 404
-        assert response.json()["detail"] == f"File with id {TestConstants.NONEXISTENT_ID} not found"
+        assert response.json()["detail"] == "File not found"
 
 
 class TestProfilePicture:
@@ -765,3 +774,148 @@ class TestUserLookup:
             json={"email": "someone@example.com"},
         )
         assert response.status_code == 401
+
+
+class TestCrossUserAuthorization:
+    """IDOR guard tests for user-scoped endpoints.
+
+    Router-level ``Depends(current_user)`` only proves the caller is logged in.
+    These tests confirm that ``require_self`` (and, for file access,
+    ``require_view``) additionally enforce the caller may only act on their own
+    account. Each endpoint is exercised with user 1 (``auth_headers``) targeting a
+    distinct second user, expecting 403, with a matching positive self case.
+    """
+
+    async def test_get_user_cross_user_forbidden(
+        self, client: AsyncClient, auth_headers, second_authenticated_user
+    ):
+        """User 1 cannot read another user's profile."""
+        response = await client.get(
+            f"/users/{second_authenticated_user['user_id']}", headers=auth_headers
+        )
+        assert response.status_code == 403
+
+    async def test_get_user_self_succeeds_without_leaking_secrets(
+        self, client: AsyncClient, authenticated_user, auth_headers
+    ):
+        """Reading one's own profile succeeds and omits sensitive fields."""
+        response = await client.get(
+            f"/users/{authenticated_user['user_id']}", headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == authenticated_user["user_id"]
+        # Sensitive columns must never be serialized in the response.
+        assert "password_hash" not in data
+        assert "email_verification_token" not in data
+
+    async def test_update_user_cross_user_forbidden(
+        self,
+        client: AsyncClient,
+        auth_headers,
+        second_authenticated_user,
+        db_session,
+    ):
+        """User 1 cannot change another user's profile/email (account takeover)."""
+        target_id = second_authenticated_user["user_id"]
+        response = await client.put(
+            f"/users/{target_id}",
+            headers=auth_headers,
+            json={
+                "name": TestConstants.UPDATED_NAME,
+                "initials": TestConstants.UPDATED_INITIALS,
+                "email": TestConstants.UPDATED_EMAIL,
+            },
+        )
+        assert response.status_code == 403
+        # The target account must be untouched.
+        target = await db_session.get(User, target_id)
+        assert target.email == TestConstants.SECOND_USER_EMAIL
+
+    async def test_change_password_cross_user_forbidden(
+        self, client: AsyncClient, auth_headers, second_authenticated_user
+    ):
+        """User 1 cannot change another user's password."""
+        response = await client.post(
+            f"/users/{second_authenticated_user['user_id']}/change-password",
+            headers=auth_headers,
+            json={
+                "current_password": TestConstants.TEST_PASSWORD,
+                "new_password": "newpassword456",
+            },
+        )
+        assert response.status_code == 403
+
+    async def test_send_verification_cross_user_forbidden(
+        self, client: AsyncClient, auth_headers, second_authenticated_user
+    ):
+        """User 1 cannot trigger a verification email for another user."""
+        response = await client.post(
+            f"/users/{second_authenticated_user['user_id']}/send-verification",
+            headers=auth_headers,
+        )
+        assert response.status_code == 403
+
+    async def test_soft_delete_cross_user_forbidden(
+        self,
+        client: AsyncClient,
+        auth_headers,
+        second_authenticated_user,
+        db_session,
+    ):
+        """User 1 cannot soft-delete another user, and the target survives."""
+        target_id = second_authenticated_user["user_id"]
+        response = await client.delete(f"/users/{target_id}", headers=auth_headers)
+        assert response.status_code == 403
+        # The target user must still exist and not be soft-deleted.
+        target = await db_session.get(User, target_id)
+        assert target is not None
+        assert target.deleted_at is None
+
+    async def test_get_user_files_cross_user_forbidden(
+        self, client: AsyncClient, auth_headers, second_authenticated_user
+    ):
+        """User 1 cannot list another user's files."""
+        response = await client.get(
+            f"/users/{second_authenticated_user['user_id']}/files", headers=auth_headers
+        )
+        assert response.status_code == 403
+
+    async def test_get_user_file_cross_user_forbidden(
+        self,
+        client: AsyncClient,
+        auth_headers,
+        second_authenticated_user,
+        second_auth_headers,
+    ):
+        """User 1 cannot read a file scoped to another user's id."""
+        file_id = await create_test_file(
+            client, second_auth_headers, second_authenticated_user["user_id"]
+        )
+        response = await client.get(
+            f"/users/{second_authenticated_user['user_id']}/files/{file_id}",
+            headers=auth_headers,
+        )
+        assert response.status_code == 403
+
+    async def test_get_user_file_self_without_access_forbidden(
+        self,
+        client: AsyncClient,
+        authenticated_user,
+        auth_headers,
+        second_authenticated_user,
+        second_auth_headers,
+    ):
+        """Even scoped to their OWN id, a caller cannot read a file they lack access to.
+
+        ``require_view`` closes the IDOR where any authenticated user could read an
+        arbitrary ``file_id`` by pairing it with their own ``user_id``.
+        """
+        file_id = await create_test_file(
+            client, second_auth_headers, second_authenticated_user["user_id"]
+        )
+        response = await client.get(
+            f"/users/{authenticated_user['user_id']}/files/{file_id}",
+            headers=auth_headers,
+        )
+        assert response.status_code == 403


### PR DESCRIPTION
## What

Codebase-wide sweep for **broken object-level authorization (IDOR)**: endpoints that took a resource id (`user_id` / `file_id` / `permission_id`) and read or mutated it with no ownership check beyond *"is logged in"*. The router-level `Depends(current_user)` only proves login, not that the caller may act on that specific resource.

21 endpoints across 6 route files, each with a cross-user 403 test.

| File | Fixed | Fix |
|---|---|---|
| `user.py` | 7 | `require_self`; `UserResponse` model stops `password_hash`/token leak. Incl. `DELETE` (delete any account) and `PUT` (change any email = account takeover) |
| `tag.py` | 7 (all) | `require_self` (path) / inline owner check (body `user_id`) |
| `permissions.py` (+crud) | 2 | scope `permission_id` to `file_id` (cross-file role tamper/revoke) |
| `file_annotations.py` | 2 | private-annotation privacy check on message reads (+ fixes a latent `MissingGreenlet` 500) |
| `file.py` | 2 | `require_edit` on collab stop/flush |
| `render.py` | 1 | VIEW check on `/render/private` (cross-user private-asset disclosure) |

New shared dep: `require_self` in `authorization.py`.

## Tests
Cross-user 403 test per endpoint. Pre-existing `*_not_found` tests updated where a foreign id now correctly 403s before 404 (no longer leaks user existence). **Full backend suite green (843 passed).** ruff + mypy clean. Also aligned one stale health-check assertion to the endpoint's actual message.

## Out of scope (filed separately)
Different vuln classes / need their own decision or frontend coordination:
- **std-b4v9** (P0) — `get_asset_raw` serves any file's assets unauthenticated; can't just lock it (rendered `<img>` can't send a bearer token) → needs a signed-URL / blob-proxy / public-flag decision
- **std-5smn** (P0) — unauthenticated `/ws/lsp` forks a subprocess per connection (DoS)
- **std-v8qo** — internal empty-secret hardening · **std-fkdh** — login logs PII

Closes std-u5k6c9

🤖 Generated with [Claude Code](https://claude.com/claude-code)