### PR TITLE
feat(security): sign rendered-manuscript asset URLs (close IDOR)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@
 BACKEND_PORT=8000
 BACKEND_TEST_PORT=8001
 BACKEND_CONTAINER_PORT=8000
+# Public origin the BROWSER reaches the backend at (used to build absolute, signed
+# image-asset URLs in rendered manuscripts). Must match how the browser reaches the
+# backend, not an internal Docker host. Prod: https://aris-backend.fly.dev
+BACKEND_URL=http://localhost:8000
 
 # Frontend configuration
 FRONTEND_PORT=5173

--- a/backend/aris/asset_signing.py
+++ b/backend/aris/asset_signing.py
@@ -1,0 +1,54 @@
+"""HMAC-signed, short-lived tokens for the public raw-asset endpoint (std-b4v9).
+
+Rendered-manuscript images load in plain browser <img> tags, which cannot send
+the app's bearer token. So instead of a session check, the backend, right after
+it has already confirmed the caller may view a file, signs each asset URL with a
+short-lived HMAC bound to (file_id, filename, exp). The public raw-asset endpoint
+verifies that signature. Binding the signature to file_id and filename together
+stops a token minted for one asset from unlocking another.
+"""
+
+import hashlib
+import hmac
+import time
+
+from aris.config import settings
+
+
+# Long enough to open a document and scroll through it, short enough to bound the
+# damage if a signed URL leaks (query strings can land in proxy logs or a Referer
+# header). Renders happen on a debounce, so fresh URLs are minted often anyway.
+ASSET_URL_TTL_SECONDS = 3600
+
+
+def _secret() -> bytes:
+    # Reuse the JWT key so this can ship without a new required env var. Splitting
+    # out a dedicated ASSET_SIGNING_SECRET is a tracked follow-up so asset URLs can
+    # be rotated without invalidating everyone's login session.
+    return settings.JWT_SECRET_KEY.encode()
+
+
+def _compute_sig(file_id: int, filename: str, exp: int) -> str:
+    message = f"{file_id}:{filename}:{exp}".encode()
+    return hmac.new(_secret(), message, hashlib.sha256).hexdigest()
+
+
+def sign_asset_path(file_id: int, filename: str, ttl_seconds: int = ASSET_URL_TTL_SECONDS) -> str:
+    """Return the ``exp=<ts>&sig=<hmac>`` query string for one asset URL."""
+    exp = int(time.time()) + ttl_seconds
+    return f"exp={exp}&sig={_compute_sig(file_id, filename, exp)}"
+
+
+def verify_asset_signature(
+    file_id: int, filename: str, exp: int, sig: str, now: int | None = None
+) -> bool:
+    """True if ``sig`` matches (file_id, filename, exp) and has not expired.
+
+    ``now`` is injectable for deterministic expiry tests; production passes None.
+    """
+    if now is None:
+        now = int(time.time())
+    if exp < now:
+        return False
+    expected = _compute_sig(file_id, filename, exp)
+    return hmac.compare_digest(expected, sig)

--- a/backend/aris/config.py
+++ b/backend/aris/config.py
@@ -94,6 +94,12 @@ class Settings(BaseSettings):
     FRONTEND_URL: str = Field("http://localhost:5173", json_schema_extra={"env": "FRONTEND_URL"})
     """Frontend base URL used for building email links."""
 
+    BACKEND_URL: str = Field("http://localhost:8000", json_schema_extra={"env": "BACKEND_URL"})
+    """Public base URL of this backend, the origin a browser reaches. Used to build
+    absolute, signed URLs for rendered-manuscript image assets, which load in plain
+    <img> tags and cannot carry a bearer token. Must be the externally reachable
+    origin (e.g. https://aris-backend.fly.dev in prod), not an internal Docker host."""
+
     INTERNAL_SHARED_SECRET: str = Field(..., json_schema_extra={"env": "INTERNAL_SHARED_SECRET"})
     """Shared secret used to authenticate trusted-infrastructure callers (e.g. the
     multi-player WebSocket server) on /internal/* endpoints. Required."""

