### PR TITLE
fix(brand): serve logos from pinned jsDelivr URL, not the backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ MULTIPLAYER_PORT=1234
 VITE_MULTIPLAYER_URL=ws://localhost:1234
 VITE_MULTIPLAYER_TEST_URL=ws://localhost:1235
 
+# Brand assets (logos). Optional: consumers default in code to a commit-pinned
+# public jsDelivr URL over the aris-pub/brand repo, so this is a no-op unless you
+# point it at another host (e.g. https://brand.aris.pub/logos). The value must end
+# at the directory that contains the per-product logo folders (.../logos).
+VITE_BRAND_BASE_URL=
+
 # Site configuration
 SITE_PORT=2999
 SITE_CONTAINER_PORT=3000

--- a/frontend/src/components/base/Logo.vue
+++ b/frontend/src/components/base/Logo.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup>
-  import { computed, inject } from "vue";
+  import { computed } from "vue";
 
   const props = defineProps({
     type: {
@@ -24,13 +24,16 @@
     },
   });
 
-  const api = inject("api");
-
-  const logomarkUrl = computed(() => {
-    const base = api.defaults.baseURL;
-    // Always use the logomark, never the combined logotype
-    return `${base}/brand/logos/studio/studio-logo-64.svg`;
-  });
+  // Brand assets load from one canonical BRAND_BASE_URL, not from the backend
+  // origin: the API scales to zero, so the logo must not depend on it being awake.
+  // Default to a commit-pinned public jsDelivr URL over the aris-pub/brand repo so
+  // a logo change is a deliberate pin bump, never an unreviewed auto-swap. Override
+  // with VITE_BRAND_BASE_URL (e.g. a brand.aris.pub host) at build time.
+  const BRAND_BASE_URL =
+    import.meta.env.VITE_BRAND_BASE_URL ||
+    "https://cdn.jsdelivr.net/gh/aris-pub/brand@d64fba720fa2eaef0b8a07d648d7e1c926e818e3/logos";
+  // Always use the logomark, never the combined logotype
+  const logomarkUrl = `${BRAND_BASE_URL}/studio/studio-logo-64.svg`;
 
   const logoClass = computed(() => {
     return `logo logo--${props.type} ${props.class}`.trim();

--- a/frontend/src/tests/components/Logo.test.js
+++ b/frontend/src/tests/components/Logo.test.js
@@ -2,22 +2,19 @@ import { mount } from "@vue/test-utils";
 import { describe, it, expect } from "vitest";
 import Logo from "@/components/base/Logo.vue";
 
-const mockApi = {
-  defaults: {
-    baseURL: import.meta.env.VITE_API_BASE_URL,
-  },
+// Logo builds its src from BRAND_BASE_URL (VITE_BRAND_BASE_URL or a commit-pinned
+// jsDelivr default). Assert the composed path, not the exact pinned base, so a
+// deliberate pin bump does not break the test.
+const LOGO_SUFFIX = "/logos/studio/studio-logo-64.svg";
+const expectLogoSrc = (img) => {
+  const src = img.attributes("src");
+  expect(src).toMatch(/^https:\/\//);
+  expect(src.endsWith(LOGO_SUFFIX)).toBe(true);
 };
 
 describe("Logo.vue", () => {
   const createWrapper = (props = {}) => {
-    return mount(Logo, {
-      props,
-      global: {
-        provide: {
-          api: mockApi,
-        },
-      },
-    });
+    return mount(Logo, { props });
   };
 
   it("renders small logo by default", () => {
@@ -30,9 +27,7 @@ describe("Logo.vue", () => {
     expect(logoDiv.classes()).toContain("logo--small");
 
     expect(img.exists()).toBe(true);
-    expect(img.attributes("src")).toBe(
-      `${mockApi.defaults.baseURL}/brand/logos/studio/studio-logo-64.svg`
-    );
+    expectLogoSrc(img);
     expect(img.attributes("alt")).toBe("RSM Studio logo");
     expect(img.classes()).toContain("logo__mark");
   });
@@ -44,9 +39,7 @@ describe("Logo.vue", () => {
     const text = wrapper.find(".logo__text");
 
     expect(logoDiv.classes()).toContain("logo--full");
-    expect(img.attributes("src")).toBe(
-      `${mockApi.defaults.baseURL}/brand/logos/studio/studio-logo-64.svg`
-    );
+    expectLogoSrc(img);
     expect(text.exists()).toBe(true);
     expect(text.text()).toBe("S");
   });
@@ -57,9 +50,7 @@ describe("Logo.vue", () => {
     const img = wrapper.find("img");
 
     expect(logoDiv.classes()).toContain("logo--gray");
-    expect(img.attributes("src")).toBe(
-      `${mockApi.defaults.baseURL}/brand/logos/studio/studio-logo-64.svg`
-    );
+    expectLogoSrc(img);
   });
 
   it("accepts custom alt text", () => {


### PR DESCRIPTION
## Problem
The sidebar logo and the rendered-manuscript logo (which reuses `<Logo>`) built their URL from the backend origin: `${api.baseURL}/brand/logos/studio/studio-logo-64.svg`. The prod backend does not serve `/brand` (the parent `.dockerignore` excludes `brand/`, the `Dockerfile` never `COPY`s it, and `main.py` only mounts `/brand` when the dir exists), so every `/brand/*` 404'd and both logos broke in prod.

## Fix
`Logo.vue` now reads a single `BRAND_BASE_URL`, defaulting in code to a **commit-pinned public jsDelivr URL** over `aris-pub/brand`:

```
https://cdn.jsdelivr.net/gh/aris-pub/brand@d64fba72…/logos/studio/studio-logo-64.svg
```

- In-code default → the prod frontend self-heals on its next Netlify build, **no dashboard/env change** needed.
- The logo no longer depends on the scale-to-zero backend being awake.
- The commit pin means a logo change is a deliberate bump (aligns with Head of Creative's review point), not an unreviewed auto-swap.
- `VITE_BRAND_BASE_URL` stays as an optional override for a future `brand.aris.pub` host.

Chosen after routing the serving-architecture question to Architecture, DevOps, and Head of Creative, who converged on a single canonical `BRAND_BASE_URL` backbone.

## Verification
- jsDelivr pinned URL: HTTP 200, `image/svg+xml`.
- `Logo.test.js`: 5/5 pass (assertions decoupled from the SHA). ESLint clean.

## Follow-ups (not in this PR)
Remove the now-dead backend `/brand` mount + `no-store`; fix `.gitmodules` submodule URL (`leotrs` → `aris-pub`); rsm `brand_assets.py` same drift (separate repo PR); brand palette color-of-record conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)