### PR TITLE
feat(frontend): hide annotations/comments/reactions behind a feature flag (std-cid4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ FRONTEND_CONTAINER_PORT=5173
 STORYBOOK_PORT=6006
 VITE_API_BASE_URL=http://localhost:8000
 
+# Feature flags
+# Annotations/comments/reactions UI (highlights, notes, marginalia, minimap
+# ticks). OFF unless set to "true"; hidden for the closed beta. Local dev
+# compose defaults this ON. See bead std-cid4.
+VITE_FEATURE_ANNOTATIONS=true
+
 # Multi-player collaboration server configuration (Y.js WebSocket)
 MULTIPLAYER_PORT=1234
 VITE_MULTIPLAYER_URL=ws://localhost:1234

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -62,6 +62,8 @@ services:
       - PROXY_API_TARGET=http://backend:${BACKEND_CONTAINER_PORT:?BACKEND_CONTAINER_PORT is required}
       - VITE_MULTIPLAYER_URL=${VITE_MULTIPLAYER_URL}
       - VITE_ENV=${ENV:-ci}
+      # Keep annotations ON in CI so the annotation e2e suites keep exercising it.
+      - VITE_FEATURE_ANNOTATIONS=true
     command: pnpm run dev --host 0.0.0.0
 
   site:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -58,6 +58,9 @@ services:
       - PROXY_API_TARGET=http://backend:${BACKEND_CONTAINER_PORT:?BACKEND_CONTAINER_PORT is required}
       - VITE_MULTIPLAYER_URL=${VITE_MULTIPLAYER_URL}
       - VITE_ENV=${ENV:-local}
+      # Annotations/collaboration UI. Defaults ON for local dev; set to false to
+      # preview the closed-beta experience (feature hidden). See std-cid4.
+      - VITE_FEATURE_ANNOTATIONS=${VITE_FEATURE_ANNOTATIONS:-true}
     command: pnpm run dev --host 0.0.0.0
 
   # frontend-test is removed — tests run from OUTSIDE containers (see CLAUDE.md).

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -11,3 +11,8 @@ VITE_API_BASE_URL_PROD=https://your-production-api.example.com
 # Dev login credentials: when VITE_ENV=DEV, prefill login form from these values
 VITE_DEV_LOGIN_EMAIL=
 VITE_DEV_LOGIN_PASSWORD=
+
+# Feature flags
+# Annotations/comments/reactions UI. OFF unless "true"; hidden for the closed
+# beta so any deployment that omits it hides the feature. See bead std-cid4.
+VITE_FEATURE_ANNOTATIONS=true

--- a/frontend/src/components/manuscript/ManuscriptWrapper.vue
+++ b/frontend/src/components/manuscript/ManuscriptWrapper.vue
@@ -13,6 +13,7 @@
     nextTick,
   } from "vue";
   import { useHighlightRenderer } from "@/composables/useHighlightRenderer.js";
+  import { annotationsEnabled } from "@/config/features.js";
   import "tooltipster/dist/css/tooltipster.bundle.min.css";
   import tooltipsterUrl from "tooltipster/dist/js/tooltipster.bundle.min.js?url";
 
@@ -93,19 +94,18 @@
         await onrender.value(mountPoint);
       }
 
