### PR TITLE
fix(security): stop logging user PII on failed login; gate /debug/user-state (std-fkdh, std-9xtntz)

### DIFF
--- a/backend/aris/routes/auth.py
+++ b/backend/aris/routes/auth.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, current_user, get_db, jwt
@@ -169,15 +169,7 @@ async def login(request: Request, user_data: UserLogin, db: AsyncSession = Depen
         select(User).where(User.email == user_data.email, User.deleted_at.is_(None))
     )
     user = result.scalars().first()
-    
-    # DEBUG: Log what user exists if login fails
-    if not user:
-        all_users_debug = await db.execute(text("SELECT id, email, name FROM users LIMIT 5"))
-        all_user_rows = all_users_debug.fetchall()
-        logger.warning(f"No user found with email {user_data.email}. Existing users:")
-        for row in all_user_rows:
-            logger.warning(f"  ID {row.id}: email='{row.email}', name='{row.name}'")
-    
+
     if not user or not verify_password(user_data.password, user.password_hash):
         logger.warning(f"Failed login attempt for email: {user_data.email}")
         raise HTTPException(status_code=400, detail="Invalid credentials")

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aris.collaboration import get_collaboration_manager
-from aris.deps import get_db
+from aris.deps import current_user, get_db
 from aris.health import HealthResponse, perform_health_check
 from aris.logging_config import get_logger, setup_logging
 from aris.routes import (
@@ -171,7 +171,23 @@ async def health_check(db: AsyncSession = Depends(get_db)):
     return health_result
 
 
-@app.get("/debug/user-state", tags=["health"], summary="Debug User State")
+def _forbid_debug_in_prod() -> None:
+    """Hide debug endpoints in production-like environments.
+
+    Raises 404 (rather than 403) in PROD/STAGING so the endpoint's existence is not
+    revealed. As a decorator-level dependency it is evaluated before the auth
+    dependency, so PROD requests never reach the auth check. Mirrors /debug/reload.
+    """
+    if os.getenv("ENV") in ("PROD", "STAGING"):
+        raise HTTPException(status_code=404, detail="Not found")
+
+
+@app.get(
+    "/debug/user-state",
+    tags=["health"],
+    summary="Debug User State",
+    dependencies=[Depends(_forbid_debug_in_prod), Depends(current_user)],
+)
 async def debug_user_state(db: AsyncSession = Depends(get_db)):
     """Debug endpoint to check test user state for auth-enabled E2E diagnostic.
 

--- a/backend/tests/test_routes/test_authz_coverage.py
+++ b/backend/tests/test_routes/test_authz_coverage.py
@@ -142,6 +142,7 @@ SELF_SCOPED: dict[tuple[str, str], str] = {
     ("POST", "/files"): "new file is owned by the caller; body owner_id ignored (test_create_file_owner_id_in_body_is_ignored)",
     ("POST", "/files/import"): "imported file is owned by the caller",
     ("POST", "/users/lookup"): "intentional email->public-profile directory lookup, rate-limited; not an ownership boundary",
+    ("GET", "/debug/user-state"): "non-PROD diagnostic; no external resource id, returns fixed TEST_USER_EMAIL state (std-9xtntz)",
 }
 
 

--- a/backend/tests/test_routes/test_routes_auth.py
+++ b/backend/tests/test_routes/test_routes_auth.py
@@ -429,6 +429,44 @@ async def test_refresh_rejects_expired_token(client: AsyncClient):
     assert response.status_code == 401
 
 
+async def test_failed_login_does_not_log_existing_users_pii(
+    client: AsyncClient, db_session, caplog
+):
+    """A failed login for an unknown email must not leak other users' PII to logs.
+
+    Regression test for std-fkdh: the handler used to log the id, email, and name
+    of the first 5 existing users on a failed login.
+    """
+    import logging
+
+    from aris.models import User
+    from aris.security import hash_password
+
+    victim = User(
+        name="Victim Fullname",
+        email="victim-pii@example.com",
+        password_hash=hash_password("victimpass123"),
+    )
+    db_session.add(victim)
+    await db_session.commit()
+
+    with caplog.at_level(logging.DEBUG, logger="aris.routes.auth"):
+        response = await client.post(
+            "/login",
+            json={"email": "unknown-attacker@example.com", "password": "wrongpass"},
+        )
+
+    assert response.status_code == 400
+    # Inspect only what the login handler logs, not DB-driver query echo noise.
+    auth_logs = "\n".join(
+        record.getMessage() for record in caplog.records if record.name == "aris.routes.auth"
+    )
+    assert "victim-pii@example.com" not in auth_logs
+    assert "Victim Fullname" not in auth_logs
+    # Sentinel for the removed diagnostic block that dumped existing users.
+    assert "Existing users" not in auth_logs
+
+
 async def test_refresh_rejects_deleted_user(client: AsyncClient, db_session):
     """POST /refresh rejects token for a deleted user."""
     from datetime import UTC, datetime

--- a/backend/tests/test_routes/test_routes_health.py
+++ b/backend/tests/test_routes/test_routes_health.py
@@ -99,25 +99,54 @@ async def test_health_check_response_structure(client):
     """Test health endpoint returns properly structured response."""
     response = await client.get("/health")
     data = response.json()
-    
+
     # Required top-level fields
     required_fields = ["status", "message", "checks", "timestamp"]
     for field in required_fields:
         assert field in data, f"Missing required field: {field}"
-    
+
     # Check structure of all health checks
     expected_checks = ["api", "database", "email_service", "rsm_rendering", "environment_config"]
     for check_name in expected_checks:
         assert check_name in data["checks"]
-        
+
         check = data["checks"][check_name]
         assert "status" in check
         assert "message" in check
         assert "response_time_ms" in check
-        
+
         # Validate response times are numbers
         assert isinstance(check["response_time_ms"], (int, float))
         assert check["response_time_ms"] >= 0
-        
+
         # Validate status values
         assert check["status"] in ["healthy", "degraded", "unhealthy", "disabled"]
+
+
+# --- /debug/user-state gating (std-9xtntz) ---
+
+
+async def test_debug_user_state_requires_auth(client):
+    """Unauthenticated access to /debug/user-state is rejected outside of PROD."""
+    response = await client.get("/debug/user-state")
+    assert response.status_code in (401, 403)
+
+
+async def test_debug_user_state_allows_authenticated_non_prod(authenticated_client):
+    """An authenticated user can reach /debug/user-state in a non-PROD environment."""
+    response = await authenticated_client.get("/debug/user-state")
+    assert response.status_code == 200
+
+
+async def test_debug_user_state_hidden_in_prod(client, monkeypatch):
+    """/debug/user-state returns 404 in PROD, before auth, to hide its existence."""
+    monkeypatch.setenv("ENV", "PROD")
+    response = await client.get("/debug/user-state")
+    assert response.status_code == 404
+
+
+async def test_debug_user_state_hidden_in_staging(client, monkeypatch):
+    """/debug/user-state is also hidden in STAGING."""
+    monkeypatch.setenv("ENV", "STAGING")
+    response = await client.get("/debug/user-state")
+    assert response.status_code == 404


### PR DESCRIPTION
Two P0 security/privacy fixes, both live production exposures ahead of the closed beta.

## std-fkdh — Login handler logged first 5 users' id/email/name on failed login (PII to logs)
On a failed login for an unknown email, the login handler ran `SELECT id, email, name FROM users LIMIT 5` and wrote each user's id, email, and name to the warning log. That is other users' PII leaking to logs on any failed login attempt.

**Fix:** removed the leftover diagnostic block in `backend/aris/routes/auth.py` (and the now-unused `text` import). A failed login now logs no user-identifying data. The existing "Failed login attempt for email: <attempted email>" line is kept, since that email is the request's own input, not other users' data.

**Test:** `test_failed_login_does_not_log_existing_users_pii` seeds a user, attempts a login with an unknown email, and asserts the `aris.routes.auth` logger emits none of the seeded user's email/name (scoped to that logger so DB-driver query echo does not create false positives). Verified it fails against the old code and passes with the fix.

## std-9xtntz — Gate /debug/user-state behind auth + non-PROD check
`/debug/user-state` in `backend/main.py` returned full user state (id, email, name, files, tags) to anyone who knew `TEST_USER_EMAIL`, with no authentication and no environment guard. `/debug/reload` right next to it already guards PROD/STAGING; this one did not.

**Fix:** added a decorator-level `_forbid_debug_in_prod` dependency that returns **404** in PROD/STAGING (404 rather than 403 so the endpoint's existence is not revealed). Because decorator dependencies are evaluated before parameter dependencies, the env guard runs before auth, so PROD requests never reach the auth check. Added `current_user` as a dependency so non-PROD access requires authentication. Mirrors the existing `/debug/reload` guard.

**Tests:** unauthenticated access is rejected (401/403), authenticated non-PROD access succeeds (200), and PROD and STAGING both return 404.

No other caller of `/debug/user-state` exists in the repo (frontend, E2E, scripts all checked), so requiring auth does not break any existing flow.

## Verification
- `uv run pytest tests/test_routes/test_routes_auth.py tests/test_routes/test_routes_health.py` — 34 passed
- `uv run ruff check` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)