### PR TITLE
feat(assets): recompile open tabs when a file's asset changes out of band (std-iu0n)

### DIFF
--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, Response, StreamingResponse
 from pydantic import BaseModel, field_validator, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +20,7 @@ from ..deps import UserRead
 from ..logging_config import get_logger
 from ..models import FileAsset
 from ..models.models import FileRole
+from ..services.file_events import FileEventBroker, get_event_broker, sse_event_stream
 from ..services.file_service import FileCreateData, FileUpdateData, InMemoryFileService
 
 
@@ -792,6 +793,7 @@ async def create_asset_for_file(
         db,
     )
     await file_service.clear_file_cache(file_id)
+    get_event_broker().publish(file_id, {"type": "asset-changed"})
     return asset
 
 
@@ -877,6 +879,7 @@ async def update_asset_for_file(
         raise HTTPException(status_code=404, detail="Asset not found")
     result = await FileAssetDB.update_asset(asset, payload, db)
     await file_service.clear_file_cache(file_id)
+    get_event_broker().publish(file_id, {"type": "asset-changed"})
     return result
 
 
@@ -894,7 +897,39 @@ async def delete_asset_for_file(
         raise HTTPException(status_code=404, detail="Asset not found")
     await FileAssetDB.soft_delete_asset(asset, db)
     await file_service.clear_file_cache(file_id)
+    get_event_broker().publish(file_id, {"type": "asset-changed"})
     return {"message": f"Asset {asset_id} deleted"}
+
+
+@router.get("/{file_id}/events")
+async def file_events(
+    file_id: int,
+    user: UserRead = Depends(current_user),
+    user_role: FileRole = Depends(require_view),
+    broker: FileEventBroker = Depends(get_event_broker),
+):
+    """Stream this file's events to the caller's browser as Server-Sent Events.
+
+    A general per-file channel (see aris.services.file_events): any backend code
+    can publish a typed event to a file and every open tab viewing it receives
+    it. The first consumer is the asset-change notification (std-iu0n) that tells
+    the tab to recompile when an asset changes out of band. Gate is require_view.
+
+    Consumed from the browser with fetch() rather than EventSource, which cannot
+    send the bearer token. Auth resolves before streaming, so an unauthorized
+    caller is rejected up front instead of opening a stream.
+    """
+
+    return StreamingResponse(
+        sse_event_stream(broker, file_id),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            # Stop nginx/Fly from buffering so events flush to the client at once.
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @router.post("/{file_id}/download/pdf")

--- a/backend/aris/services/file_events.py
+++ b/backend/aris/services/file_events.py
@@ -1,0 +1,91 @@
+"""General in-process pub/sub for per-file events.
+
+Any backend code can publish a typed event to a file, and any number of
+subscribers (e.g. one Server-Sent-Events stream per open browser tab) receive
+it. Events are plain dicts carrying at least a ``type``; the transport and the
+consumers decide what the types mean.
+
+First consumer: the asset-change notification (std-iu0n) that tells an open tab
+to recompile when a file's asset changes out of band. Kept deliberately generic
+so any file-scoped event (comment added, version created, collaborator joined)
+can reuse the same channel.
+
+In-process only: state lives in one process, which is correct for the current
+single backend instance. Moving to multiple instances would need a shared bus
+(Redis pub/sub, Postgres LISTEN/NOTIFY) behind this same interface.
+"""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+
+class FileEventBroker:
+    """Fan-out of file-scoped events to live subscribers."""
+
+    def __init__(self) -> None:
+        self._subscribers: dict[int, set[asyncio.Queue]] = {}
+
+    def publish(self, file_id: int, event: dict[str, Any]) -> int:
+        """Deliver ``event`` to every current subscriber of ``file_id``.
+
+        Non-blocking: the event is queued for each subscriber and never awaits a
+        consumer, so a slow or stalled subscriber cannot hold up the publisher.
+        Returns the number of subscribers reached (0 is a harmless no-op).
+        """
+        queues = self._subscribers.get(file_id)
+        if not queues:
+            return 0
+        for queue in queues:
+            queue.put_nowait(event)
+        return len(queues)
+
+    @asynccontextmanager
+    async def subscribe(self, file_id: int) -> AsyncIterator[asyncio.Queue]:
+        """Subscribe to ``file_id`` for the duration of the context.
+
+        Yields a queue that receives every event published after subscription;
+        the subscription is torn down on exit, even if the consumer is cancelled
+        (e.g. the browser closes the SSE connection).
+        """
+        queue: asyncio.Queue = asyncio.Queue()
+        self._subscribers.setdefault(file_id, set()).add(queue)
+        try:
+            yield queue
+        finally:
+            subscribers = self._subscribers.get(file_id)
+            if subscribers is not None:
+                subscribers.discard(queue)
+                if not subscribers:
+                    del self._subscribers[file_id]
+
+    def subscriber_count(self, file_id: int) -> int:
+        """Number of live subscribers for a file (0 if none)."""
+        return len(self._subscribers.get(file_id, ()))
+
+
+async def sse_event_stream(
+    broker: FileEventBroker, file_id: int
+) -> AsyncIterator[str]:
+    """Server-Sent-Events view of a file's event stream.
+
+    Subscribes to ``file_id`` and yields SSE-framed strings: an initial ``:``
+    comment (flushes headers, confirms the subscription is live, keep-alive),
+    then one ``data:`` line per published event. Runs until the consumer stops
+    iterating (the browser closing the connection), at which point the
+    subscription is torn down.
+    """
+    async with broker.subscribe(file_id) as queue:
+        yield ": connected\n\n"
+        while True:
+            event = await queue.get()
+            yield f"data: {json.dumps(event)}\n\n"
+
+
+_broker = FileEventBroker()
+
+
+def get_event_broker() -> FileEventBroker:
+    """FastAPI dependency / accessor for the process-wide broker singleton."""
+    return _broker

--- a/backend/tests/test_routes/test_authz_coverage.py
+++ b/backend/tests/test_routes/test_authz_coverage.py
@@ -92,6 +92,7 @@ CROSS_USER_TESTED: dict[tuple[str, str], str] = {
     ("POST", "/files/{file_id}/download"): "test_routes_file.py::test_download_file_permission_denied",
     ("POST", "/files/{file_id}/download/pdf"): "test_routes_file.py::test_download_pdf_permission_denied",
     ("POST", "/files/{file_id}/assets"): "test_routes_file_assets.py::test_upload_asset_viewer_forbidden",
+    ("GET", "/files/{file_id}/events"): "test_routes_file_events.py::test_file_events_forbidden_without_view_permission",
     ("POST", "/files/{file_id}/collab/start"): "test_routes_collab.py::test_collab_start_forbidden_for_user_without_permission_row",
     ("POST", "/files/{file_id}/collab/stop"): "test_routes_collab.py::test_collab_stop_forbidden_for_user_without_permission",
     ("POST", "/files/{file_id}/collab/flush"): "test_routes_collab.py::test_collab_flush_forbidden_for_user_without_permission",

--- a/backend/tests/test_routes/test_routes_file_events.py
+++ b/backend/tests/test_routes/test_routes_file_events.py
@@ -1,0 +1,82 @@
+"""Tests for the per-file event endpoint and the asset-change publishes.
+
+GET /files/{id}/events streams a file's events (from FileEventBroker) to an
+authorized viewer. The streaming behaviour (subscribe -> ": connected" -> data
+lines) is covered directly against sse_event_stream in
+tests/test_services/test_file_events.py, because httpx's ASGI transport buffers
+the whole response and cannot consume an endless SSE stream here. These tests
+cover the require_view gate and that the asset routes publish an "asset-changed"
+event.
+"""
+
+import asyncio
+
+from aris.crud.file import create_file
+from aris.services.file_events import get_event_broker
+
+
+_ASSET = {"filename": "a.txt", "mime_type": "text/plain", "content": "hi"}
+
+
+async def _make_file(authenticated_user, db_session) -> int:
+    file = await create_file(
+        source="# T", owner_id=authenticated_user["user_id"], db=db_session
+    )
+    return file.id
+
+
+async def test_file_events_requires_authentication(client, test_file):
+    async with client.stream("GET", f"/files/{test_file.id}/events") as response:
+        assert response.status_code in (401, 403)
+
+
+async def test_file_events_forbidden_without_view_permission(
+    authenticated_client2, test_file
+):
+    # test_file is owned by test_user; test_user2 has no permission on it.
+    async with authenticated_client2.stream(
+        "GET", f"/files/{test_file.id}/events"
+    ) as response:
+        assert response.status_code == 403
+
+
+async def test_creating_an_asset_publishes_asset_changed(
+    authenticated_client, authenticated_user, db_session
+):
+    file_id = await _make_file(authenticated_user, db_session)
+    async with get_event_broker().subscribe(file_id) as q:
+        resp = await authenticated_client.post(f"/files/{file_id}/assets", json=_ASSET)
+        assert resp.status_code in (200, 201)
+        event = await asyncio.wait_for(q.get(), timeout=2)
+        assert event["type"] == "asset-changed"
+
+
+async def test_updating_an_asset_publishes_asset_changed(
+    authenticated_client, authenticated_user, db_session
+):
+    file_id = await _make_file(authenticated_user, db_session)
+    created = await authenticated_client.post(f"/files/{file_id}/assets", json=_ASSET)
+    asset_id = created.json()["id"]
+    # subscribe only around the update, so the create's own publish is not counted
+    async with get_event_broker().subscribe(file_id) as q:
+        resp = await authenticated_client.put(
+            f"/files/{file_id}/assets/{asset_id}", json={"filename": "renamed.txt"}
+        )
+        assert resp.status_code == 200
+        event = await asyncio.wait_for(q.get(), timeout=2)
+        assert event["type"] == "asset-changed"
+
+
+async def test_deleting_an_asset_publishes_asset_changed(
+    authenticated_client, authenticated_user, db_session
+):
+    file_id = await _make_file(authenticated_user, db_session)
+    created = await authenticated_client.post(f"/files/{file_id}/assets", json=_ASSET)
+    asset_id = created.json()["id"]
+    async with get_event_broker().subscribe(file_id) as q:
+        resp = await authenticated_client.delete(
+            f"/files/{file_id}/assets/{asset_id}"
+        )
+        assert resp.status_code == 200
+        event = await asyncio.wait_for(q.get(), timeout=2)
+        assert event["type"] == "asset-changed"

--- a/backend/tests/test_services/test_file_events.py
+++ b/backend/tests/test_services/test_file_events.py
@@ -1,0 +1,82 @@
+"""Tests for the general per-file event broker (in-process pub/sub).
+
+The broker is transport-agnostic: publishers push typed events to a file_id and
+any number of subscribers receive them. Its first consumer is the asset-change
+notification (std-iu0n), but it is deliberately generic so any file-scoped event
+(comments, version created, collaborator joined, ...) can reuse it.
+"""
+
+import asyncio
+
+from aris.services.file_events import FileEventBroker, sse_event_stream
+
+
+async def test_publish_delivers_to_subscriber():
+    broker = FileEventBroker()
+    async with broker.subscribe(1) as q:
+        reached = broker.publish(1, {"type": "asset-changed"})
+        assert reached == 1
+        event = await asyncio.wait_for(q.get(), timeout=1)
+        assert event == {"type": "asset-changed"}
+
+
+async def test_publish_reaches_all_subscribers():
+    broker = FileEventBroker()
+    async with broker.subscribe(1) as q1, broker.subscribe(1) as q2:
+        assert broker.publish(1, {"type": "x"}) == 2
+        assert (await q1.get())["type"] == "x"
+        assert (await q2.get())["type"] == "x"
+
+
+async def test_publish_with_no_subscribers_is_a_noop():
+    broker = FileEventBroker()
+    assert broker.publish(999, {"type": "x"}) == 0
+
+
+async def test_events_are_isolated_by_file_id():
+    broker = FileEventBroker()
+    async with broker.subscribe(1) as q1, broker.subscribe(2) as q2:
+        broker.publish(1, {"type": "for-1"})
+        assert (await q1.get())["type"] == "for-1"
+        assert q2.empty()
+
+
+async def test_subscriber_is_removed_on_context_exit():
+    broker = FileEventBroker()
+    async with broker.subscribe(1):
+        assert broker.subscriber_count(1) == 1
+    assert broker.subscriber_count(1) == 0
+    # publishing after everyone has left is a harmless no-op
+    assert broker.publish(1, {"type": "x"}) == 0
+
+
+async def test_one_slow_subscriber_does_not_block_publish():
+    # put_nowait means publish never awaits a consumer; the event just queues.
+    broker = FileEventBroker()
+    async with broker.subscribe(1) as q:
+        for i in range(5):
+            broker.publish(1, {"type": "n", "i": i})
+        assert q.qsize() == 5
+
+
+async def test_sse_stream_yields_connected_comment_then_data_lines():
+    broker = FileEventBroker()
+    stream = sse_event_stream(broker, 1)
+    try:
+        first = await asyncio.wait_for(stream.__anext__(), timeout=1)
+        assert first.startswith(":")  # the initial keep-alive comment
+        # subscription is live once the comment is out; a publish becomes a data line
+        broker.publish(1, {"type": "asset-changed"})
+        data = await asyncio.wait_for(stream.__anext__(), timeout=1)
+        assert data == 'data: {"type": "asset-changed"}\n\n'
+    finally:
+        await stream.aclose()
+
+
+async def test_sse_stream_unsubscribes_when_closed():
+    broker = FileEventBroker()
+    stream = sse_event_stream(broker, 1)
+    await asyncio.wait_for(stream.__anext__(), timeout=1)  # enter the subscription
+    assert broker.subscriber_count(1) == 1
+    await stream.aclose()
+    assert broker.subscriber_count(1) == 0

--- a/frontend/src/composables/useFileEvents.js
+++ b/frontend/src/composables/useFileEvents.js
@@ -1,0 +1,94 @@
+/**
+ * Subscribe to a file's server-sent event stream and dispatch events by type.
+ *
+ * The backend exposes a general per-file event channel at GET /files/{id}/events
+ * (see backend aris.services.file_events). This opens it with fetch() rather than
+ * EventSource, because EventSource cannot attach the bearer token, then parses
+ * the SSE frames and calls handlers[event.type] for each event.
+ *
+ * Deliberately generic: pass any map of { eventType: handler }. Its first use is
+ * recompiling when a file's asset changes out of band (std-iu0n), but any future
+ * file-scoped event can reuse the same channel and this same composable.
+ *
+ * @param {number|string} fileId
+ * @param {Record<string, (event: object) => void>} handlers
+ * @param {object} [options] - fetch, getToken, baseURL, retryMs (injectable for tests)
+ * @returns {{ close: () => void }}
+ */
+export function useFileEvents(fileId, handlers, options = {}) {
+  const baseURL = options.baseURL ?? import.meta.env.VITE_API_BASE_URL;
+  const getToken = options.getToken ?? (() => localStorage.getItem("accessToken"));
+  const fetchFn = options.fetch ?? ((...args) => fetch(...args));
+  const retryMs = options.retryMs ?? 3000;
+
+  const controller = new AbortController();
+  let closed = false;
+
+  function dispatch(frame) {
+    for (const line of frame.split("\n")) {
+      if (!line.startsWith("data:")) continue; // ':' comments and blanks are keep-alives
+      let event;
+      try {
+        event = JSON.parse(line.slice("data:".length).trim());
+      } catch {
+        continue;
+      }
+      const handler = handlers[event?.type];
+      if (handler) handler(event);
+    }
+  }
+
+  async function consume(body) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!closed) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let sep;
+      // SSE frames are separated by a blank line.
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const frame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        if (closed) return;
+        dispatch(frame);
+      }
+    }
+  }
+
+  async function run() {
+    while (!closed) {
+      try {
+        const response = await fetchFn(`${baseURL}/files/${fileId}/events`, {
+          headers: {
+            Authorization: `Bearer ${getToken()}`,
+            Accept: "text/event-stream",
+          },
+          signal: controller.signal,
+        });
+        // No permission (or gone): don't reconnect, there's nothing to wait for.
+        if (response.status === 401 || response.status === 403 || response.status === 404) {
+          return;
+        }
+        if (response.ok && response.body) {
+          await consume(response.body);
+        }
+      } catch {
+        if (closed || controller.signal.aborted) return;
+      }
+      if (closed) return;
+      // The server closed the stream or a transient error hit — back off, reconnect.
+      await new Promise((resolve) => setTimeout(resolve, retryMs));
+    }
+  }
+
+  run();
+
+  return {
+    close() {
+      closed = true;
+      controller.abort();
+    },
+  };
+}