-      mountPoint.querySelectorAll('mjx-container[tabindex]').forEach(el => {
-        el.removeAttribute('tabindex');
+      mountPoint.querySelectorAll("mjx-container[tabindex]").forEach((el) => {
+        el.removeAttribute("tabindex");
       });
-      mountPoint.querySelectorAll('.hr a[href]').forEach(el => {
-        el.setAttribute('tabindex', '-1');
+      mountPoint.querySelectorAll(".hr a[href]").forEach((el) => {
+        el.setAttribute("tabindex", "-1");
       });
-
     } catch (err) {
       console.error("Render error:", err);
     } finally {
       executeRenderInProgress = false;
       await nextTick();
-      applyHighlights();
+      if (annotationsEnabled) applyHighlights();
     }
   };
 
@@ -128,7 +128,7 @@
 
   let cleanupClickHandler = null;
   onMounted(() => {
-    cleanupClickHandler = setupClickHandler();
+    if (annotationsEnabled) cleanupClickHandler = setupClickHandler();
   });
   onUnmounted(() => {
     cleanupClickHandler?.();
@@ -157,7 +157,7 @@
       <div class="footer-logo"><Logo type="small" /></div>
     </div>
 
-    <AnnotationMenu />
+    <AnnotationMenu v-if="annotationsEnabled" />
   </div>
 </template>
 
@@ -213,8 +213,12 @@
   }
 
   @keyframes synctarget-fade-bg {
-    0% { background-color: color-mix(in srgb, var(--orange-200) 40%, transparent); }
-    100% { background-color: transparent; }
+    0% {
+      background-color: color-mix(in srgb, var(--orange-200) 40%, transparent);
+    }
+    100% {
+      background-color: transparent;
+    }
   }
 
   .cm-synctarget-gutter {

--- a/frontend/src/config/features.js
+++ b/frontend/src/config/features.js
@@ -1,0 +1,17 @@
+/**
+ * Frontend feature flags.
+ *
+ * `annotationsEnabled` gates the collaboration UI deferred for the closed beta:
+ * the selection Mark/Note/Comment toolbar, annotation keyboard shortcuts,
+ * marginalia cards/overlay, manuscript highlights, minimap annotation/reaction
+ * ticks, the "Marginalia" search scope, and home-card annotation/reaction data.
+ *
+ * It is OFF unless `VITE_FEATURE_ANNOTATIONS` is explicitly the string "true",
+ * so any deployment that does not set the variable hides the feature. Dev and CI
+ * set it to "true" so the feature stays visible and its tests keep exercising it.
+ * To re-enable annotations in a deployment, set VITE_FEATURE_ANNOTATIONS=true.
+ *
+ * Reversibility: this flag only hides UI/data flow; no annotation code is
+ * removed. Flipping it back on restores the full experience. See bead std-cid4.
+ */
+export const annotationsEnabled = import.meta.env.VITE_FEATURE_ANNOTATIONS === "true";

--- a/frontend/src/tests/config/annotationsFeatureFlag.test.js
+++ b/frontend/src/tests/config/annotationsFeatureFlag.test.js
@@ -1,0 +1,134 @@
+// std-cid4 — annotations/comments/reactions are hidden for the closed beta via
+// the `annotationsEnabled` feature flag. These tests force the flag OFF and prove
+// each gated entry point does not render. Each assertion is self-validating: a
+// sibling element that is NOT gated (manuscript mount point, section ticks,
+// output/source scope chips) is asserted present, so an absent annotation
+// element means the gate worked, not that the component failed to mount.
+//
+// Existing suites run with the flag ON (VITE_FEATURE_ANNOTATIONS="true" in
+// vite.config test.env) and already cover the enabled behavior.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+
+// Force the beta behavior (feature OFF) for this whole file.
+vi.mock("@/config/features.js", () => ({ annotationsEnabled: false }));
+
+// ManuscriptWrapper loads RSM assets via dynamic import in onBeforeMount.
+const onloadStub = vi.fn();
+vi.mock("/static/onload.js", () => ({ onload: onloadStub }), { virtual: true });
+
+// Feed ScrollbarMinimap annotation + feedback marks so we prove they are
+// filtered at render time even when the underlying data is present.
+vi.mock("@/composables/useMinimapMarks.js", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    useMinimapMarks: vi.fn(() => ({
+      marks: ref([
+        { top: 0.1, color: "var(--gray-300)", type: "section", id: "s1", level: 1 },
+        { top: 0.5, color: "var(--purple-600)", type: "annotation", id: "a1", label: "note" },
+        { top: 0.7, color: "var(--red-400)", type: "feedback", id: "f1", label: "Heart" },
+      ]),
+      computeMarks: vi.fn(),
+    })),
+  };
+});
+
+import ManuscriptWrapper from "@/components/manuscript/ManuscriptWrapper.vue";
+import ScrollbarMinimap from "@/views/workspace/ScrollbarMinimap.vue";
+import TopbarSearch from "@/views/workspace/TopbarSearch.vue";
+import * as HSM from "@/utils/highlightSearchMatches.js";
+import * as KSMod from "@/composables/useKeyboardShortcuts.js";
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("annotations feature flag OFF", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = null;
+    }
+  });
+
+  it("ManuscriptWrapper renders the manuscript but not the selection AnnotationMenu", async () => {
+    const api = { defaults: { baseURL: "" } };
+    wrapper = mount(ManuscriptWrapper, {
+      props: { htmlString: "<div>content</div>", keys: false },
+      global: {
+        provide: { api },
+        stubs: {
+          Teleport: true,
+          AnnotationMenu: {
+            name: "AnnotationMenuStub",
+            template: '<div data-testid="annotation-menu-stub"></div>',
+          },
+        },
+      },
+    });
+    await flushPromises();
+
+    // Control: the manuscript itself renders (mount succeeded).
+    expect(wrapper.find(".manuscriptwrapper").exists()).toBe(true);
+    // Gate: the Mark/Note/Comment toolbar is not mounted.
+    expect(wrapper.find('[data-testid="annotation-menu-stub"]').exists()).toBe(false);
+  });
+
+  it("ScrollbarMinimap renders section ticks but hides annotation and reaction ticks", () => {
+    wrapper = mount(ScrollbarMinimap, {
+      props: { file: { id: 1, html: "<p>content</p>", source: "# hi" } },
+      global: {
+        provide: {
+          manuscriptRef: ref(null),
+          annotations: ref([]),
+          reactions: ref([]),
+          awareness: ref(null),
+          columnSizes: { inner: { height: 400 } },
+        },
+      },
+    });
+
+    // Control: non-annotation marks still render.
+    expect(wrapper.findAll(".mm-section").length).toBe(1);
+    // Gate: annotation and reaction (feedback) ticks are gone.
+    expect(wrapper.findAll(".mm-annotation").length).toBe(0);
+    expect(wrapper.findAll(".mm-feedback").length).toBe(0);
+  });
+
+  it("TopbarSearch advanced scopes exclude the Marginalia chip", async () => {
+    vi.spyOn(HSM, "highlightSearchMatches").mockReturnValue([]);
+    vi.spyOn(HSM, "clearHighlights").mockImplementation(() => {});
+    vi.spyOn(HSM, "updateCurrentMatch").mockImplementation(() => {});
+    vi.spyOn(KSMod, "useKeyboardShortcuts").mockImplementation(() => ({
+      activate: vi.fn(),
+      deactivate: vi.fn(),
+    }));
+
+    wrapper = mount(TopbarSearch, {
+      global: {
+        provide: {
+          manuscriptRef: ref({ $el: document.createElement("div") }),
+          file: ref({ source: "test content" }),
+          showSearch: ref(true),
+        },
+        stubs: { ButtonClose: true, ButtonToggle: true },
+      },
+    });
+
+    await wrapper.find("[data-testid='search-toggle-advanced']").trigger("click");
+
+    // Control: the non-annotation scopes still render.
+    expect(wrapper.find("[data-testid='scope-chip-output']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='scope-chip-source']").exists()).toBe(true);
+    // Gate: the annotation-targeting Marginalia scope is gone.
+    expect(wrapper.find("[data-testid='scope-chip-marginalia']").exists()).toBe(false);
+    expect(wrapper.findAll("button-toggle-stub").length).toBe(2);
+  });
+});

