### PR TITLE
feat(gdpr): hard-delete accounts after 30-day retention (std-4uwr9z)

### DIFF
--- a/.github/workflows/purge-deleted-accounts.yml
+++ b/.github/workflows/purge-deleted-accounts.yml
@@ -1,0 +1,82 @@
+name: Purge Deleted Accounts
+
+# Daily hard-delete of accounts soft-deleted more than 30 days ago: the second
+# stage of the GDPR deletion path. Soft delete (backend) removes an account's
+# data from the app immediately; this job erases it for good once the grace
+# period has passed.
+#
+# The heavy lifting is done by database ON DELETE cascades added in the
+# user_deletion_cascades migration, so the job is just two DELETEs. It mirrors
+# backend aris.crud.user.hard_delete_expired_users (keep the 30-day window in
+# sync). Uses the same Supabase session-pooler connection + secrets as the
+# database-backup workflow.
+
+on:
+  schedule:
+    # 03:00 UTC, after the 02:00 backup so an account still appears in that
+    # day's backup before it is purged.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Only report how many accounts would be purged'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Install PostgreSQL client
+        run: |
+          # PostgreSQL 17 client to match the Supabase server version
+          sudo apt-get update
+          sudo apt-get install -y wget ca-certificates
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+
+      - name: Purge accounts past the retention window
+        env:
+          PGPASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          DB_HOST: ${{ secrets.DATABASE_HOST }}
+          DB_PORT: ${{ secrets.DATABASE_PORT }}
+          DB_NAME: ${{ secrets.DATABASE_NAME }}
+          DB_USER: ${{ secrets.DATABASE_USER }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          PSQL="psql --host=$DB_HOST --port=$DB_PORT --username=$DB_USER --dbname=$DB_NAME --no-password -v ON_ERROR_STOP=1"
+
+          # Retention window MUST match backend hard_delete_expired_users (30 days).
+          WINDOW="deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '30 days'"
+
+          COUNT=$($PSQL -tA -c "SELECT count(*) FROM users WHERE $WINDOW;")
+          echo "Accounts past the 30-day retention window: $COUNT"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run requested: no rows deleted."
+            exit 0
+          fi
+
+          if [ "$COUNT" = "0" ]; then
+            echo "Nothing to purge."
+            exit 0
+          fi
+
+          # Single transaction. Deleting the users rows cascades each account's
+          # owned content (files -> versions/assets/settings/permissions/
+          # annotations/messages) via the migration's ON DELETE CASCADE, while
+          # attribution-only references on other users' files are set NULL.
+          # Profile pictures are referenced BY the users row, so they are removed
+          # in the second statement once the referencing users are gone.
+          $PSQL -c "BEGIN;
+            DELETE FROM users WHERE $WINDOW;
+            DELETE FROM profile_pictures WHERE $WINDOW;
+            COMMIT;"
+
+          echo "Purge complete."

--- a/backend/alembic/versions/i4d5e6f7a8b9_user_deletion_cascades.py
+++ b/backend/alembic/versions/i4d5e6f7a8b9_user_deletion_cascades.py
@@ -1,0 +1,106 @@
+"""User deletion cascades: let the DB purge an account's data on user delete
+
+Aligns the foreign keys that reference users (and the annotation/file chain
+reachable from them) with the ORM's already-declared cascade intent, so the
+hard-delete retention job can run a plain DELETE FROM users and have the
+database remove the account's owned content transitively.
+
+- CASCADE for owned content:
+    files.owner_id, annotation.owner_id, annotation.file_id,
+    annotation_message.owner_id, annotation_message.annotation_id
+- SET NULL for attribution-only references that must survive on other users'
+  files (mirrors file_assets.owner_id):
+    file_versions.created_by, file_permissions.granted_by
+- SET NULL for the self-referential files.prev_version_id
+
+created_by and granted_by become nullable to allow the SET NULL. The original
+constraints carried no ON DELETE clause (database default), so downgrade
+restores them without one.
+
+Revision ID: i4d5e6f7a8b9
+Revises: h3c4d5e6f7a8
+Create Date: 2026-07-14
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision = "i4d5e6f7a8b9"
+down_revision = "h3c4d5e6f7a8"
+branch_labels = None
+depends_on = None
+
+
+# (table, column, ref_table, ref_column, existing_constraint_name, new_ondelete)
+# existing names are the real ones in the DB: all follow "<table>_<column>_fkey"
+# except annotation.owner_id, which an earlier migration named fk_annotation_owner_id.
+_CASCADES = [
+    ("files", "owner_id", "users", "id", "files_owner_id_fkey", "CASCADE"),
+    ("files", "prev_version_id", "files", "id", "files_prev_version_id_fkey", "SET NULL"),
+    ("file_versions", "created_by", "users", "id", "file_versions_created_by_fkey", "SET NULL"),
+    ("annotation", "owner_id", "users", "id", "fk_annotation_owner_id", "CASCADE"),
+    ("annotation", "file_id", "files", "id", "annotation_file_id_fkey", "CASCADE"),
+    (
+        "annotation_message",
+        "owner_id",
+        "users",
+        "id",
+        "annotation_message_owner_id_fkey",
+        "CASCADE",
+    ),
+    (
+        "annotation_message",
+        "annotation_id",
+        "annotation",
+        "id",
+        "annotation_message_annotation_id_fkey",
+        "CASCADE",
+    ),
+    (
+        "file_permissions",
+        "granted_by",
+        "users",
+        "id",
+        "file_permissions_granted_by_fkey",
+        "SET NULL",
+    ),
+]
+
+# Columns that must become nullable so ON DELETE SET NULL is legal.
+_NULLABLE = [("file_versions", "created_by"), ("file_permissions", "granted_by")]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        # SQLite does not enforce FK ON DELETE; only the nullability matters.
+        for table, column in _NULLABLE:
+            with op.batch_alter_table(table, schema=None) as batch_op:
+                batch_op.alter_column(column, existing_type=sa.Integer(), nullable=True)
+        return
+
+    for table, column in _NULLABLE:
+        op.alter_column(table, column, existing_type=sa.Integer(), nullable=True)
+    for table, column, ref_table, ref_column, old_name, new in _CASCADES:
+        op.drop_constraint(old_name, table, type_="foreignkey")
+        op.create_foreign_key(
+            f"fk_{table}_{column}", table, ref_table, [column], [ref_column], ondelete=new
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        for table, column in _NULLABLE:
+            with op.batch_alter_table(table, schema=None) as batch_op:
+                batch_op.alter_column(column, existing_type=sa.Integer(), nullable=False)
+        return
+
+    # Restore the original constraints (name + no ON DELETE clause).
+    for table, column, ref_table, ref_column, old_name, _new in _CASCADES:
+        op.drop_constraint(f"fk_{table}_{column}", table, type_="foreignkey")
+        op.create_foreign_key(old_name, table, ref_table, [column], [ref_column])
+    for table, column in _NULLABLE:
+        op.alter_column(table, column, existing_type=sa.Integer(), nullable=False)

--- a/backend/aris/crud/user.py
+++ b/backend/aris/crud/user.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import case, delete, desc, or_, select, update
@@ -243,6 +243,43 @@ async def soft_delete_user(user_id: int, db: AsyncSession):
     user.deleted_at = now
     await db.commit()
     return user
+
+
+async def hard_delete_expired_users(
+    db: AsyncSession, retention_days: int = 30
+) -> dict[str, int]:
+    """Permanently delete accounts soft-deleted more than retention_days ago.
+
+    This is the second half of the GDPR deletion path: soft delete removes an
+    account's data from the application immediately, and this retention job then
+    erases it for good once the grace period has passed.
+
+    It relies on database-level ON DELETE cascades (see the
+    user_deletion_cascades migration): deleting a users row transitively removes
+    the account's files and everything hanging off them, while attribution-only
+    references on other users' files (file_versions.created_by,
+    file_permissions.granted_by, file_assets.owner_id) are set to NULL so those
+    contributions survive. Profile pictures are referenced *by* the users row, so
+    they are cleaned up in a second statement once the referencing users are gone.
+
+    Runs on PostgreSQL in production; the cascade is a no-op on SQLite (which does
+    not enforce foreign keys). Returns the row count deleted per table.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+
+    users_deleted = await db.execute(
+        delete(User).where(User.deleted_at.isnot(None), User.deleted_at < cutoff)
+    )
+    pictures_deleted = await db.execute(
+        delete(ProfilePicture).where(
+            ProfilePicture.deleted_at.isnot(None), ProfilePicture.deleted_at < cutoff
+        )
+    )
+    await db.commit()
+    return {
+        "users": users_deleted.rowcount,
+        "profile_pictures": pictures_deleted.rowcount,
+    }
 
 
 async def get_user_files(user_id: int, with_tags: bool, db: AsyncSession):

