### PR TITLE
fix(security): stop logging user email as PII on every authenticated request

### DIFF
--- a/backend/aris/crud/user.py
+++ b/backend/aris/crud/user.py
@@ -39,35 +39,10 @@ async def get_user(user_id: int, db: AsyncSession):
     User or None
         The user object if found and not deleted, None otherwise.
     """
-    import logging
-
-    logger = logging.getLogger("aris.crud.user")
-    logger.info(f"[get_user] Querying for user_id={user_id}")
-    logger.info(f"[get_user] DB session: {db}, in_transaction: {db.in_transaction()}")
-
     result: Result[Any] = await db.execute(
         select(User).where(User.id == user_id, User.deleted_at.is_(None))
     )
-    user = result.scalars().first()
-
-    logger.info(f"[get_user] Result: {user}")
-    if user:
-        logger.info(
-            f"[get_user] Found user: id={user.id}, email={user.email}, deleted_at={user.deleted_at}"
-        )
-    else:
-        logger.warning(f"[get_user] User {user_id} not found in database")
-        # Query without deleted_at check to see if user exists but is deleted
-        check_result = await db.execute(select(User).where(User.id == user_id))
-        check_user = check_result.scalars().first()
-        if check_user:
-            logger.warning(
-                f"[get_user] User {user_id} exists but is DELETED: deleted_at={check_user.deleted_at}"
-            )
-        else:
-            logger.warning(f"[get_user] User {user_id} does not exist at all in database")
-
-    return user
+    return result.scalars().first()
 
 
 async def create_user(name: str, initials: str, email: str, password_hash: str, db: AsyncSession):
@@ -312,18 +287,9 @@ async def get_user_files(user_id: int, with_tags: bool, db: AsyncSession):
     Tags are fetched concurrently if requested to optimize performance.
     Includes all files where user has any permission level.
     """
-    import logging
-
-    logger = logging.getLogger("aris.crud.user")
-    logger.info(f"[get_user_files] Called for user_id={user_id}, with_tags={with_tags}")
-    logger.info(f"[get_user_files] DB session: {db}, in_transaction: {db.in_transaction()}")
-
     user = await get_user(user_id, db)
     if not user:
-        logger.error(f"[get_user_files] User {user_id} not found, raising ValueError")
         raise ValueError(f"User {user_id} not found")
