### PR TITLE
feat(security): authenticate the LSP WebSocket + cap concurrent sessions

### DIFF
--- a/backend/aris/config.py
+++ b/backend/aris/config.py
@@ -65,6 +65,18 @@ class Settings(BaseSettings):
     )
     """Expiration time in minutes for JWT refresh tokens (default: 129600 = 90 days)."""
 
+    LSP_MAX_CONCURRENT_SESSIONS: int = Field(
+        20, json_schema_extra={"env": "LSP_MAX_CONCURRENT_SESSIONS"}
+    )
+    """Global cap on concurrent LSP WebSocket sessions. Each spawns a ~100MB node
+    subprocess, so this bounds total memory. Tune to the backend instance size."""
+
+    LSP_MAX_SESSIONS_PER_USER: int = Field(
+        3, json_schema_extra={"env": "LSP_MAX_SESSIONS_PER_USER"}
+    )
+    """Per-user cap on concurrent LSP sessions (one per open editor, plus a spare
+    tab), so a single account cannot exhaust the global pool."""
+
     TEST_USER_EMAIL: str = Field("", json_schema_extra={"env": "TEST_USER_EMAIL"})
     """Test user email for visual/e2e tests. Optional: only read on deploy-preview
     origins (see routes/auth.py), never on prod, so it must not be a required field

--- a/backend/aris/routes/lsp.py
+++ b/backend/aris/routes/lsp.py
@@ -117,12 +117,22 @@ class LSPProxy:
             logger.info(f"Spawned LSP server process (PID: {self.process.pid})")
             self.running = True
 
-            # Start bidirectional proxy
-            await asyncio.gather(
-                self._proxy_websocket_to_stdin(),
-                self._proxy_stdout_to_websocket(),
-                self._log_stderr(),
-            )
+            # Run the bidirectional proxy, but return as soon as ANY side finishes
+            # (normally the client disconnecting, which ends _proxy_websocket_to_stdin).
+            # gather() would instead wait for all three, and _proxy_stdout_to_websocket
+            # can block indefinitely on `process.stdout.read()` after the client is gone,
+            # so start() would never return and the session slot (released by the caller's
+            # finally) would leak until the per-user cap is hit.
+            tasks = [
+                asyncio.create_task(self._proxy_websocket_to_stdin()),
+                asyncio.create_task(self._proxy_stdout_to_websocket()),
+                asyncio.create_task(self._log_stderr()),
+            ]
+            _done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            self.running = False
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
 
         except Exception as e:
             logger.error(f"LSP proxy error: {e}", exc_info=True)

--- a/backend/aris/routes/lsp.py
+++ b/backend/aris/routes/lsp.py
@@ -9,11 +9,75 @@ from typing import Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from aris.config import settings
+from aris.jwt import decode_token
 from aris.logging_config import get_logger
 
 
 logger = get_logger(__name__)
 router = APIRouter()
+
+# The browser passes the access JWT as a WebSocket subprotocol, ["lsp", <token>],
+# because an <img>/WebSocket cannot send an Authorization header. Verifying it
+# during the handshake lets us reject before accept(), so an unauthenticated
+# client never gets an accepted socket, let alone a subprocess.
+LSP_SUBPROTOCOL = "lsp"
+
+# Reject any inbound frame larger than this before forwarding it to the language
+# server, so one huge frame cannot amplify into a parser memory/CPU spike.
+MAX_LSP_FRAME_BYTES = 512 * 1024
+
+# In-memory concurrency registry. The asyncio loop is single-threaded, so as long
+# as no await sits between the check and the increment in _try_acquire_lsp_slot,
+# a plain int + dict need no lock.
+_active_global = 0
+_active_per_user: dict[int, int] = {}
+
+
+def _extract_lsp_user_id(websocket: WebSocket) -> Optional[int]:
+    """Return the authenticated user id from the ["lsp", <token>] subprotocol.
+
+    Returns None (caller rejects the handshake) for a missing/malformed
+    subprotocol, an invalid or expired access token, a refresh token, or a token
+    with no numeric subject. Pure and sync so the auth contract is unit-testable
+    without standing up a socket.
+    """
+    protocols = websocket.scope.get("subprotocols") or []
+    if len(protocols) < 2 or protocols[0] != LSP_SUBPROTOCOL:
+        return None
+    payload = decode_token(protocols[1])
+    if not payload or payload.get("type") == "refresh":
+        return None
+    sub = payload.get("sub")
+    if sub is None:
+        return None
+    try:
+        return int(sub)
+    except (TypeError, ValueError):
+        return None
+
+
+def _try_acquire_lsp_slot(user_id: int) -> bool:
+    """Reserve a session slot if under both the global and per-user caps."""
+    global _active_global
+    if _active_global >= settings.LSP_MAX_CONCURRENT_SESSIONS:
+        return False
+    if _active_per_user.get(user_id, 0) >= settings.LSP_MAX_SESSIONS_PER_USER:
+        return False
+    _active_global += 1
+    _active_per_user[user_id] = _active_per_user.get(user_id, 0) + 1
+    return True
+
+
+def _release_lsp_slot(user_id: int) -> None:
+    """Release a previously acquired slot. Floored so a double-release is safe."""
+    global _active_global
+    _active_global = max(0, _active_global - 1)
+    remaining = _active_per_user.get(user_id, 0) - 1
+    if remaining <= 0:
+        _active_per_user.pop(user_id, None)
+    else:
+        _active_per_user[user_id] = remaining
 
 
 class LSPProxy:
@@ -70,6 +134,12 @@ class LSPProxy:
             while self.running:
                 # Receive JSON-RPC message from WebSocket
                 data = await self.websocket.receive_text()
+
+                # Guard against an oversized frame amplifying into the parser.
+                if len(data.encode("utf-8")) > MAX_LSP_FRAME_BYTES:
+                    logger.warning("Rejecting oversized LSP frame")
+                    self.running = False
+                    break
 
                 if not self.process or not self.process.stdin:
                     break
@@ -185,16 +255,31 @@ class LSPProxy:
 async def lsp_websocket(websocket: WebSocket):
     """WebSocket endpoint for LSP communication.
 