--- a/backend/aris/models/models.py
+++ b/backend/aris/models/models.py
@@ -348,11 +348,18 @@ class File(Base):
     # files predating this column: seeded once from `source`, then authoritative.
     ydoc_state = Column(LargeBinary, nullable=True)
     deleted_at = Column(DateTime(timezone=True), nullable=True)
-    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    
+    # ON DELETE CASCADE: deleting an account permanently removes its files (and,
+    # via the files' own cascades, their versions/assets/settings/permissions/
+    # annotations). Used by the hard-delete retention job.
+    owner_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+
     # Versioning fields
     version = Column(Integer, nullable=False, default=0)
-    prev_version_id = Column(Integer, ForeignKey("files.id"), nullable=True)
+    prev_version_id = Column(
+        Integer, ForeignKey("files.id", ondelete="SET NULL"), nullable=True
+    )
 
     owner = relationship("User", back_populates="files")
     tags = relationship("Tag", secondary=file_tags, back_populates="files")
@@ -432,7 +439,12 @@ class FileVersion(Base):
     rsm_content = Column(Text, nullable=False)
     title = Column(String, nullable=True)
     abstract = Column(Text, nullable=True)
-    created_by = Column(Integer, ForeignKey("users.id"), nullable=False)
+    # Attribution only (like file_assets.owner_id): a version created by an
+    # editor on someone else's file must survive that editor's account deletion,
+    # so ON DELETE SET NULL rather than CASCADE.
+    created_by = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     deleted_at = Column(DateTime(timezone=True), nullable=True)
     checkpoint_type = Column(String(10), nullable=False, default='manual')