-
-    logger.info(f"[get_user_files] User found: id={user.id}, email={user.email}")
 
     role_order = case(
         (FilePermission.role == FileRole.OWNER, 1),

--- a/backend/aris/logging_config.py
+++ b/backend/aris/logging_config.py
@@ -10,22 +10,32 @@ import sys
 from typing import Optional
 
 
+def _resolve_log_level() -> str:
+    """Resolve the default log level from the environment.
+
+    PROD and STAGING must never run at DEBUG: DEBUG lets verbose diagnostics
+    (including any accidental PII) reach prod logs and Sentry breadcrumbs. Only
+    local development defaults to DEBUG.
+    """
+    env = os.getenv("ENV", "LOCAL")
+    ci_mode = bool(os.getenv("CI")) or env == "CI"
+
+    if env in ("PROD", "STAGING"):
+        return "INFO"
+    if ci_mode:
+        return "INFO"
+    return "DEBUG"
+
+
 def setup_logging(log_level: Optional[str] = None) -> None:
     """Configure application logging.
-    
+
     Args:
         log_level: Override log level. If None, uses environment-based defaults.
     """
-    # Determine log level based on environment
     if log_level is None:
-        env = os.getenv("ENV", "LOCAL")
-        ci_mode = os.getenv("CI") or env == "CI"
-        
-        if ci_mode:
-            log_level = "INFO"
-        else:
-            log_level = "DEBUG"
-    
+        log_level = _resolve_log_level()
+
     # Configure root logger
     logging.basicConfig(
         level=getattr(logging, log_level.upper()),

--- a/backend/aris/routes/user.py
+++ b/backend/aris/routes/user.py
@@ -424,14 +424,8 @@ async def get_user_files(
     -----
     Requires authentication. Returns files ordered by last edited date.
     """
-    import logging
-    logger = logging.getLogger("aris.routes.user")
-    logger.info(f"[get_user_files route] Called for user_id={user_id}, with_tags={with_tags}")
-    logger.info(f"[get_user_files route] DB session: {db}, in_transaction: {db.in_transaction()}")
-
     try:
         result = await crud.get_user_files(user_id, with_tags, db)
-        logger.info(f"[get_user_files route] Success: returning {len(result)} files")
 
         # Add rendered HTML for home page minimap
         from ..deps import get_file_service
@@ -442,8 +436,7 @@ async def get_user_files(
             f["html"] = html or ""
 
         return result
-    except ValueError as e:
-        logger.error(f"[get_user_files route] ValueError: {e}")
+    except ValueError:
         raise not_found_exception("User", user_id)
 
 

--- a/backend/tests/test_crud/test_crud_user.py
+++ b/backend/tests/test_crud/test_crud_user.py
@@ -1,5 +1,6 @@
 """Tests for user CRUD operations."""
 
+import logging
 from datetime import datetime
 from unittest.mock import patch
 
@@ -22,6 +23,28 @@ async def test_get_user_returns_correct_user(db_session, test_user):
     fetched = await get_user(test_user.id, db_session)
     assert fetched.id == test_user.id
     assert fetched.email == test_user.email
+
+
+async def test_get_user_does_not_log_user_email(db_session, test_user, caplog):
+    """get_user must not leak the user's email (PII) to logs.
+
+    current_user calls get_user on every authenticated request, so any email
+    emitted here reaches prod logs and Sentry breadcrumbs on every hit.
+    """
+    with caplog.at_level(logging.DEBUG, logger="aris.crud.user"):
+        await get_user(test_user.id, db_session)
+
+    assert test_user.email not in caplog.text
+    assert test_user.name not in caplog.text
+
+
+async def test_get_user_files_does_not_log_user_email(db_session, test_user, caplog):
+    """get_user_files must not leak the user's email (PII) to logs."""
+    with caplog.at_level(logging.DEBUG, logger="aris.crud.user"):
+        await get_user_files(test_user.id, with_tags=False, db=db_session)
+
+    assert test_user.email not in caplog.text
+    assert test_user.name not in caplog.text
 
 
 async def test_create_user_sets_defaults(db_session):

--- a/backend/tests/test_logging_config.py
+++ b/backend/tests/test_logging_config.py
@@ -1,0 +1,31 @@
+"""Tests for logging configuration level resolution."""
+
+import pytest
+
+from aris.logging_config import _resolve_log_level
+
+
+@pytest.mark.parametrize(
+    "env, ci, expected",
+    [
+        ("PROD", None, "INFO"),
+        ("STAGING", None, "INFO"),
+        ("CI", None, "INFO"),
+        ("LOCAL", "true", "INFO"),
+        ("LOCAL", None, "DEBUG"),
+    ],
+)
+def test_resolve_log_level(monkeypatch, env, ci, expected):
+    monkeypatch.setenv("ENV", env)
+    if ci is None:
+        monkeypatch.delenv("CI", raising=False)
+    else:
+        monkeypatch.setenv("CI", ci)
+    assert _resolve_log_level() == expected
+
+
+def test_prod_never_resolves_to_debug(monkeypatch):
+    """PROD at DEBUG would leak verbose diagnostics/PII to prod logs and Sentry."""
+    monkeypatch.setenv("ENV", "PROD")
+    monkeypatch.delenv("CI", raising=False)
+    assert _resolve_log_level() != "DEBUG"


### PR DESCRIPTION
## Problem (std-hotu, P1)

Found in the closed-beta security audit. `get_user` runs on **every** authenticated request (`current_user` -> `get_user`) and logged the user's **email at INFO**, plus DB-session repr, `in_transaction` state, and an extra all-rows fallback query. `get_user_files` logged the email too. Because the prod log level resolved to **DEBUG** (only CI got INFO) and `setup_logging()` is called with no args in `main.py`, all of this emitted in production, leaking PII to prod logs and Sentry breadcrumbs (which capture log records as breadcrumbs on error events even with `send_default_pii=False`).

## Fix

- **`crud/user.py`**: stripped the `[get_user]` / `[get_user_files]` instrumentation (Querying / Found / DB-session / all-rows-fallback logs). Function behavior is identical; the extra diagnostic query is removed along with the logging.
- **`routes/user.py`**: removed the matching `[get_user_files route]` debug logs (same leftover dev instrumentation emitted at INFO on every home-page load; no PII but same noise).
- **`logging_config.py`**: default log level now resolves to **INFO** for PROD/STAGING (and CI); only local dev stays at DEBUG. Level resolution extracted into `_resolve_log_level()` for testing.

## Tests (TDD)

- `test_get_user_does_not_log_user_email` / `test_get_user_files_does_not_log_user_email`: `caplog` scoped to `aris.crud.user` at DEBUG, assert the user's email/name never appear in log output. Confirmed **red** against the old code, green after the fix.
- `test_logging_config.py`: parametrized level resolution and an explicit assertion that PROD never resolves to DEBUG.

## Verification

`uv run pytest tests/test_crud/test_crud_user.py tests/test_logging_config.py tests/test_routes/test_routes_user.py tests/test_authorization.py` — all pass (30 + 96). `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)