-    Accepts WebSocket connections from the browser and proxies LSP
-    JSON-RPC messages to/from the stdio-based RSM LSP server.
+    Proxies LSP JSON-RPC between the browser and the stdio RSM LSP server. Because
+    each connection spawns a node subprocess, nothing is spent until the caller is
+    authenticated (via the ["lsp", <access-jwt>] subprotocol, checked before the
+    handshake is accepted) and a concurrency slot is free.
     """
-    await websocket.accept()
-    logger.info("LSP WebSocket connection accepted")
+    user_id = _extract_lsp_user_id(websocket)
+    if user_id is None:
+        # Reject during the handshake: no accepted socket, no subprocess.
+        await websocket.close(code=1008)
+        logger.info("LSP WebSocket rejected: unauthenticated")
+        return
+
+    if not _try_acquire_lsp_slot(user_id):
+        await websocket.accept(subprotocol=LSP_SUBPROTOCOL)
+        await websocket.close(code=1013)  # try again later
+        logger.warning(f"LSP WebSocket rejected: session cap reached (user {user_id})")
+        return
+
+    await websocket.accept(subprotocol=LSP_SUBPROTOCOL)
+    logger.info(f"LSP WebSocket connection accepted (user {user_id})")
 
     proxy = LSPProxy(websocket)
-
     try:
         await proxy.start()
     finally:
         await proxy.cleanup()
-        logger.info("LSP WebSocket connection closed")
+        _release_lsp_slot(user_id)
+        logger.info(f"LSP WebSocket connection closed (user {user_id})")

--- a/backend/tests/test_routes/test_lsp_auth.py
+++ b/backend/tests/test_routes/test_lsp_auth.py
@@ -6,8 +6,10 @@ passed as a WebSocket subprotocol ["lsp", <token>] so it never lands in a URL or
 access log, and it is checked during the handshake before the socket is accepted.
 """
 
+import asyncio
 import time
 
+from fastapi import WebSocketDisconnect
 from jose import jwt as jose_jwt
 
 from aris import jwt as jwt_helpers
@@ -167,3 +169,63 @@ class TestLspEndpointWiring:
         # slot released after the session ends
         assert lsp_module._active_global == 0
         assert 42 not in lsp_module._active_per_user
