### PR TITLE
feat(ops): daily Postgres backups via GitHub Actions

### DIFF
--- a/.github/workflows/backup-health-check.yml
+++ b/.github/workflows/backup-health-check.yml
@@ -1,0 +1,67 @@
+name: Backup Health Check
+
+# Twice-daily check that a recent database backup artifact exists. Emails an
+# alert (Resend) and fails the run if the latest backup is missing or stale.
+# Modeled on the Press repo's backup-health-check.yml.
+
+on:
+  schedule:
+    # 9 AM and 9 PM UTC
+    - cron: '0 9,21 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+
+jobs:
+  check-backup-health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check last backup timestamp
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LATEST=$(gh api "repos/${{ github.repository }}/actions/artifacts" --paginate \
+            --jq '.artifacts[] | select(.name | startswith("studio_backup_")) | {name: .name, created_at: .created_at}' \
+            | jq -s 'sort_by(.created_at) | reverse | .[0]')
+
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+            echo "No backup artifacts found"
+            echo "alert=true" >> "$GITHUB_OUTPUT"
+            echo "reason=No studio_backup_* artifacts exist" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NAME=$(echo "$LATEST" | jq -r '.name')
+          CREATED=$(echo "$LATEST" | jq -r '.created_at')
+          CREATED_TS=$(date -d "$CREATED" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED" +%s)
+          AGE_HOURS=$(( ( $(date +%s) - CREATED_TS ) / 3600 ))
+          echo "Latest backup: $NAME (${AGE_HOURS}h old)"
+
+          if [ "$AGE_HOURS" -gt 48 ]; then
+            echo "alert=true" >> "$GITHUB_OUTPUT"
+            echo "reason=Last backup is ${AGE_HOURS}h old (created $CREATED)" >> "$GITHUB_OUTPUT"
+          else
+            echo "alert=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send alert email
+        if: steps.check.outputs.alert == 'true'
+        run: |
+          curl -sS -X POST 'https://api.resend.com/emails' \
+            -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "from": "${{ secrets.FROM_EMAIL }}",
+              "to": ["leo@leotrs.com"],
+              "subject": "⚠️ RSM Studio database backup alert",
+              "html": "<h2>Database backup alert</h2><p><strong>${{ steps.check.outputs.reason }}</strong></p><p><a href=\"https://github.com/${{ github.repository }}/actions/workflows/database-backup.yml\">Backup workflow</a> · <a href=\"https://github.com/${{ github.repository }}/actions\">Recent runs</a></p><p>Trigger a backup manually: <code>gh workflow run database-backup.yml</code></p>"
+            }'
+          echo "Alert email sent"
+          exit 1   # fail the run so the alert is visible in GitHub too
+
+      - name: Health check passed
+        if: steps.check.outputs.alert != 'true'
+        run: echo "Backup is fresh — no action needed"

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -1,0 +1,129 @@
+name: Database Backup
+
+# Daily pg_dump of the prod (Supabase) database, stored as a private GitHub
+# Actions artifact. Modeled on the Press repo's database-backup.yml. Bootstrap
+# phase: free, 30-day retention, last 7 kept. Graduate to Supabase Pro / external
+# storage as the user base grows.
+
+on:
+  schedule:
+    # Daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      backup_name:
+        description: 'Custom backup name (optional)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  actions: write   # cleanup job deletes old backup artifacts
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Install PostgreSQL client
+        run: |
+          # PostgreSQL 17 client to match the Supabase server version
+          sudo apt-get update
+          sudo apt-get install -y wget ca-certificates
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+
+      - name: Create database backup
+        env:
+          PGPASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          DB_HOST: ${{ secrets.DATABASE_HOST }}
+          DB_PORT: ${{ secrets.DATABASE_PORT }}
+          DB_NAME: ${{ secrets.DATABASE_NAME }}
+          DB_USER: ${{ secrets.DATABASE_USER }}
+        run: |
+          TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+          if [ -n "${{ github.event.inputs.backup_name }}" ]; then
+            BACKUP_NAME="${{ github.event.inputs.backup_name }}_${TIMESTAMP}"
+          else
+            BACKUP_NAME="studio_backup_${TIMESTAMP}"
+          fi
+          BACKUP_FILE="${BACKUP_NAME}.sql"
+
+          echo "Creating backup: $BACKUP_FILE"
+
+          # --schema=public: studio's application data lives in the public schema;
+          # skip Supabase-managed schemas (auth/storage/extensions) that the app
+          # user can't fully dump and that aren't studio's data.
+          pg_dump \
+            --host="$DB_HOST" \
+            --port="$DB_PORT" \
+            --username="$DB_USER" \
+            --dbname="$DB_NAME" \
+            --schema=public \
+            --no-password \
+            --no-owner \
+            --no-privileges \
+            --format=plain \
+            --file="$BACKUP_FILE"
+
+          if [ ! -s "$BACKUP_FILE" ]; then
+            echo "::error::Backup file is empty or missing"
+            exit 1
+          fi
+
+          echo "Backup created: $BACKUP_FILE ($(du -h "$BACKUP_FILE" | cut -f1))"
+
+          gzip "$BACKUP_FILE"
+          echo "Compressed: ${BACKUP_FILE}.gz ($(du -h "${BACKUP_FILE}.gz" | cut -f1))"
+
+          echo "BACKUP_FILE=${BACKUP_FILE}.gz" >> "$GITHUB_ENV"
+          echo "BACKUP_NAME=$BACKUP_NAME" >> "$GITHUB_ENV"
+
+      - name: Verify backup integrity + schema
+        run: |
+          gunzip -t "${{ env.BACKUP_FILE }}"
+          echo "gzip integrity OK"
+          # The dump must contain the core studio tables, else it is not a usable backup.
+          for table in users files; do
+            if ! gunzip -c "${{ env.BACKUP_FILE }}" | grep -qE "CREATE TABLE (public\.)?${table} "; then
+              echo "::error::Backup missing expected table: ${table}"
+              exit 1
+            fi
+          done
+          echo "Backup contains the expected studio schema (users, files)"
+
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BACKUP_NAME }}
+          path: ${{ env.BACKUP_FILE }}
+          retention-days: 30
+          compression-level: 0   # already gzipped
+
+  cleanup-old-backups:
+    runs-on: ubuntu-latest
+    needs: backup
+    if: success()
+    steps:
+      - name: Keep only the 7 most recent backup artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ARTIFACTS=$(gh api "repos/${{ github.repository }}/actions/artifacts" --paginate \
+            --jq '.artifacts[] | select(.name | startswith("studio_backup_")) | {id: .id, name: .name, created_at: .created_at}')
+          SORTED=$(echo "$ARTIFACTS" | jq -s 'sort_by(.created_at) | reverse')
+          TOTAL=$(echo "$SORTED" | jq 'length')
+          echo "Found $TOTAL backup artifacts"
+          if [ "$TOTAL" -le 7 ]; then
+            echo "Nothing to clean up"
+            exit 0
+          fi
+          echo "$SORTED" | jq -r '.[7:][].id' | while read -r id; do
+            name=$(echo "$SORTED" | jq -r ".[] | select(.id == $id) | .name")
+            echo "Deleting old backup: $name ($id)"
+            gh api --method DELETE "repos/${{ github.repository }}/actions/artifacts/$id" || echo "  (delete failed for $id)"
+          done
+          echo "Kept the 7 most recent backups"

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,0 +1,43 @@
+# Database
+
+Prod uses **Supabase** Postgres (`aws-0-eu-central-1.pooler.supabase.com`). The
+app connects through the transaction pooler (port 6543); backups use the session
+pooler (port 5432) because `pg_dump` needs session-level connections.
+
+## Backups
+
+Bootstrap-phase backups run as GitHub Actions (mirrors the Press repo), no paid
+tier required.
+
+- **`.github/workflows/database-backup.yml`** — daily at 2 AM UTC (and manual via
+  `gh workflow run database-backup.yml`). Runs `pg_dump --schema=public`, gzips,
+  verifies the dump contains the core tables (`users`, `files`), and uploads it as
+  a private GitHub Actions **artifact**. Retention 30 days; a cleanup job keeps the
+  7 most recent.
+- **`.github/workflows/backup-health-check.yml`** — twice daily (9 AM / 9 PM UTC).
+  Emails an alert (Resend) and fails the run if the latest backup artifact is
+  missing or older than 48 hours.
+
+Only the `public` schema is dumped: that is where all studio application data
+lives. Supabase-managed schemas (`auth`, `storage`, extensions) are Supabase's
+responsibility and the app role cannot fully dump them.
+
+### Restore (manual)
+
+```bash
+# download the artifact from the workflow run, then:
+gunzip -c studio_backup_YYYYMMDD_HHMMSS.sql.gz | \
+  psql "postgresql://<user>:<pw>@<host>:5432/postgres"
+```
+
+### Required GitHub secrets
+
+`DATABASE_HOST`, `DATABASE_PORT` (5432), `DATABASE_NAME`, `DATABASE_USER`,
+`DATABASE_PASSWORD`, plus `RESEND_API_KEY` and `FROM_EMAIL` for the health-check
+alert.
+
+### Later
+
+Graduate to Supabase Pro (daily backups + point-in-time recovery) or push dumps to
+external object storage (S3/R2) as the user base grows. End-to-end restore
+rehearsal into a throwaway DB is a worthwhile follow-up.


### PR DESCRIPTION
Delivers **std-onbpxl** (backups), modeled on the Press repo for our Supabase prod DB.

- `database-backup.yml` — daily 2 AM UTC + manual; `pg_dump --schema=public` → gzip → private GitHub artifact (30-day retention, keep 7); verifies the dump contains `users` + `files`.
- `backup-health-check.yml` — twice daily; Resend alert + failed run if the latest backup is missing or >48h old.
- `docs/DATABASE.md` — strategy + manual restore command.

Port 5432 (session pooler) for pg_dump. Repo secrets set (DATABASE_*, RESEND_API_KEY, FROM_EMAIL). After merge I'll trigger a manual run to prove the dump + upload work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)