--- a/frontend/src/tests/composables/useFileEvents.test.js
+++ b/frontend/src/tests/composables/useFileEvents.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { useFileEvents } from "@/composables/useFileEvents.js";
+
+function streamOf(chunks) {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+function okStream(chunks) {
+  return { ok: true, status: 200, body: streamOf(chunks) };
+}
+
+describe("useFileEvents", () => {
+  it("parses SSE frames and dispatches events to the matching handler", async () => {
+    const onAsset = vi.fn();
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(okStream([": connected\n\n", 'data: {"type":"asset-changed"}\n\n']));
+
+    const sub = useFileEvents(
+      42,
+      { "asset-changed": onAsset },
+      { fetch: fetchFn, getToken: () => "tok", baseURL: "http://x" }
+    );
+
+    await vi.waitFor(() => expect(onAsset).toHaveBeenCalledTimes(1));
+    expect(onAsset).toHaveBeenCalledWith({ type: "asset-changed" });
+    expect(fetchFn).toHaveBeenCalledWith(
+      "http://x/files/42/events",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      })
+    );
+    sub.close();
+  });
+
+  it("ignores comment lines and event types with no handler", async () => {
+    const onAsset = vi.fn();
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(okStream([": ping\n\n", 'data: {"type":"unrelated"}\n\n']));
+
+    const sub = useFileEvents(
+      1,
+      { "asset-changed": onAsset },
+      { fetch: fetchFn, getToken: () => "t", baseURL: "" }
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(onAsset).not.toHaveBeenCalled();
+    sub.close();
+  });
+
+  it("gives up without retrying when the stream is forbidden", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+
+    const sub = useFileEvents(
+      1,
+      {},
+      { fetch: fetchFn, getToken: () => "t", baseURL: "", retryMs: 1 }
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    sub.close();
+  });
+
+  it("stops dispatching after close()", async () => {
+    const onAsset = vi.fn();
+    let controllerRef;
+    const body = new ReadableStream({
+      start(controller) {
+        controllerRef = controller;
+      },
+    });
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, status: 200, body });
+
+    const sub = useFileEvents(
+      1,
+      { "asset-changed": onAsset },
+      { fetch: fetchFn, getToken: () => "t", baseURL: "" }
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    sub.close();
+    // an event enqueued after close must not be dispatched
+    const encoder = new TextEncoder();
+    controllerRef.enqueue(encoder.encode('data: {"type":"asset-changed"}\n\n'));
+    controllerRef.close();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onAsset).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/e2e/asset-change-recompile.spec.js
+++ b/frontend/src/tests/e2e/asset-change-recompile.spec.js
@@ -1,0 +1,89 @@
+/**
+ * E2E for std-iu0n: an out-of-band asset change recompiles the open tab.
+ *
+ * Bug: when an asset is changed from outside the tab (an AI agent via the API,
+ * another tab, another user), the open editor kept showing the old asset until
+ * the user manually recompiled. Fix: the backend publishes an "asset-changed"
+ * event on the per-file SSE channel (GET /files/{id}/events); the tab subscribes
+ * and recompiles on it.
+ *
+ * This asserts the whole path in a real browser: subscribe -> out-of-band asset
+ * update -> the tab issues a /render/private on its own (no edit, no Cmd+S).
+ *
+ * Tag: @collab
+ */
+
+import { test } from "./fixtures.js";
+import {
+  loginUser,
+  createTestFile,
+  deleteTestFile,
+  createAuthenticatedContext,
+  openFileInEditor,
+  cleanupYjs,
+} from "./yjs-helpers.js";
+import { getBackendURL } from "./utils/test-config.js";
+
+const backendURL = getBackendURL();
+const SOURCE = "# Asset Doc\n\nA paragraph.";
+
+async function createAsset(fileId, token) {
+  const response = await fetch(`${backendURL}/files/${fileId}/assets`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ filename: "data.txt", mime_type: "text/plain", content: "v1" }),
+  });
+  if (!response.ok) throw new Error(`create asset failed: ${response.status}`);
+  return (await response.json()).id;
+}
+
+async function renameAsset(fileId, assetId, token, filename) {
+  const response = await fetch(`${backendURL}/files/${fileId}/assets/${assetId}`, {
+    method: "PUT",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ filename }),
+  });
+  if (!response.ok) throw new Error(`update asset failed: ${response.status}`);
+}
+
+test.describe("Asset change recompile @collab", () => {
+  let auth;
+
+  test.beforeAll(async ({ request }) => {
+    auth = await loginUser(request);
+  });
+
+  test("an out-of-band asset update recompiles the open tab", async ({ browser, request }) => {
+    test.setTimeout(60000);
+
+    const fileId = await createTestFile(request, auth.token, auth.userData.id, SOURCE);
+    const assetId = await createAsset(fileId, auth.token);
+    const { context, page } = await createAuthenticatedContext(browser, auth);
+
+    try {
+      // The tab's event subscription opens the SSE stream; wait for its response
+      // headers so we know the backend has a live subscriber before we publish.
+      const sseConnected = page.waitForResponse(
+        (r) => r.url().includes(`/files/${fileId}/events`) && r.status() === 200,
+        { timeout: 15000 }
+      );
+
+      await openFileInEditor(page, fileId);
+      await page.waitForSelector('[data-testid="manuscript-viewer"]', { timeout: 15000 });
+      await sseConnected;
+
+      // Now change the asset from outside the tab (as an agent/API would). The
+      // tab must recompile on its own — no keystroke, no Cmd+S.
+      const recompiled = page.waitForResponse(
+        (r) => r.url().includes("/render/private") && r.status() === 200,
+        { timeout: 20000 }
+      );
+      await renameAsset(fileId, assetId, auth.token, "data-v2.txt");
+      await recompiled;
+    } finally {
+      await cleanupYjs(page);
+      await context.close();
+      await deleteTestFile(request, auth.token, fileId);
+    }
+  });
+});