+
+
+class TestLspProxyReleasesOnDisconnect:
+    """start() must return when the client disconnects even if the LSP process
+    stdout blocks, so the caller's finally releases the session slot. Without the
+    fix (plain asyncio.gather) start() hangs on the blocking stdout read and the
+    slot leaks until the per-user cap is hit (std-5smn)."""
+
+    async def test_start_returns_on_disconnect_despite_blocking_stdout(self, monkeypatch):
+        class _WS:
+            scope = {"subprotocols": ["lsp"]}
+
+            async def receive_text(self):
+                raise WebSocketDisconnect()
+
+            async def send_text(self, _msg):
+                pass
+
+            async def close(self, code=1000):
+                pass
+
+        class _Blocking:
+            async def read(self, _n):
+                await asyncio.sleep(3600)
+
+            async def readline(self):
+                await asyncio.sleep(3600)
+
+        class _Stdin:
+            def write(self, _b):
+                pass
+
+            async def drain(self):
+                pass
+
+        class _Proc:
+            pid = 4242
+            returncode = None
+            stdin = _Stdin()
+            stdout = _Blocking()
+            stderr = _Blocking()
+
+            def terminate(self):
+                pass
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                return 0
+
+        async def _fake_exec(*_args, **_kwargs):
+            return _Proc()
+
+        monkeypatch.setattr(lsp_module.os.path, "exists", lambda _p: True)
+        monkeypatch.setattr(lsp_module.asyncio, "create_subprocess_exec", _fake_exec)
+
+        proxy = LSPProxy(_WS())
+        # Would hang here (and TimeoutError) without the FIRST_COMPLETED fix.
+        await asyncio.wait_for(proxy.start(), timeout=5)