--- a/frontend/src/views/home/FilesItem.vue
+++ b/frontend/src/views/home/FilesItem.vue
@@ -15,6 +15,7 @@
   import { useRouter } from "vue-router";
   import { useKeyboardShortcuts } from "@/composables/useKeyboardShortcuts.js";
   import { File } from "@/models/File.js";
+  import { annotationsEnabled } from "@/config/features.js";
   import { downloadBlob } from "@/utils/download.js";
   import Date from "./FilesItemDate.vue";
   import FilesItemCollaborators from "./FilesItemCollaborators.vue";
@@ -36,9 +37,11 @@
 
   // Minimap: provide annotations/reactions so ScrollbarMinimap can render marks.
   // Data comes from file store (no per-item API calls).
+  // Annotation/reaction ticks on home cards are hidden for the closed beta;
+  // provide empty lists so no annotation/reaction data reaches the minimap.
   const manuscriptRef = useTemplateRef("manuscript-ref");
-  const fileAnnotations = computed(() => file.value?.annotations || []);
-  const fileReactions = computed(() => file.value?.reactions || []);
+  const fileAnnotations = computed(() => (annotationsEnabled ? file.value?.annotations || [] : []));
+  const fileReactions = computed(() => (annotationsEnabled ? file.value?.reactions || [] : []));
   provide("manuscriptRef", manuscriptRef);
   provide("annotations", fileAnnotations);
   provide("reactions", fileReactions);