--- a/frontend/src/views/workspace/EditorCodeMirror.vue
+++ b/frontend/src/views/workspace/EditorCodeMirror.vue
@@ -37,6 +37,7 @@
   import { useLSPClient } from "@/composables/useLSPClient";
   import { semanticTokensExtension, requestSemanticTokens } from "@/composables/useSemanticTokens";
   import { rsmKeymap } from "@/composables/useRSMCommands";
+  import { useFileEvents } from "@/composables/useFileEvents.js";
 
   const file = defineModel({ type: Object, required: true });
   const api = inject("api");
@@ -51,6 +52,8 @@
   // DOM ref for CodeMirror container
   const editorContainer = ref(null);
   const activeCollabFileId = ref(null);
+  // Subscription to this file's server-sent event stream (asset changes, etc.).
+  let fileEvents = null;
   // Y.js objects must use shallowRef — Vue's reactive Proxy breaks Y.js
   // internal identity checks (UndoManager scope, findRootTypeKey, etc.)
   const view = shallowRef(null);
@@ -157,6 +160,11 @@
       activeCollabFileId.value = null;
     }
 
+    if (fileEvents) {
+      fileEvents.close();
+      fileEvents = null;
+    }
+
     ytext.value = null;
     if (parentYtext) parentYtext.value = null;
     awareness.value = null;
