### PR TITLE
fix: prod FRONTEND_URL + CI baked image from pinned rsm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,18 +29,9 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Clone RSM repository
-      run: |
-        cd ..
-        git clone --recurse-submodules https://github.com/aris-pub/rsm.git
-
-    - name: Prepare pristine rsm source for the build context
-      run: |
-        rsync -a --delete \
-          --exclude='.git' --exclude='.venv' --exclude='node_modules' \
-          --exclude='prebuilds' --exclude='build' --exclude='*.dylib' --exclude='*.so' \
-          --exclude='__pycache__' --exclude='.entrypoint-cache' \
-          ../rsm/ ./_rsm_ci/
+    - name: Read pinned RSM_VERSION
+      id: rsmver
+      run: echo "version=$(grep -oP 'RSM_VERSION = "\K[^"]+' backend/fly.toml)" >> "$GITHUB_OUTPUT"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
@@ -57,6 +48,8 @@ jobs:
       with:
         context: .
         file: docker/backend/Dockerfile.ci
+        build-args: |
+          RSM_VERSION=${{ steps.rsmver.outputs.version }}
         push: true
         tags: ghcr.io/${{ github.repository_owner }}/studio-backend:${{ github.sha }}
         cache-from: type=gha,scope=backend-ci

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -20,6 +20,11 @@ kill_timeout = "30s"
   # rather than in Fly secrets.
   BACKEND_URL = "https://aris-backend.fly.dev"
 
+  # Public origin of the frontend, used to build email links (verify-email,
+  # collaborator invites). Without it, config.py defaults to http://localhost:5173
+  # and prod emails point at localhost. Non-secret.
+  FRONTEND_URL = "https://app.rsm.studio"
+
 [build]
   dockerfile = "Dockerfile"
   build-target = "runtime"

--- a/docker/backend/Dockerfile.ci
+++ b/docker/backend/Dockerfile.ci
@@ -32,10 +32,14 @@ RUN curl -fL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# --- rsm source (pinned, pristine) ---
-# uv.lock pins rsm-lang as an editable install resolving to /workspace/rsm, so the
-# source must live there and must not be mounted over at runtime.
-COPY _rsm_ci /workspace/rsm
+# --- rsm source (pinned) ---
+# Clone rsm at the pinned version instead of COPYing a host-prepared tree, so CI
+# builds the SAME rsm the pinned prod image ships (not rsm HEAD) and no rsm
+# sibling is needed in the build context. uv.lock resolves rsm-lang editable to
+# /workspace/rsm, and tree-sitter-rsm / rsm-lsp are built from it below.
+ARG RSM_VERSION
+RUN git clone --depth 1 --branch "v${RSM_VERSION}" --recurse-submodules --shallow-submodules \
+    https://github.com/aris-pub/rsm.git /workspace/rsm
 
 WORKDIR /workspace/studio/backend
 


### PR DESCRIPTION
Two follow-ups to the studio-context/rsm-pin work.

**FRONTEND_URL** — set to `https://app.rsm.studio` in `fly.toml [env]`. It's passed raw into the verification + collaborator-invite emails, so prod's localhost default made those email links broken. (Post-deploy I'll exercise the email path to confirm the built link, not just the config value.)

**Dockerfile.ci** — now git-clones rsm at the pinned `RSM_VERSION` (read from `fly.toml`) instead of copying a host-prepared rsm HEAD tree, so the CI baked image bakes the same rsm prod ships. Verified locally: rsm 1.5.1 imports, binding loads, rsm-lsp built. Finishes std-cf10 for the CI baked image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)