@@ -86,7 +89,7 @@
       const response = await api.post(
         `/files/${file.value.id}/download`,
         {},
-        { responseType: "blob" },
+        { responseType: "blob" }
       );
 
       const blob = new Blob([response.data], { type: "text/html" });
@@ -106,7 +109,7 @@
       const response = await api.post(
         `/files/${file.value.id}/download/pdf`,
         {},
-        { responseType: "blob", timeout: 120000 },
+        { responseType: "blob", timeout: 120000 }
       );
 
       const blob = new Blob([response.data], { type: "application/pdf" });
@@ -208,7 +211,12 @@
 
       <template v-if="!xsMode">
         <div class="minimap-cell">
-          <ScrollbarMinimap :file="file" mode="compact" orientation="horizontal" @mark-click="onMarkClick" />
+          <ScrollbarMinimap
+            :file="file"
+            mode="compact"
+            orientation="horizontal"
+            @mark-click="onMarkClick"
+          />
         </div>
         <TagRow :file="file" />
         <div class="spacer"></div>

--- a/frontend/src/views/workspace/Canvas.vue
+++ b/frontend/src/views/workspace/Canvas.vue
@@ -20,6 +20,7 @@
   import { registerAsFallback } from "@/composables/useKeyboardShortcuts.js";
   import { useHeadInjection } from "@/composables/useHeadInjection.js";
   import { useSourcePreviewNav } from "@/composables/useSourcePreviewNav.js";
+  import { annotationsEnabled } from "@/config/features.js";
   import { IconMessageFilled } from "@/components/base/iconRegistry.js";
   import useClosable from "@/composables/useClosable.js";
   import ReaderTopbar from "./ReaderTopbar.vue";
@@ -400,6 +401,7 @@
   const annotations = inject("annotations", ref([]));
   const activeAnnotationId = inject("activeAnnotationId", ref(null));
   const hasAnnotations = computed(() => {
+    if (!annotationsEnabled) return false;
     const list = isRef(annotations) ? annotations.value : annotations;
     return list && list.length > 0;
   });
@@ -534,7 +536,9 @@
 
           <Transition name="overlay-slide">
             <div
-              v-if="annotationOverlayOpen && (!showAnnotationCards || focusMode)"
+              v-if="
+                annotationsEnabled && annotationOverlayOpen && (!showAnnotationCards || focusMode)
+              "
               ref="overlay-panel-ref"
               class="annotation-overlay"
               role="complementary"

--- a/frontend/src/views/workspace/ScrollbarMinimap.vue
+++ b/frontend/src/views/workspace/ScrollbarMinimap.vue
@@ -1,6 +1,7 @@
 <script setup>
   import { ref, computed, inject, watch, nextTick, onMounted, onUnmounted } from "vue";
   import { useMinimapMarks, FEEDBACK_COLORS } from "@/composables/useMinimapMarks.js";
+  import { annotationsEnabled } from "@/config/features.js";
   import Tooltip from "@/components/base/Tooltip.vue";
 
   const hoveredMark = ref(null);