--- a/backend/tests/test_routes/test_lsp_auth.py
+++ b/backend/tests/test_routes/test_lsp_auth.py
@@ -1,0 +1,169 @@
+"""Auth and concurrency-cap tests for the LSP WebSocket (std-5smn).
+
+/ws/lsp spawns a node subprocess per connection, so it must prove the caller is
+logged in and cap concurrent sessions before spending anything. The access JWT is
+passed as a WebSocket subprotocol ["lsp", <token>] so it never lands in a URL or
+access log, and it is checked during the handshake before the socket is accepted.
+"""
+
+import time
+
+from jose import jwt as jose_jwt
+
+from aris import jwt as jwt_helpers
+from aris.config import settings
+from aris.routes import lsp as lsp_module
+from aris.routes.lsp import (
+    LSPProxy,
+    _extract_lsp_user_id,
+    _release_lsp_slot,
+    _try_acquire_lsp_slot,
+    lsp_websocket,
+)
+
+
+class _FakeWS:
+    def __init__(self, subprotocols):
+        self.scope = {"subprotocols": subprotocols}
+
+
+class _RecordingWS:
+    """A minimal WebSocket stand-in that records accept/close instead of using a socket."""
+
+    def __init__(self, subprotocols):
+        self.scope = {"subprotocols": subprotocols}
+        self.accepted_subprotocol = "UNSET"
+        self.closed_code = None
+
+    async def accept(self, subprotocol=None):
+        self.accepted_subprotocol = subprotocol
+
+    async def close(self, code=1000):
+        self.closed_code = code
+
+
+def _access(user_id: int) -> str:
+    return jwt_helpers.create_access_token({"sub": str(user_id)})
+
+
+class TestExtractLspUserId:
+    def test_valid_access_token_returns_user_id(self):
+        assert _extract_lsp_user_id(_FakeWS(["lsp", _access(7)])) == 7
+
+    def test_missing_subprotocols_returns_none(self):
+        assert _extract_lsp_user_id(_FakeWS([])) is None
+        assert _extract_lsp_user_id(_FakeWS(None)) is None
+
+    def test_marker_without_token_returns_none(self):
+        assert _extract_lsp_user_id(_FakeWS(["lsp"])) is None
+
+    def test_wrong_marker_returns_none(self):
+        assert _extract_lsp_user_id(_FakeWS(["notlsp", _access(1)])) is None
+
+    def test_garbage_token_returns_none(self):
+        assert _extract_lsp_user_id(_FakeWS(["lsp", "not-a-jwt"])) is None
+
+    def test_refresh_token_rejected(self):
+        refresh = jwt_helpers.create_refresh_token({"sub": "5"})
+        assert _extract_lsp_user_id(_FakeWS(["lsp", refresh])) is None
+
+    def test_expired_token_rejected(self):
+        payload = {"sub": "5", "exp": int(time.time()) - 10}
+        tok = jose_jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+        assert _extract_lsp_user_id(_FakeWS(["lsp", tok])) is None
+
+    def test_token_without_sub_rejected(self):
+        payload = {"exp": int(time.time()) + 60}
+        tok = jose_jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+        assert _extract_lsp_user_id(_FakeWS(["lsp", tok])) is None
+
+
+class TestLspConcurrencyCaps:
+    def setup_method(self):
+        lsp_module._active_global = 0
+        lsp_module._active_per_user.clear()
+
+    def teardown_method(self):
+        lsp_module._active_global = 0
+        lsp_module._active_per_user.clear()
+
+    def test_per_user_cap_rejects_excess(self, monkeypatch):
+        monkeypatch.setattr(settings, "LSP_MAX_SESSIONS_PER_USER", 2)
+        monkeypatch.setattr(settings, "LSP_MAX_CONCURRENT_SESSIONS", 100)
+        assert _try_acquire_lsp_slot(1) is True
+        assert _try_acquire_lsp_slot(1) is True
+        assert _try_acquire_lsp_slot(1) is False  # third for same user
+        assert _try_acquire_lsp_slot(2) is True   # a different user is unaffected
+
+    def test_global_cap_rejects_excess(self, monkeypatch):
+        monkeypatch.setattr(settings, "LSP_MAX_SESSIONS_PER_USER", 100)
+        monkeypatch.setattr(settings, "LSP_MAX_CONCURRENT_SESSIONS", 2)
+        assert _try_acquire_lsp_slot(1) is True
+        assert _try_acquire_lsp_slot(2) is True
+        assert _try_acquire_lsp_slot(3) is False  # global ceiling
+
+    def test_release_frees_a_slot(self, monkeypatch):
+        monkeypatch.setattr(settings, "LSP_MAX_SESSIONS_PER_USER", 1)
+        monkeypatch.setattr(settings, "LSP_MAX_CONCURRENT_SESSIONS", 100)
+        assert _try_acquire_lsp_slot(1) is True
+        assert _try_acquire_lsp_slot(1) is False
+        _release_lsp_slot(1)
+        assert _try_acquire_lsp_slot(1) is True
+
+    def test_release_is_floored_and_cleans_up(self, monkeypatch):
+        monkeypatch.setattr(settings, "LSP_MAX_SESSIONS_PER_USER", 5)
+        monkeypatch.setattr(settings, "LSP_MAX_CONCURRENT_SESSIONS", 5)
+        _release_lsp_slot(99)  # release with nothing held must not go negative
+        assert lsp_module._active_global == 0
+        assert 99 not in lsp_module._active_per_user
+
+
+class TestLspEndpointWiring:
+    """The endpoint must never spawn a subprocess without auth + a free slot."""
+
+    def setup_method(self):
+        lsp_module._active_global = 0
+        lsp_module._active_per_user.clear()
+
+    def teardown_method(self):
+        lsp_module._active_global = 0
+        lsp_module._active_per_user.clear()
+
+    def _no_spawn_proxy(self, monkeypatch):
+        started = {"n": 0}
+
+        async def fake_start(_self):
+            started["n"] += 1
+
+        async def fake_cleanup(_self):
+            pass
+
+        monkeypatch.setattr(LSPProxy, "start", fake_start)
+        monkeypatch.setattr(LSPProxy, "cleanup", fake_cleanup)
+        return started
+
+    async def test_unauthenticated_rejected_before_accept(self, monkeypatch):
+        started = self._no_spawn_proxy(monkeypatch)
+        ws = _RecordingWS([])  # no token offered
+        await lsp_websocket(ws)
+        assert ws.closed_code == 1008
+        assert ws.accepted_subprotocol == "UNSET"  # never accepted
+        assert started["n"] == 0  # never reached the spawn path
+
+    async def test_cap_reached_rejected_with_1013_no_spawn(self, monkeypatch):
+        started = self._no_spawn_proxy(monkeypatch)
+        monkeypatch.setattr(settings, "LSP_MAX_CONCURRENT_SESSIONS", 0)
+        ws = _RecordingWS(["lsp", _access(1)])
+        await lsp_websocket(ws)
+        assert ws.closed_code == 1013
+        assert started["n"] == 0
+
+    async def test_authenticated_accepts_spawns_and_releases(self, monkeypatch):
+        started = self._no_spawn_proxy(monkeypatch)
+        ws = _RecordingWS(["lsp", _access(42)])
+        await lsp_websocket(ws)
+        assert ws.accepted_subprotocol == "lsp"
+        assert started["n"] == 1
+        # slot released after the session ends
+        assert lsp_module._active_global == 0
+        assert 42 not in lsp_module._active_per_user

--- a/frontend/src/composables/useLSPClient.js
+++ b/frontend/src/composables/useLSPClient.js
@@ -12,12 +12,16 @@ import { LSPClient, languageServerExtensions } from "@codemirror/lsp-client";
  * Create WebSocket transport for LSP communication.
  *
  * @param {string} uri - WebSocket URI (e.g., "ws://localhost:8080/ws/lsp")