@@ -713,8 +725,14 @@ class Annotation(Base):
     __tablename__ = "annotation"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    file_id = Column(Integer, ForeignKey("files.id"), nullable=False)
-    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    # CASCADE on both: an annotation is personal content, removed when either its
+    # file or its author's account is deleted.
+    file_id = Column(
+        Integer, ForeignKey("files.id", ondelete="CASCADE"), nullable=False
+    )
+    owner_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
     color = Column(String, nullable=False, default="purple")
     visibility: Column[AnnotationVisibility] = Column(
         Enum(AnnotationVisibility), nullable=False, default=AnnotationVisibility.PRIVATE
@@ -735,8 +753,12 @@ class AnnotationMessage(Base):
     __tablename__ = "annotation_message"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    annotation_id = Column(Integer, ForeignKey("annotation.id"), nullable=False)
-    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    annotation_id = Column(
+        Integer, ForeignKey("annotation.id", ondelete="CASCADE"), nullable=False
+    )
+    owner_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
     content = Column(Text, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), nullable=True)
@@ -870,7 +892,11 @@ class FilePermission(Base):
         Enum(FileRole, name="filerole"), nullable=False
     )
     granted_at = Column(DateTime(timezone=True), server_default=func.now())
-    granted_by = Column(Integer, ForeignKey("users.id"), nullable=False)
+    # Attribution only: SET NULL so deleting the granting account does not block
+    # the hard-delete job (the grant row itself is removed via file_id CASCADE).
+    granted_by = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
     deleted_at = Column(DateTime(timezone=True), nullable=True)
 
     file = relationship("File", back_populates="permissions")