--- a/backend/aris/models/models.py
+++ b/backend/aris/models/models.py
@@ -296,7 +296,8 @@ class File(Base):
     keywords : str
         Optional comma-separated keywords.
     status : FileStatus
-        Draft, Under Review, or Published.
+        Currently only DRAFT exists. Published/public states are not modeled yet
+        (anonymous public reading lives in Press, not Studio).
     last_edited_at : datetime
         Auto-updated on edit.
     created_at : datetime

--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -798,11 +798,25 @@ async def create_asset_for_file(
 async def get_asset_raw(
     file_id: int,
     filename: str,
+    exp: int = 0,
+    sig: str = "",
     db: AsyncSession = Depends(get_db),
 ):
-    """Serve raw asset binary for browser rendering (img src, etc.)."""
+    """Serve raw asset bytes for browser <img> rendering.
+
+    This stays on the public router because an <img> tag cannot send a bearer
+    token. Access is proved instead by the short-lived HMAC signature the renderer
+    minted for a caller it had already authorized (see aris.asset_signing). The
+    signature is checked before any DB lookup, so a caller without a valid one
+    cannot use the 200-vs-404 response to discover which filenames exist.
+    """
     import base64 as b64
     import mimetypes
+
+    from aris.asset_signing import verify_asset_signature
+
+    if not verify_asset_signature(file_id, filename, exp, sig):
+        raise HTTPException(status_code=403, detail="Invalid or expired asset signature")
 
     from sqlalchemy import select
     result = await db.execute(

--- a/backend/aris/services/asset_resolver.py
+++ b/backend/aris/services/asset_resolver.py
@@ -12,6 +12,8 @@ from typing import Optional
 from rsm.asset_resolver import AssetResolver
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..asset_signing import sign_asset_path
+from ..config import settings
 from ..models.models import FileAsset
 
 
@@ -51,7 +53,13 @@ class FileAssetResolver(AssetResolver):
         # be inlined since there's no browser-native way to embed HTML by URL.
         is_image = any(path.lower().endswith(ext) for ext in (".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"))
         if not self._standalone and is_image:
-            return f"/files/{self._file_id}/assets/raw/{path}"
+            # Absolute (frontend and backend are different origins in prod, so a
+            # root-relative path would resolve against the frontend and 404) and
+            # signed (a plain <img> cannot send a bearer token, so the short-lived
+            # HMAC is what authorizes the fetch). Signed here, downstream of the
+            # VIEW check the caller already passed to reach rendering.
+            query = sign_asset_path(self._file_id, path)
+            return f"{settings.BACKEND_URL}/files/{self._file_id}/assets/raw/{path}?{query}"
 
         content, encoding = asset_info
         if encoding == "base64":

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -14,6 +14,12 @@ primary_region = 'fra'
 kill_signal = "SIGTERM"
 kill_timeout = "30s"
 
+[env]
+  # Public origin the browser reaches this backend at, used to build absolute
+  # signed image-asset URLs in rendered manuscripts. Non-secret, so it lives here
+  # rather than in Fly secrets.
+  BACKEND_URL = "https://aris-backend.fly.dev"
+
 [build]
   dockerfile = "Dockerfile"
   build-target = "runtime"

--- a/backend/main.py
+++ b/backend/main.py
@@ -114,7 +114,7 @@ app = FastAPI(
         # {"name": "render", "description": "Convert RSM markup to rendered HTML output"},  # DISABLED FOR NOW
         {"name": "signup", "description": "Early access signup and waitlist management"},
         {"name": "lsp", "description": "Language Server Protocol integration for RSM editing"},
-        {"name": "public", "description": "Public preprint access without authentication"},
+        {"name": "public", "description": "Endpoints reachable without a session: signed asset URLs and email verification"},
         {"name": "health", "description": "System health and status monitoring"},
     ],
 )
@@ -419,6 +419,10 @@ async def add_no_cache_headers(request, call_next):
     response = await call_next(request)
     if request.url.path.startswith("/static") or request.url.path.startswith("/styles") or request.url.path.startswith("/brand"):
         response.headers["Cache-Control"] = "no-store"
+    # Signed asset URLs carry their token in the query string. Keep the full URL
+    # out of the Referer header so a signed URL cannot leak to any third-party
+    # resource a rendered document happens to load.
+    response.headers.setdefault("Referrer-Policy", "no-referrer")
     return response
 
 

--- a/backend/tests/test_routes/test_asset_raw_signed.py
+++ b/backend/tests/test_routes/test_asset_raw_signed.py
@@ -1,0 +1,99 @@
+"""Signed-URL access tests for the public raw-asset endpoint (std-b4v9).
+
+GET /files/{file_id}/assets/raw/{filename} is fetched by browser <img> tags that
+cannot carry a bearer token, so it stays on the public router but requires a valid
+short-lived HMAC signature (exp + sig query params). These tests lock in that an
+unsigned, tampered, expired, or cross-file request is rejected before any DB lookup
+(so the endpoint is not an existence/filename oracle either).
+"""
+
+import base64
+
+import pytest
+from httpx import AsyncClient
+
+from aris.asset_signing import sign_asset_path
+
+
+PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture
+async def file_with_image(client: AsyncClient, authenticated_user):
+    headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    resp = await client.post(
+        "/files",
+        headers=headers,
+        json={
+            "title": "Doc",
+            "abstract": "",
+            "owner_id": authenticated_user["user_id"],
+            "source": "x",
+        },
+    )
+    file_id = resp.json()["id"]
+    upload = await client.post(
+        f"/files/{file_id}/assets",
+        headers=headers,
+        json={
+            "filename": "chart.png",
+            "mime_type": "image/png",
+            "content": PNG_B64,
+            "content_encoding": "base64",
+        },
+    )
+    assert upload.status_code == 200, upload.text
+    return file_id
+
+
+def _tamper(qs: str) -> str:
+    parts = dict(p.split("=", 1) for p in qs.split("&"))
+    sig = parts["sig"]
+    flipped = sig[:-1] + ("0" if sig[-1] != "0" else "1")
+    return f"exp={parts['exp']}&sig={flipped}"
+
+
+async def test_valid_signature_serves_bytes(client: AsyncClient, file_with_image):
+    fid = file_with_image
+    qs = sign_asset_path(fid, "chart.png")
+    resp = await client.get(f"/files/{fid}/assets/raw/chart.png?{qs}")
+    assert resp.status_code == 200
+    assert resp.content == base64.b64decode(PNG_B64)
+
+
+async def test_missing_signature_forbidden(client: AsyncClient, file_with_image):
+    fid = file_with_image
+    resp = await client.get(f"/files/{fid}/assets/raw/chart.png")
+    assert resp.status_code == 403
+
+
+async def test_tampered_signature_forbidden(client: AsyncClient, file_with_image):
+    fid = file_with_image
+    qs = _tamper(sign_asset_path(fid, "chart.png"))
+    resp = await client.get(f"/files/{fid}/assets/raw/chart.png?{qs}")
+    assert resp.status_code == 403
+
+
+async def test_expired_signature_forbidden(client: AsyncClient, file_with_image):
+    fid = file_with_image
+    qs = sign_asset_path(fid, "chart.png", ttl_seconds=-10)
+    resp = await client.get(f"/files/{fid}/assets/raw/chart.png?{qs}")
+    assert resp.status_code == 403
+
+
+async def test_cross_file_signature_forbidden(client: AsyncClient, file_with_image):
+    # A signature minted for a different file must not unlock this file's asset.
+    fid = file_with_image
+    qs = sign_asset_path(fid + 12345, "chart.png")
+    resp = await client.get(f"/files/{fid}/assets/raw/chart.png?{qs}")
+    assert resp.status_code == 403
+
+
+async def test_no_existence_oracle_for_unsigned_request(client: AsyncClient, file_with_image):
+    # An unsigned request for a non-existent asset must also 403, not 404, so the
+    # endpoint cannot be walked to discover which filenames exist.
+    fid = file_with_image
+    resp = await client.get(f"/files/{fid}/assets/raw/does-not-exist.png")
+    assert resp.status_code == 403

--- a/backend/tests/test_services/test_asset_resolver.py
+++ b/backend/tests/test_services/test_asset_resolver.py
@@ -19,7 +19,12 @@ class TestFileAssetResolver:
         assert result is None
 
     def test_resolver_with_assets_url_mode(self):
-        """Test resolver returns URL paths for images, content for HTML."""
+        """Test resolver returns absolute signed URLs for images, content for HTML."""
+        from urllib.parse import parse_qs, urlparse
+
+        from aris.asset_signing import verify_asset_signature
+        from aris.config import settings
+
         assets = {
             "test.html": ("<div>Test HTML</div>", "plain"),
             "chart.png": ("base64data", "plain"),
@@ -31,8 +36,12 @@ class TestFileAssetResolver:
         assert resolver.resolve_asset("test.html") == "<div>Test HTML</div>"
         # Non-image non-HTML returns content
         assert resolver.resolve_asset("style.css") == "body { color: red; }"
-        # Image assets return URL paths
-        assert resolver.resolve_asset("chart.png") == "/files/42/assets/raw/chart.png"
+        # Image assets return an absolute backend URL carrying a valid signature so
+        # a plain <img> (which cannot send a bearer token) can still be authorized.
+        url = resolver.resolve_asset("chart.png")
+        assert url.startswith(f"{settings.BACKEND_URL}/files/42/assets/raw/chart.png?")
+        q = parse_qs(urlparse(url).query)
+        assert verify_asset_signature(42, "chart.png", int(q["exp"][0]), q["sig"][0]) is True
         assert resolver.resolve_asset("missing.js") is None
 
     def test_resolver_with_assets_standalone_mode(self):

--- a/backend/tests/test_services/test_asset_signing.py
+++ b/backend/tests/test_services/test_asset_signing.py
@@ -1,0 +1,66 @@
+"""Unit tests for HMAC-signed asset URL tokens (std-b4v9).
+
+The rendered-manuscript asset endpoint is fetched by plain browser <img> tags
+that cannot carry a bearer token, so access is proved by a short-lived HMAC
+signature bound to (file_id, filename, exp) instead of a session.
+"""
+
+import time
+
+from aris.asset_signing import (
+    ASSET_URL_TTL_SECONDS,
+    sign_asset_path,
+    verify_asset_signature,
+)
+
+
+def _parse(qs: str) -> tuple[int, str]:
+    parts = dict(p.split("=", 1) for p in qs.split("&"))
+    return int(parts["exp"]), parts["sig"]
+
+
+class TestAssetSigning:
+    def test_sign_then_verify_roundtrips(self):
+        exp, sig = _parse(sign_asset_path(42, "chart.png"))
+        assert verify_asset_signature(42, "chart.png", exp, sig) is True
+
+    def test_sign_emits_future_exp_and_sha256_sig(self):
+        exp, sig = _parse(sign_asset_path(1, "a.png"))
+        assert exp > int(time.time())
+        assert len(sig) == 64  # sha256 hex digest
+
+    def test_tampered_signature_fails(self):
+        exp, sig = _parse(sign_asset_path(42, "chart.png"))
+        flipped = sig[:-1] + ("0" if sig[-1] != "0" else "1")
+        assert verify_asset_signature(42, "chart.png", exp, flipped) is False
+
+    def test_wrong_file_id_fails(self):
+        # A token minted for file 42 must not verify for file 43 (cross-file replay).
+        exp, sig = _parse(sign_asset_path(42, "chart.png"))
+        assert verify_asset_signature(43, "chart.png", exp, sig) is False
+
+    def test_wrong_filename_fails(self):
+        # A token for chart.png must not unlock a different asset on the same file.
+        exp, sig = _parse(sign_asset_path(42, "chart.png"))
+        assert verify_asset_signature(42, "secret.png", exp, sig) is False
+
+    def test_expired_token_fails(self):
+        exp, sig = _parse(sign_asset_path(42, "chart.png"))
+        assert verify_asset_signature(42, "chart.png", exp, sig, now=exp + 1) is False
+
+    def test_valid_at_expiry_boundary(self):
+        exp, sig = _parse(sign_asset_path(42, "chart.png"))
+        assert verify_asset_signature(42, "chart.png", exp, sig, now=exp) is True
+
+    def test_empty_signature_fails(self):
+        exp, _ = _parse(sign_asset_path(42, "chart.png"))
+        assert verify_asset_signature(42, "chart.png", exp, "") is False
+
+    def test_negative_ttl_produces_already_expired_token(self):
+        # Used by the endpoint tests to exercise the expiry branch over HTTP.
+        exp, sig = _parse(sign_asset_path(42, "chart.png", ttl_seconds=-10))
+        assert exp < int(time.time())
+        assert verify_asset_signature(42, "chart.png", exp, sig) is False
+
+    def test_default_ttl_is_bounded(self):
+        assert 300 <= ASSET_URL_TTL_SECONDS <= 3600

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -28,6 +28,8 @@ services:
       - ALEMBIC_DB_URL_LOCAL=postgresql://postgres:postgres@postgres:5432/${DB_NAME}
       - DB_URL_LOCAL=postgresql+asyncpg://postgres:postgres@postgres:5432/${DB_NAME}
       - ENV=${ENV:-LOCAL}
+      # Browser-facing backend origin for signed image-asset URLs in rendered docs.
+      - BACKEND_URL=http://localhost:${BACKEND_PORT}
       - MULTIPLAYER_HOST=localhost
       - MULTIPLAYER_PORT=${MULTIPLAYER_PORT}
       - FRONTEND_PORT=${FRONTEND_PORT}


### PR DESCRIPTION
## What

`GET /files/{file_id}/assets/raw/{filename}` served **any** file's uploaded assets to **anonymous** callers (`file_id` is a sequential int, so trivially enumerable). It was public on purpose: rendered-manuscript `<img>` tags load without a bearer token. It now requires a short-lived **HMAC signature** the renderer mints, downstream of the VIEW check the caller already passed.

Follows the [three-expert consensus](https://github.com/aris-pub/studio) (security + architecture + CTO): **option (a), signed expiring URLs**, not the blob-proxy (memory + no-JS cost) and not a published-flag (doesn't exist yet, and doesn't fix the private-draft case).

## Changes
- **`aris/asset_signing.py`** (new): `sign`/`verify`, HMAC-SHA256 over `file_id:filename:exp`, constant-time compare, 1h TTL. Reuses `JWT_SECRET_KEY` for now (dedicated `ASSET_SIGNING_SECRET` is std-rn9e).
- **`asset_resolver.py`**: emit an **absolute, signed** backend URL. The old root-relative URL also resolved against the Netlify SPA on the split-origin deploy and 404'd, so this **also fixes broken manuscript images** (std-eo8s).
- **`get_asset_raw`**: verify the signature **before any DB lookup** (403 on missing/bad/expired) — also closes the 200-vs-404 filename oracle.
- **`BACKEND_URL`** config: default `localhost:8000`, dev compose `http://localhost:${BACKEND_PORT}`, prod `fly.toml` → `https://aris-backend.fly.dev`.
- **`Referrer-Policy: no-referrer`** middleware so signed URLs can't leak via `Referer`.
- Cleanups: dropped the false "public preprint access without authentication" API metadata claim; corrected the `FileStatus` docstring.

## Tests (TDD — written first, confirmed red, then implemented)
- 10 signing unit tests (round-trip, tamper, cross-file replay, wrong filename, expiry boundary, empty sig)
- 6 endpoint tests (valid→200, missing/tampered/expired/cross-file→403, no-existence-oracle)
- Updated the resolver emission test
- **Full backend suite: 855 passed, 0 failures.** ruff + mypy clean.

## Follow-ups (filed, not in this PR)
- **std-rn9e** — split onto a dedicated `ASSET_SIGNING_SECRET` (rotate asset URLs without logging everyone out)
- **std-uwqm** — add `BACKEND_URL` to `preview.yml` (left out: OAuth token lacks `workflow` scope; preview images fall back to the localhost default until then)

Closes std-b4v9
Closes std-eo8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)