### PR TITLE
docs: fix RSM acronym to "Readable Science Markup"

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 RSM Studio is a web-native scientific publishing platform. FastAPI backend + Vue.js frontend
-for RSM (Readable Research Markup) manuscripts.
+for RSM (Readable Science Markup) manuscripts.
 
 ## Structure
 ```

--- a/docs/peer-review-preprint-mvp.md
+++ b/docs/peer-review-preprint-mvp.md
@@ -56,7 +56,7 @@ This document outlines the Minimum Viable Product (MVP) features for RSM Studio'
 ## Technical Architecture
 
 ### Document AST Integration
-The peer review system builds on RSM Studio's existing RSM (Readable Research Markup) rendering engine:
+The peer review system builds on RSM Studio's existing RSM (Readable Science Markup) rendering engine:
 
 - **AST Foundation**: Each document is parsed into an Abstract Syntax Tree that represents the semantic structure
 - **Node-based anchoring**: Comments are anchored to specific AST nodes rather than character positions

--- a/frontend/src/views/demo/demoData.js
+++ b/frontend/src/views/demo/demoData.js
@@ -63,7 +63,7 @@ We developed a proof-of-concept platform using\\:
 
   :-: **Backend**\\: FastAPI with PostgreSQL database
 
-  :-: **Document Format**\\: RSM (Readable Research Markup)
+  :-: **Document Format**\\: RSM (Readable Science Markup)
 
   :-: **Deployment**\\: Docker containers on cloud infrastructure
 


### PR DESCRIPTION
Part of the brand-consistency doc pass. "Readable Science Markup" is canonical across the repos (studio README, backend email templates, org vision + messaging). Three files still said "Readable **Research** Markup":

- `.claude/CLAUDE.md`
- `docs/peer-review-preprint-mvp.md`
- `frontend/src/views/demo/demoData.js` (the demo document's "Document Format" label)

Documentation/copy only, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)