--- a/backend/tests/test_crud/test_crud_user_hard_delete.py
+++ b/backend/tests/test_crud/test_crud_user_hard_delete.py
@@ -1,0 +1,160 @@
+"""Tests for the hard-delete retention job (GDPR erasure, second stage).
+
+hard_delete_expired_users permanently removes accounts soft-deleted longer than
+the retention window, relying on the database ON DELETE cascades added by the
+user_deletion_cascades migration. Those cascades are only enforced on
+PostgreSQL, so these tests are skipped on SQLite.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aris.crud.user import hard_delete_expired_users
+from aris.models.models import (
+    Annotation,
+    AnnotationMessage,
+    File,
+    FileAsset,
+    FilePermission,
+    FileRole,
+    FileSettings,
+    FileVersion,
+    ProfilePicture,
+    Tag,
+    User,
+    UserSettings,
+)
+
+
+async def _file(db, owner_id, title="Doc"):
+    f = File(owner_id=owner_id, source="c", title=title)
+    db.add(f)
+    await db.flush()
+    return f
+
+
+async def test_hard_delete_cascades_and_preserves_attribution(
+    db_session, test_user, test_user2, is_postgresql
+):
+    if not is_postgresql:
+        pytest.skip("DB-level ON DELETE cascade requires PostgreSQL")
+
+    pic = ProfilePicture(filename="p.png", mime_type="image/png", content="x")
+    db_session.add(pic)
+    await db_session.flush()
+    test_user.profile_picture_id = pic.id
+
+    own = await _file(db_session, test_user.id)
+    own_ann = Annotation(file_id=own.id, owner_id=test_user.id, anchor_data={}, selected_text="s")
+    db_session.add(own_ann)
+    await db_session.flush()
+    owned = {
+        "file": own,
+        "annotation": own_ann,
+        "message": AnnotationMessage(annotation_id=own_ann.id, owner_id=test_user.id, content="m"),
+        "version": FileVersion(
+            file_id=own.id, version_number=1, rsm_content="v", created_by=test_user.id
+        ),
+        "asset": FileAsset(
+            filename="a.png",
+            mime_type="image/png",
+            content="x",
+            file_id=own.id,
+            owner_id=test_user.id,
+        ),
+        "settings": FileSettings(user_id=test_user.id, file_id=own.id),
+        "permission": FilePermission(
+            file_id=own.id,
+            user_id=test_user.id,
+            role=FileRole.OWNER,
+            granted_by=test_user.id,
+        ),
+        "tag": Tag(user_id=test_user.id, name="t", color="blue"),
+        "user_settings": UserSettings(user_id=test_user.id),
+    }
+    for row in owned.values():
+        db_session.add(row)
+
+    # contributions to another account's file: must survive, attribution nulled
+    shared = await _file(db_session, test_user2.id, title="Shared")
+    surviving_version = FileVersion(
+        file_id=shared.id, version_number=1, rsm_content="v", created_by=test_user.id
+    )
+    surviving_asset = FileAsset(
+        filename="c.png",
+        mime_type="image/png",
+        content="x",
+        file_id=shared.id,
+        owner_id=test_user.id,
+    )
+    db_session.add_all([surviving_version, surviving_asset])
+    await db_session.commit()
+
+    models = {
+        "file": File,
+        "annotation": Annotation,
+        "message": AnnotationMessage,
+        "version": FileVersion,
+        "asset": FileAsset,
+        "settings": FileSettings,
+        "permission": FilePermission,
+        "tag": Tag,
+        "user_settings": UserSettings,
+    }
+    owned_ids = {k: owned[k].id for k in models}
+    pic_id, tu_id, tu2_id = pic.id, test_user.id, test_user2.id
+    shared_id, sv_id, sa_id = shared.id, surviving_version.id, surviving_asset.id
+
+    # age the soft delete past the retention window
+    old = datetime.now(UTC) - timedelta(days=31)
+    test_user.deleted_at = old
+    pic.deleted_at = old
+    await db_session.commit()
+
+    result = await hard_delete_expired_users(db_session, retention_days=30)
+    assert result["users"] == 1
+    assert result["profile_pictures"] == 1
+
+    db_session.expunge_all()
+
+    assert await db_session.get(User, tu_id) is None
+    assert await db_session.get(ProfilePicture, pic_id) is None
+    for key, model in models.items():
+        assert await db_session.get(model, owned_ids[key]) is None, f"{key} survived"
+
+    # the other account, its file, and the survived contributions remain
+    assert await db_session.get(User, tu2_id) is not None
+    assert await db_session.get(File, shared_id) is not None
+
+    sv = await db_session.get(FileVersion, sv_id)
+    assert sv is not None and sv.created_by is None
+    sa = await db_session.get(FileAsset, sa_id)
+    assert sa is not None and sa.owner_id is None
+
+
+async def test_hard_delete_respects_retention_window(db_session, test_user, is_postgresql):
+    if not is_postgresql:
+        pytest.skip("DB-level ON DELETE cascade requires PostgreSQL")
+
+    test_user.deleted_at = datetime.now(UTC) - timedelta(days=5)
+    await db_session.commit()
+    tu_id = test_user.id
+
+    result = await hard_delete_expired_users(db_session, retention_days=30)
+    assert result["users"] == 0
+
+    db_session.expunge_all()
+    assert await db_session.get(User, tu_id) is not None
+
+
+async def test_hard_delete_ignores_live_accounts(db_session, test_user, is_postgresql):
+    if not is_postgresql:
+        pytest.skip("DB-level ON DELETE cascade requires PostgreSQL")
+
+    tu_id = test_user.id
+    result = await hard_delete_expired_users(db_session, retention_days=30)
+    assert result["users"] == 0
+
+    db_session.expunge_all()
+    assert await db_session.get(User, tu_id) is not None

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -22,6 +22,26 @@ Only the `public` schema is dumped: that is where all studio application data
 lives. Supabase-managed schemas (`auth`, `storage`, extensions) are Supabase's
 responsibility and the app role cannot fully dump them.
 
+## Account deletion (GDPR erasure)
+
+Two stages:
+
+1. **Soft delete (immediate).** `DELETE /users/{id}` (`aris.crud.user.soft_delete_user`)
+   cascades a `deleted_at` timestamp across every table holding the account's
+   data, so "delete my account" removes it from the application at once.
+   Contributions to other users' files (uploaded assets, named versions) are
+   kept as attribution-only and survive.
+2. **Hard delete (after 30 days).** The **`.github/workflows/purge-deleted-accounts.yml`**
+   cron (daily at 3 AM UTC, after the backup; `dry_run` input for a count-only
+   run) permanently deletes accounts whose `deleted_at` is older than 30 days.
+   It is two `DELETE`s; the database does the rest through the `ON DELETE`
+   cascades added in the `user_deletion_cascades` migration
+   (`CASCADE` for owned content, `SET NULL` for attribution). This mirrors
+   `aris.crud.user.hard_delete_expired_users` — keep the 30-day window in sync.
+
+A deleted account's data can therefore persist for up to ~60 days total: the
+30-day soft-delete grace window plus the 30-day backup-artifact retention.
+
 ### Restore (manual)
 
 ```bash


### PR DESCRIPTION
## Why

Second stage of the GDPR deletion path. [#472](https://github.com/aris-pub/studio/pull/472) soft-deletes an account's data immediately; this PR permanently erases it once a 30-day grace window passes.

A plain `DELETE FROM users` was impossible: most FKs referencing `users` are `RESTRICT` + `NOT NULL`, so the delete errors out. Rather than hand-order children-before-parents in the cron (fragile, and `created_by`/`prev_version_id` still need handling), this aligns the FKs with the cascade the ORM relationships already intend, so the **database** does the work.

## What

**Migration `user_deletion_cascades`** (validated on real PostgreSQL 17 — upgrade, downgrade, re-upgrade):
- **`CASCADE`** (owned content): `files.owner_id`, `annotation.owner_id`, `annotation.file_id`, `annotation_message.owner_id`, `annotation_message.annotation_id`
- **`SET NULL`** (attribution-only, must survive on other users' files — mirrors the existing `file_assets.owner_id` design): `file_versions.created_by`, `file_permissions.granted_by`
- **`SET NULL`** self-referential: `files.prev_version_id`
- `created_by` and `granted_by` become nullable to allow `SET NULL`

> One FK (`annotation.owner_id`) was named `fk_annotation_owner_id` by an earlier migration, not the postgres default `annotation_owner_id_fkey`. The migration carries the real constraint names — caught by running it against a throwaway Postgres, exactly the failure the local exercise was for.

**`hard_delete_expired_users`** is then two `DELETE`s (users, then the `profile_pictures` the users row referenced) and the DB cascades the rest.

**`purge-deleted-accounts.yml`** cron runs the equivalent SQL daily at 03:00 UTC (after the 02:00 backup) against Supabase, reusing the backup's secrets. A `dry_run` input reports the count without deleting.

`docs/DATABASE.md` documents both stages and the ~60-day total tail (30-day grace + 30-day backup retention).

## Validation

On a throwaway PostgreSQL 17:
- migration upgrades/downgrades/re-upgrades cleanly, all 8 `ON DELETE` clauses correct
- a full purge removes the account + all owned content, keeps other users' data, and **preserves** a version/asset the deleted user contributed to another user's file with attribution nulled

Tests (`test_crud_user_hard_delete.py`) are **PostgreSQL-only** — SQLite doesn't enforce FK cascades, so they skip on the default SQLite test DB and run in CI against the postgres service.

Completes the code half of std-4uwr9z. DPAs remain a legal sign-off. Stacked on #472 conceptually but independent (branches off main; either can merge first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)