@@ -191,6 +199,13 @@
       ydoc.value = new Y.Doc();
       ytext.value = ydoc.value.getText("text");
       if (parentYtext) parentYtext.value = ytext.value;
+
+      // Recompile when an asset for this file changes out of band (an agent,
+      // another tab, or another user), so the rendered image refreshes without a
+      // manual save. Reuses the general per-file event channel (std-iu0n).
+      fileEvents = useFileEvents(fileId, {
+        "asset-changed": () => compile && compile(true),
+      });
 
       // Tell the backend to start its Y.js client and get a short-lived WS auth
       // token. The multi-player server requires the token as the first frame on


### PR DESCRIPTION
## Why

An out-of-band asset change (AI agent via the API, another tab, another user) didn't reach an open editor — it kept showing the old asset until the user manually recompiled. Investigation (in the bead) found the URL cache-busting the original report proposed is **already** handled by the signed-URL `exp`; the real remaining gap was the **missing notification**.

## What

A general, reusable **per-file event channel**, with asset-changed as its first consumer:

- **`aris/services/file_events.py`** — `FileEventBroker` (in-process pub/sub keyed by file, typed events) + `sse_event_stream` (subscription → Server-Sent Events). Deliberately generic so any future file-scoped event (comment added, version created, …) can reuse it.
- **`GET /files/{id}/events`** (`require_view`) — streams a file's events to an authorized viewer. Registered in the authz-coverage guard.
- Asset **create/update/delete** publish `{"type": "asset-changed"}`.
- **`useFileEvents(fileId, handlers)`** — opens the stream with `fetch` (not `EventSource`, which can't send the bearer token), parses SSE, dispatches by event type. Wired into `EditorCodeMirror` to recompile on `asset-changed`, torn down on file-change/unmount.

**Why not the Y.js socket:** that socket is owned by the collab message loop (which also sends), so an external push would need serializing all sends through a queue — a risky change to the fragile, duplication-prone collab core. This channel keeps that code untouched.

## Tests (TDD — written first)

- Backend: broker fan-out/isolation/cleanup, SSE stream framing, endpoint `require_view` gating, and each asset route publishing. 46 green in the affected area.
- Frontend: `useFileEvents` SSE parse / dispatch-by-type / no-retry-on-403 / teardown (4).
- **E2e** (`asset-change-recompile.spec.js`, `@collab`): open a file, change its asset from outside the tab via the API, assert the tab issues a `/render/private` on its own — no edit, no Cmd+S.

The refetch-every-image-per-render efficiency issue (separate, from the signed URL's changing `exp`) is tracked in its own bead.

Closes std-iu0n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)