+ * @param {string} [token] - Access JWT, sent as the ["lsp", token] subprotocol.
+ *   A browser cannot set an Authorization header on a WebSocket, so the backend
+ *   reads the token from Sec-WebSocket-Protocol and verifies it during the
+ *   handshake (before accepting the socket or spawning the LSP process).
  * @returns {Promise<Object>} Transport object with send/subscribe/unsubscribe methods
  */
-function createWebSocketTransport(uri) {
+function createWebSocketTransport(uri, token) {
   return new Promise((resolve, reject) => {
     const handlers = [];
-    const socket = new WebSocket(uri);
+    const socket = new WebSocket(uri, token ? ["lsp", token] : ["lsp"]);
 
     socket.onopen = () => {
       resolve({
@@ -130,8 +134,17 @@ export function createIndexReadyTracker() {
   return { handleMessage, awaitReady, reset };
 }
 
-export function useLSPClient({ serverUrl, documentUri }) {
+export function useLSPClient({ serverUrl, documentUri, token }) {
   const indexReady = createIndexReadyTracker();
+
+  // Resolve the auth token fresh at connect time (it may be a getter/ref so a
+  // refreshed access token is picked up on reconnect). Accepts a string, a Vue
+  // ref, or a function.
+  function resolveToken() {
+    if (typeof token === "function") return token();
+    if (token && typeof token === "object" && "value" in token) return token.value;
+    return token;
+  }
   const client = ref(null);
   const plugin = ref(null);
   const transport = ref(null);
@@ -154,7 +167,7 @@ export function useLSPClient({ serverUrl, documentUri }) {
   async function connect() {
     try {
       // Create WebSocket transport (async)
-      transport.value = await createWebSocketTransport(serverUrl);
+      transport.value = await createWebSocketTransport(serverUrl, resolveToken());
 
       // Observe rsm/indexReady notifications alongside the LSP client's own
       // handling (the transport fans every message out to all subscribers), so

--- a/frontend/src/views/workspace/EditorCodeMirror.vue
+++ b/frontend/src/views/workspace/EditorCodeMirror.vue
@@ -74,6 +74,9 @@
   const lsp = useLSPClient({
     serverUrl: lspServerUrl,
     documentUri: computed(() => `file:///${file.value?.id || "untitled"}.rsm`),
+    // Read fresh at connect time so a refreshed access token is used on reconnect.
+    // The backend authenticates the LSP socket via the ["lsp", token] subprotocol.
+    token: () => localStorage.getItem("accessToken"),
   });
 
   // User info for awareness


### PR DESCRIPTION
## What

`/ws/lsp` accepted **any anonymous** connection and spawned a `node` LSP subprocess per socket, so anyone could exhaust host memory (DoS) and feed untrusted input to the RSM language server. It now requires the caller's access JWT, passed as the **`["lsp", <token>]` WebSocket subprotocol** (a browser can't set an `Authorization` header on a WebSocket), verified **during the handshake, before `accept()`** — so an unauthenticated client never gets an accepted socket, let alone a subprocess.

Design from security + architecture expert review. The one split (subprotocol vs first-frame transport) went to the security recommendation: the token rides in a header (not the URL/access logs) and lets us reject during the handshake.

## Changes
- **`lsp.py`**: `_extract_lsp_user_id` verifies the access JWT from the subprotocol (rejects refresh / expired / no-sub); reject-before-accept (1008); **per-user (3) + global (20)** concurrency caps with fast **1013** reject and slot released in a `finally`; subprocess spawns **only after** auth + a free slot; oversized inbound frames rejected.
- **config**: `LSP_MAX_CONCURRENT_SESSIONS`, `LSP_MAX_SESSIONS_PER_USER`.
- **frontend**: `useLSPClient` sends `localStorage` `accessToken` as the `["lsp", token]` subprotocol, read fresh at connect (picks up refreshed tokens on reconnect).

Reuses the access JWT for now (LSP isn't file-scoped, so a minted token buys little today); a dedicated short-lived `scope=lsp` token is a follow-up (**std-o87u**).

## Tests (TDD — written first, confirmed red)
- 8 auth-extract (valid / missing / marker-only / wrong-marker / garbage / refresh / expired / no-sub)
- 4 concurrency-cap (per-user, global, release, floored)
- 3 endpoint-wiring (unauth → 1008 no spawn; cap → 1013 no spawn; authed → accept + spawn + release) — assert **no node subprocess** on the reject paths
- frontend LSP unit tests green
- **Full backend suite: 870 passed.** ruff + mypy + eslint clean.

Closes std-5smn

🤖 Generated with [Claude Code](https://claude.com/claude-code)