@@ -37,7 +38,13 @@
     file: computed(() => props.file),
   });
 
-  const allMarks = computed(() => marks.value);
+  // Annotation and reaction (feedback) ticks are hidden for the closed beta.
+  // Filtering here also keeps them out of hover/click navigation below.
+  const allMarks = computed(() =>
+    annotationsEnabled
+      ? marks.value
+      : marks.value.filter((m) => m.type !== "annotation" && m.type !== "feedback")
+  );
   const sectionMarks = computed(() => allMarks.value.filter((m) => m.type === "section"));
   const annotationMarks = computed(() => allMarks.value.filter((m) => m.type === "annotation"));
   const searchMarks = computed(() => allMarks.value.filter((m) => m.type === "search"));
@@ -109,8 +116,14 @@
         const noop = () => {};
         hoveredEl.value = {
           getBoundingClientRect: () => ({
-            top: markY - 4, bottom: markY + 4, left: rect.left, right: rect.right,
-            width: rect.width, height: 8, x: rect.left, y: markY - 4,
+            top: markY - 4,
+            bottom: markY + 4,
+            left: rect.left,
+            right: rect.right,
+            width: rect.width,
+            height: 8,
+            x: rect.left,
+            y: markY - 4,
           }),
           addEventListener: noop,
           removeEventListener: noop,
@@ -216,7 +229,11 @@
   <div
     ref="stripRef"
     class="scrollbar-minimap"
-    :class="[mode, orientation, { compact: isCompact, dragging: isDragging, 'has-hovered': hoveredMark }]"
+    :class="[
+      mode,
+      orientation,
+      { compact: isCompact, dragging: isDragging, 'has-hovered': hoveredMark },
+    ]"
     @pointerdown="onStripPointerDown"
     @pointermove="onStripPointerMove"
     @pointerup="onStripPointerUp"
@@ -237,7 +254,11 @@
       v-for="mark in sectionMarks"
       :key="mark.id"
       class="mm-section"
-      :class="{ 'level-1': mark.level === 1, hovered: isHovered(mark), 'near-hovered': isNearHovered(mark) }"
+      :class="{
+        'level-1': mark.level === 1,
+        hovered: isHovered(mark),
+        'near-hovered': isNearHovered(mark),
+      }"
       :style="posStyle(mark.top)"
     />
 
@@ -326,27 +347,45 @@
     transform: scaleX(0.75);
     transform-origin: center;
     opacity: 0.3;
-    transition: transform 0.25s ease, opacity 0.25s ease, width 0.15s ease, box-shadow 0.15s ease, margin-inline 0.15s ease, background-color 0.15s ease, height 0.15s ease;
+    transition:
+      transform 0.25s ease,
+      opacity 0.25s ease,
+      width 0.15s ease,
+      box-shadow 0.15s ease,
+      margin-inline 0.15s ease,
+      background-color 0.15s ease,
+      height 0.15s ease;
   }
 
   .scrollbar-minimap .mm-annotation::after {
     transform: scaleX(0.75);
     transform-origin: left;
     opacity: 0.3;
-    transition: transform 0.25s ease, opacity 0.25s ease, width 0.15s ease, box-shadow 0.15s ease;
+    transition:
+      transform 0.25s ease,
+      opacity 0.25s ease,
+      width 0.15s ease,
+      box-shadow 0.15s ease;
   }
 
   .scrollbar-minimap .mm-feedback::after {
     transform: scaleX(0.75);
     transform-origin: right;
     opacity: 0.3;
-    transition: transform 0.25s ease, opacity 0.25s ease, width 0.15s ease, box-shadow 0.15s ease;
+    transition:
+      transform 0.25s ease,
+      opacity 0.25s ease,
+      width 0.15s ease,
+      box-shadow 0.15s ease;
   }
 
   .scrollbar-minimap .mm-presence {
     transform: translate(-50%, -50%) scale(0.75);
     opacity: 0.3;
-    transition: transform 0.25s ease, opacity 0.25s ease, top 300ms ease-out;
+    transition:
+      transform 0.25s ease,
+      opacity 0.25s ease,
+      top 300ms ease-out;
   }
 
   .scrollbar-minimap:hover .mm-section::after,
