### PR TITLE
chore(brand): remove dead /brand backend mount, fix submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "brand"]
 	path = brand
-	url = https://github.com/leotrs/brand.git
+	url = https://github.com/aris-pub/brand.git

--- a/backend/main.py
+++ b/backend/main.py
@@ -445,7 +445,7 @@ async def _run_checkpoint_gc():
 @app.middleware("http")
 async def add_no_cache_headers(request, call_next):
     response = await call_next(request)
-    if request.url.path.startswith("/static") or request.url.path.startswith("/styles") or request.url.path.startswith("/brand"):
+    if request.url.path.startswith("/static") or request.url.path.startswith("/styles"):
         response.headers["Cache-Control"] = "no-store"
     # Signed asset URLs carry their token in the query string. Keep the full URL
     # out of the Referer header so a signed URL cannot leak to any third-party
@@ -514,26 +514,3 @@ if styles_dir:
     logger.info(f"Styles mounted successfully at /styles from {styles_dir}")
 else:
     logger.info(f"Styles directory not found. Tried paths: {styles_paths}")
-
-# Mount brand assets (only if directory exists)
-brand_paths = [
-    "../brand",  # When running from backend/ directory
-    "brand",     # When running from project root
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "brand")  # Absolute path fallback
-]
-
-brand_dir = None
-for path in brand_paths:
-    if os.path.exists(path):
-        brand_dir = path
-        break
-
-if brand_dir:
-    app.mount(
-        "/brand",
-        StaticFiles(directory=brand_dir),
-        name="brand"
-    )
-    logger.info(f"Brand assets mounted successfully at /brand from {brand_dir}")
-else:
-    logger.info(f"Brand directory not found. Tried paths: {brand_paths}")


### PR DESCRIPTION
Follow-up cleanup after #458 (frontend now serves brand logos from a pinned jsDelivr URL).

- **Remove the backend `/brand` StaticFiles mount** (`main.py`). It was only reachable when a local `brand/` dir existed; prod never had one, and nothing points at `/brand` anymore (the frontend `<Logo>` uses jsDelivr, and the server render path never injected a brand URL). A repo-wide grep confirms `main.py` was the sole reference.
- **Drop `/brand` from the `no-store` cache-control middleware** (kept `/static` and `/styles`).
- **Fix the brand submodule URL** in `.gitmodules`: `leotrs/brand` (personal fork) → `aris-pub/brand` (canonical).

No prod functional change: the mount was already dead in prod. Backend redeploy not required for correctness; it lands on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)