### PR TITLE
fix(deploy): pin rsm to 1.5.1 (lsp fix) + correct version guard

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,9 +29,8 @@ COPY multi-player/ ./multi-player/
 ARG RSM_VERSION
 RUN git clone --depth 1 --branch "v${RSM_VERSION}" --recurse-submodules --shallow-submodules \
         https://github.com/aris-pub/rsm.git /rsm-src \
-    && GOT="$(node -p "require('/rsm-src/tree-sitter-rsm/package.json').version")" \
-    && [ "$GOT" = "${RSM_VERSION}" ] \
-       || { echo "rsm grammar version mismatch: got $GOT, expected ${RSM_VERSION}"; exit 1; }
+    && grep -q "^version = \"${RSM_VERSION}\"" /rsm-src/pyproject.toml \
+       || { echo "rsm version mismatch: /rsm-src/pyproject.toml is not ${RSM_VERSION}"; exit 1; }
 
 # Compile the tree-sitter-rsm native addon for linux (prebuilds may target a
 # different arch; binding.gyp may be absent, regenerate it).

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -28,7 +28,7 @@ kill_timeout = "30s"
   # vX.Y.Z (for rsm-lsp + the grammar) and pins rsm-lang==X.Y.Z from PyPI. Bump
   # this one value to move every built environment to a new rsm release together.
   [build.args]
-    RSM_VERSION = "1.5.0"
+    RSM_VERSION = "1.5.1"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
Follow-up to #467. Pins rsm to **1.5.1** (released with the rsm-lsp `highlights.scm` path fix, #84 in rsm) and fixes the build-time version guard to check rsm-lang's own version rather than the independently-versioned tree-sitter-rsm submodule.

Verified in prod: `/health` all-green including the lsp `services` check, rsm-lang 1.5.1 from PyPI, no `/rsm`, no baked `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)