@@ -621,7 +660,9 @@
     transform: translate(-50%, -50%);
     pointer-events: none;
     z-index: 1;
-    transition: top 300ms ease-out, transform 0.15s ease;
+    transition:
+      top 300ms ease-out,
+      transform 0.15s ease;
     box-shadow: 0 0 0 2px var(--surface-page, #fff);
   }
 

--- a/frontend/src/views/workspace/TopbarSearch.vue
+++ b/frontend/src/views/workspace/TopbarSearch.vue
@@ -3,6 +3,7 @@
   import { IconSearch, IconAdjustmentsHorizontal } from "@/components/base/iconRegistry.js";
   import { useKeyboardShortcuts } from "@/composables/useKeyboardShortcuts.js";
   import { useSearch } from "@/composables/useSearch.js";
+  import { annotationsEnabled } from "@/config/features.js";
 
   const manuscriptRef = inject("manuscriptRef");
   const file = inject("file");
@@ -48,7 +49,8 @@
   const scopes = [
     { id: "output", label: "Output" },
     { id: "source", label: "Source" },
-    { id: "marginalia", label: "Marginalia" },
+    // Marginalia search targets annotations, hidden for the closed beta.
+    ...(annotationsEnabled ? [{ id: "marginalia", label: "Marginalia" }] : []),
   ];
 
   const onEnter = (ev) => {

--- a/frontend/src/views/workspace/View.vue
+++ b/frontend/src/views/workspace/View.vue
@@ -1,5 +1,15 @@
 <script setup>
-  import { ref, shallowRef, computed, inject, provide, onMounted, onBeforeUnmount, watch, watchEffect } from "vue";
+  import {
+    ref,
+    shallowRef,
+    computed,
+    inject,
+    provide,
+    onMounted,
+    onBeforeUnmount,
+    watch,
+    watchEffect,
+  } from "vue";
   import { useRoute, useRouter } from "vue-router";
   import { useLocalStorage } from "@vueuse/core";
   import { useKeyboardShortcuts } from "@/composables/useKeyboardShortcuts.js";
@@ -8,6 +18,7 @@
   import { extractAnchor } from "@/utils/anchorExtraction.js";
   import { toast } from "@/utils/toast.js";
   import { useReactions } from "@/composables/useReactions.js";
+  import { annotationsEnabled } from "@/config/features.js";
   import { File } from "@/models/File.js";
   import Sidebar from "./Sidebar.vue";
   import Canvas from "./Canvas.vue";
@@ -84,11 +95,17 @@
   });
   provide("file", file);
 
-  watch(() => file.value?.title, (title) => {
-    document.title = title ? `${title} — RSM Studio` : "RSM Studio";
-  }, { immediate: true });
+  watch(
+    () => file.value?.title,
+    (title) => {
+      document.title = title ? `${title} — RSM Studio` : "RSM Studio";
+    },
+    { immediate: true }
+  );
 
-  onBeforeUnmount(() => { document.title = "RSM Studio"; });
+  onBeforeUnmount(() => {
+    document.title = "RSM Studio";
+  });
 
   // Shared Y.Doc ref — EditorCodeMirror writes to it, useAnnotations observes it
   const ydoc = shallowRef(null);
