### PR TITLE
chore(supervisord): remove the dead supervised [program:lsp] singleton

### DIFF
--- a/backend/aris/health.py
+++ b/backend/aris/health.py
@@ -234,7 +234,7 @@ async def check_supervisord_services() -> Dict[str, Any]:
             return {
                 "status": "healthy",
                 "response_time_ms": response_time,
-                "message": "All services running (backend, multiplayer, lsp)",
+                "message": "All services running (backend, multiplayer)",
             }
         else:
             error_msg = stderr.decode().strip() if stderr else stdout.decode().strip()

--- a/backend/tests/test_docker_config.py
+++ b/backend/tests/test_docker_config.py
@@ -63,11 +63,16 @@ class TestSupervisordConf:
             assert f"[{section}]" in self.conf
 
     def test_manages_all_services(self):
-        for service in ["backend", "multiplayer", "lsp"]:
+        for service in ["backend", "multiplayer"]:
             assert f"[program:{service}]" in self.conf
 
-    def test_lsp_points_to_correct_path(self):
-        assert "/app/rsm-lsp/dist/server.js" in self.conf
+    def test_lsp_not_supervised(self):
+        # The LSP is spawned per WebSocket session by the backend
+        # (aris/routes/lsp.py), not run as a supervised singleton, so there must
+        # be no [program:lsp] section (a comment mentioning it is fine).
+        assert not any(
+            line.strip() == "[program:lsp]" for line in self.conf.splitlines()
+        )
 
     def _multiplayer_env_line(self) -> str:
         """Return the `environment=...` line of the multiplayer program."""
@@ -196,7 +201,7 @@ class TestHealthCheck:
 
     def test_checks_all_services(self):
         checks = re.findall(r'check_service\s+"(\w+)"', self.script)
-        assert set(checks) == {"backend", "multiplayer", "lsp"}
+        assert set(checks) == {"backend", "multiplayer"}
 
     def test_no_lsp_exclusion_comment(self):
         assert "LSP excluded" not in self.script

--- a/docker/health-check.sh
+++ b/docker/health-check.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Health check script for multi-service container
-# Verifies that all services (backend, multiplayer, lsp) are running
+# Verifies that all supervised services (backend, multiplayer) are running.
+# The language server is spawned per WebSocket session by the backend, not
+# supervised, so there is nothing to check for it here.
 
 set -e
 
@@ -29,7 +31,6 @@ check_service() {
 FAILED=0
 check_service "backend" || FAILED=1
 check_service "multiplayer" || FAILED=1
-check_service "lsp" || FAILED=1
 
 if [ $FAILED -eq 0 ]; then
     echo "All services are healthy"

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -42,14 +42,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 priority=200
 
-[program:lsp]
-command=/usr/bin/node /app/rsm-lsp/dist/server.js --stdio
-directory=/app/rsm-lsp
-autostart=true
-autorestart=true
-startsecs=3
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-priority=300
+# No [program:lsp] here on purpose: the language server runs per WebSocket
+# session, spawned by the backend (aris/routes/lsp.py), not as a supervised
+# singleton. A standalone `server.js --stdio` reading empty stdin served no
+# traffic and only added a process that could flap the health check.


### PR DESCRIPTION
The supervised `[program:lsp]` ran `node server.js --stdio` on empty stdin and served **no traffic** — the backend spawns a fresh per-session lsp subprocess per WebSocket (`aris/routes/lsp.py`). The singleton only added a process that could flap the health check (it did, on rsm 1.5.0's highlights.scm crash). Removed from `supervisord.conf` + `health-check.sh`; `health.py` message + `test_docker_config` updated (now asserts lsp is *not* supervised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)