@@ -143,7 +160,9 @@
   watch(
     fileId,
     (id) => {
-      if (id) {
+      // Annotations/reactions are hidden for the closed beta; skip the fetches
+      // entirely so no annotation/reaction data flows when the flag is off.
+      if (id && annotationsEnabled) {
         fetchAnnotations();
         fetchReactions();
       }
@@ -326,7 +345,7 @@
   }
 
   onMounted(() => {
-    document.addEventListener("keydown", handleAnnotationShortcut);
+    if (annotationsEnabled) document.addEventListener("keydown", handleAnnotationShortcut);
   });
   onBeforeUnmount(() => {
     document.removeEventListener("keydown", handleAnnotationShortcut);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -34,10 +34,11 @@ const envVars = loadEnvFile();
 // Proxy target for the Vite dev server (runs inside Docker container).
 // PROXY_API_TARGET uses Docker service name (e.g. http://backend:8000).
 // Falls back to VITE_API_BASE_URL for local dev without Docker.
-const proxyTarget = process.env.PROXY_API_TARGET
-  || process.env.VITE_API_BASE_URL
-  || envVars.VITE_API_BASE_URL
-  || "http://localhost:8000";
+const proxyTarget =
+  process.env.PROXY_API_TARGET ||
+  process.env.VITE_API_BASE_URL ||
+  envVars.VITE_API_BASE_URL ||
+  "http://localhost:8000";
 
 export default defineConfig({
   plugins: [vue()],
@@ -72,6 +73,9 @@ export default defineConfig({
     fileParallelism: false,
     env: {
       VITE_API_BASE_URL: process.env.VITE_API_BASE_URL || envVars.VITE_API_BASE_URL,
+      // Keep the annotation/collaboration feature ON in unit tests so existing
+      // suites keep exercising it; the flag defaults OFF in real deployments.
+      VITE_FEATURE_ANNOTATIONS: "true",
     },
     exclude: [
       "**/node_modules/**",


### PR DESCRIPTION
## Summary

The closed beta defers annotations/comments/reactions, but the UI was always-on and reachable with no frontend feature-flag mechanism. This adds one and gates every entry point behind it, without deleting any annotation code, so it is cleanly reversible.

**Flag:** `annotationsEnabled` in `frontend/src/config/features.js`, driven by `VITE_FEATURE_ANNOTATIONS`.
- Defaults **OFF** when the variable is unset, so any deployment that omits it hides the feature (beta-safe default).
- **To re-enable annotations** in a deployment: set `VITE_FEATURE_ANNOTATIONS=true`.
- Dev (`docker-compose.dev.yml`), CI (`docker-compose.ci.yml`), and Vitest (`vite.config.js` `test.env`) all set it to `true`, so the feature and its existing tests keep working unchanged.

## Gated entry points

- Selection Mark/Note/Comment toolbar — `ManuscriptWrapper.vue` `<AnnotationMenu>` mount
- Manuscript highlight painting + click-to-select handler — `ManuscriptWrapper.vue`
- Annotation keyboard shortcuts (Cmd+Shift+H/M/K) — `View.vue`
- `fetchAnnotations` / `fetchReactions` — skipped so no annotation/reaction data flows — `View.vue`
- Marginalia cards, narrow-viewport overlay, and toggle button — `Canvas.vue` (`hasAnnotations` lever + overlay `v-if`)
- Minimap annotation + reaction (feedback) ticks — `ScrollbarMinimap.vue` (also covers home file cards)
- "Marginalia" search scope chip — `TopbarSearch.vue`
- Home-card annotation/reaction data — `FilesItem.vue`

## Deliberately left untouched (not collaboration UI)

- App-level **Feedback** user-menu item + `FeedbackModal.vue` (bug reports)
- `EditorToolbar.vue` RSM `%` source-comment button (not a collaboration comment)

## Tests

- New self-validating gating test `frontend/src/tests/config/annotationsFeatureFlag.test.js` forces the flag OFF and asserts the selection toolbar, minimap annotation/reaction ticks, and the Marginalia scope chip do **not** render, while non-gated siblings (manuscript body, section ticks, Output/Source scopes) still do.
- Existing suites run with the flag ON via `test.env`, so annotation coverage is preserved. Targeted runs green: `annotationsFeatureFlag`, `ManuscriptWrapper`, `Minimap`, `TopbarSearch`, `Canvas`, `useMinimapMarks`, `View`, `FilesItem.icons` (159 tests). ESLint clean on all changed files.

Bead: std-cid4

🤖 Generated with [Claude Code](https://claude.com/claude-code)