### PR TITLE
feat(versions): gate restore to sole-participant sessions (std-2spq)

### DIFF
--- a/frontend/src/tests/components/VersionPreviewModal.test.js
+++ b/frontend/src/tests/components/VersionPreviewModal.test.js
@@ -50,7 +50,7 @@ describe("VersionPreviewModal", () => {
 
   const cmViewRef = shallowRef(null);
 
-  function createWrapper(props = {}) {
+  function createWrapper(props = {}, provides = {}) {
     return mount(VersionPreviewModal, {
       props: {
         version: mockVersion,
@@ -62,6 +62,7 @@ describe("VersionPreviewModal", () => {
         provide: {
           api: mockApi,
           cmView: cmViewRef,
+          ...provides,
         },
         components: {
           Button,
@@ -71,6 +72,23 @@ describe("VersionPreviewModal", () => {
         },
       },
     });
+  }
+
+  // Minimal Y.js awareness stub: getStates() returns a Map keyed by clientID, and
+  // on/off register "change" listeners that _emit() can fire to simulate join/leave.
+  function createMockAwareness(clientIds = [1]) {
+    const listeners = new Set();
+    const states = new Map(clientIds.map((id) => [id, { user: { id, name: `User ${id}` } }]));
+    return {
+      getStates: () => states,
+      on: (_event, cb) => listeners.add(cb),
+      off: (_event, cb) => listeners.delete(cb),
+      _setClients(ids) {
+        states.clear();
+        for (const id of ids) states.set(id, { user: { id, name: `User ${id}` } });
+        listeners.forEach((cb) => cb({ added: [], updated: [], removed: [] }));
+      },
+    };
   }
 
   describe("mounting and content fetching", () => {
@@ -339,6 +357,82 @@ describe("VersionPreviewModal", () => {
       expect(dateText).toContain("Oct");
       expect(dateText).toContain("15");
       expect(dateText).toContain("2025");
+    });
+  });
+
+  describe("restore gating by participant count (std-2spq)", () => {
+    it("hides restore and shows a note when another participant is present", async () => {
+      const awareness = shallowRef(createMockAwareness([1, 2]));
+      wrapper = createWrapper({ isOwner: true }, { awareness });
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="restore-version-button"]').exists()).toBe(false);
+      const note = wrapper.find('[data-testid="restore-solo-only-note"]');
+      expect(note.exists()).toBe(true);
+      expect(note.text()).toContain("only one editing");
+    });
+
+    it("shows restore when the owner is the sole participant", async () => {
+      const awareness = shallowRef(createMockAwareness([1]));
+      wrapper = createWrapper({ isOwner: true }, { awareness });
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="restore-version-button"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="restore-solo-only-note"]').exists()).toBe(false);
+    });
+
+    it("shows restore when there is no collab session (awareness unavailable)", async () => {
+      const awareness = shallowRef(null);
+      wrapper = createWrapper({ isOwner: true }, { awareness });
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="restore-version-button"]').exists()).toBe(true);
+    });
+
+    it("reactively disables restore when a second participant joins", async () => {
+      const mock = createMockAwareness([1]);
+      const awareness = shallowRef(mock);
+      wrapper = createWrapper({ isOwner: true }, { awareness });
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="restore-version-button"]').exists()).toBe(true);
+
+      mock._setClients([1, 2]);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="restore-version-button"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="restore-solo-only-note"]').exists()).toBe(true);
+    });
+
+    it("reactively collapses an open confirmation when a peer joins", async () => {
+      const mock = createMockAwareness([1]);
+      const awareness = shallowRef(mock);
+      wrapper = createWrapper({ isOwner: true }, { awareness });
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      await wrapper.find('[data-testid="restore-version-button"]').trigger("click");
+      expect(wrapper.find(".confirmation").exists()).toBe(true);
+
+      mock._setClients([1, 2]);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find(".confirmation").exists()).toBe(false);
+      expect(wrapper.find('[data-testid="restore-solo-only-note"]').exists()).toBe(true);
+    });
+
+    it("shows the owner-only note (not the solo note) for a non-owner with peers", async () => {
+      const awareness = shallowRef(createMockAwareness([1, 2]));
+      wrapper = createWrapper({ isOwner: false }, { awareness });
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find(".owner-only-note").exists()).toBe(true);
+      expect(wrapper.find('[data-testid="restore-solo-only-note"]').exists()).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/e2e/content/version-restore.spec.js
+++ b/frontend/src/tests/e2e/content/version-restore.spec.js
@@ -2,9 +2,10 @@
  * @file E2E tests for version restore functionality
  * @tags @auth @version-restore
  *
- * Tests the core restore flow: owner restores a named version via the
- * preview modal, content is replaced via Y.js (window.__cmView.dispatch),
- * and all connected clients receive the update.
+ * Tests the core restore flow: a sole-participant owner restores a named
+ * version via the preview modal and the content is replaced via Y.js
+ * (window.__cmView.dispatch). Restore is gated to the sole-participant case,
+ * so it is unavailable while another client is connected (std-2spq).
  *
  * Tests for concurrent-editor detection, read-only lock, and in-progress
  * guard are skipped pending implementation of the useAwareness /
@@ -199,16 +200,22 @@ test.describe("Version Restore Tests @auth @version-restore", () => {
     test.skip();
   });
 
-  test("all connected clients see restored content", async ({ page, context }) => {
-    test.setTimeout(90000); // Y.js propagation across two tabs in CI
+  test("restore is unavailable while another client is connected", async ({ page, context }) => {
+    test.setTimeout(90000); // Y.js awareness propagation across two tabs in CI
     const timeouts = getTimeouts();
 
-    // Open a second tab with the editor fully ready (waits for manuscript,
-    // .cm-editor, __cmView, and provider sync — with retry on failure)
+    // Open a second tab connected to the same document. A whole-document restore
+    // garbles concurrent edits, so restore is only offered to a sole participant
+    // (std-2spq): with a peer present, the button is hidden and a note is shown.
     const page2 = await context.newPage();
     await openFileInEditor(page2, fileId);
 
-    // page1: restore the version
+    // Wait until page1's awareness reflects the second client (self + peer = 2).
+    await page.waitForFunction(() => (window.__awareness?.getStates().size ?? 0) >= 2, null, {
+      timeout: timeouts.heavyOperation,
+    });
+
+    // Open the version preview modal on page1
     await page.locator('[data-testid="version-item"]').first().locator(".version-info").click();
     await page.waitForSelector('[data-testid="version-preview-modal"]', {
       timeout: timeouts.heavyOperation,
@@ -217,23 +224,13 @@ test.describe("Version Restore Tests @auth @version-restore", () => {
       state: "hidden",
       timeout: timeouts.heavyOperation,
     });
-    await page.click('[data-testid="restore-version-button"]');
-    await page.waitForSelector('[data-testid="restore-confirm-dialog"]');
-    await page.click('[data-testid="confirm-restore-button"]');
-    await expect(page.locator('[data-testid="version-preview-modal"]')).not.toBeVisible({
-      timeout: timeouts.heavyOperation,
-    });
 
-    // Wait for Y.js to propagate the restoration to page2
-    await page2.waitForFunction(
-      () => window.__cmView?.state.doc.toString().includes("Original Content"),
-      null,
-      { timeout: timeouts.heavyOperation }
+    // Restore is gated: the button is hidden and the sole-participant note is shown.
+    await expect(page.locator('[data-testid="restore-version-button"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="restore-solo-only-note"]')).toBeVisible();
+    await expect(page.locator('[data-testid="restore-solo-only-note"]')).toContainText(
+      "only one editing"
     );
-
-    const content2 = await page2.evaluate(() => window.__cmView.state.doc.toString());
-    expect(content2).toContain("Original Content");
-    expect(content2).not.toContain("Modified Content");
 
     await page2.close();
   });

--- a/frontend/src/views/workspace/Canvas.vue
+++ b/frontend/src/views/workspace/Canvas.vue
@@ -48,8 +48,9 @@
   );
   provide("manuscriptRef", manuscriptRef);
 
-  // Shared awareness ref — EditorCodeMirror writes to it, ScrollbarMinimap reads it
-  const awareness = shallowRef(null);
+  // Shared awareness ref — provided by View.vue so Sidebar siblings (DrawerVersions) can
+  // read presence too; EditorCodeMirror writes to it, ScrollbarMinimap reads it.
+  const awareness = inject("awareness", shallowRef(null));
   provide("awareness", awareness);
 
   // Shared CodeMirror view — provided by View.vue, written by EditorCodeMirror

--- a/frontend/src/views/workspace/VersionPreviewModal.vue
+++ b/frontend/src/views/workspace/VersionPreviewModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref, shallowRef, inject, onMounted } from "vue";
+  import { ref, shallowRef, computed, inject, watch, onMounted, onBeforeUnmount } from "vue";
   import { IconX } from "@/components/base/iconRegistry.js";
   import Button from "@/components/base/Button.vue";
 
@@ -13,12 +13,54 @@
 
   const api = inject("api");
   const cmView = inject("cmView", shallowRef(null));
+  // Y.js awareness for the collaborative session (provided by View.vue). Restoring a
+  // version blindly replaces the whole document, which garbles concurrent edits, so we
+  // only offer restore when the current user is the sole participant.
+  const awareness = inject("awareness", shallowRef(null));
 
   const versionContent = ref("");
   const isLoadingContent = ref(false);
   const contentError = ref(null);
   const isRestoring = ref(false);
   const showConfirmation = ref(false);
+
+  // Live count of clients connected to this document's awareness session, including self.
+  // Kept reactive via the awareness "change" event so it updates as peers join or leave
+  // while the modal is open.
+  const participantCount = ref(1);
+
+  function recomputeParticipantCount() {
+    const a = awareness.value;
+    // No collab session (awareness unavailable): treat as a sole user so restore still
+    // works in non-collaborative contexts rather than being hard-blocked.
+    participantCount.value = a ? a.getStates().size : 1;
+  }
+
+  let awarenessCleanup = null;
+  watch(
+    awareness,
+    (a) => {
+      if (awarenessCleanup) {
+        awarenessCleanup();
+        awarenessCleanup = null;
+      }
+      recomputeParticipantCount();
+      if (!a) return;
+      const handler = () => recomputeParticipantCount();
+      a.on("change", handler);
+      awarenessCleanup = () => a.off("change", handler);
+    },
+    { immediate: true }
+  );
+
+  const isSoleParticipant = computed(() => participantCount.value <= 1);
+  const canRestore = computed(() => props.isOwner && isSoleParticipant.value);
+
+  // If a peer joins while the confirmation dialog is open, collapse it back so restore
+  // can no longer be triggered concurrently.
+  watch(canRestore, (ok) => {
+    if (!ok) showConfirmation.value = false;
+  });
 
   // Fetch version content for preview
   async function fetchVersionContent() {
@@ -42,6 +84,13 @@
   }
 
   async function confirmRestore() {
+    // Defensive re-check: a peer may have joined between opening the confirmation and
+    // clicking Restore.
+    if (!canRestore.value) {
+      showConfirmation.value = false;
+      return;
+    }
+
     const view = cmView.value;
     if (!view) {
       alert("Editor not available. Please open the source editor and try again.");
@@ -103,9 +152,9 @@
   });
 
   // Cleanup
-  import { onBeforeUnmount } from "vue";
   onBeforeUnmount(() => {
     window.removeEventListener("keydown", handleKeydown, { capture: true });
+    if (awarenessCleanup) awarenessCleanup();
   });
 </script>
 
@@ -197,7 +246,7 @@
         <div v-else class="actions">
           <Button kind="secondary" size="md" text="Close" :disabled="isRestoring" @click="close" />
           <Button
-            v-if="isOwner"
+            v-if="canRestore"
             kind="primary"
             size="md"
             :text="`Restore v${version.version_number}`"
@@ -206,6 +255,13 @@
             title="Restore this version (Owner only)"
             @click="handleRestoreClick"
           />
+          <div
+            v-else-if="isOwner"
+            class="restore-blocked-note"
+            data-testid="restore-solo-only-note"
+          >
+            Restore is only available when you're the only one editing this document.
+          </div>
           <div v-else class="owner-only-note">Only the file owner can restore versions</div>
         </div>
       </div>
@@ -407,10 +463,13 @@
     gap: 12px;
   }
 
-  .owner-only-note {
+  .owner-only-note,
+  .restore-blocked-note {
     font-size: 13px;
     color: var(--text-disabled);
     font-style: italic;
+    text-align: right;
+    max-width: 60%;
   }
 
   .btn-primary,

--- a/frontend/src/views/workspace/View.vue
+++ b/frontend/src/views/workspace/View.vue
@@ -98,6 +98,12 @@
   const cmView = shallowRef(null);
   provide("cmView", cmView);
 
+  // Shared Y.js awareness — EditorCodeMirror writes, Canvas re-provides it for the minimap,
+  // and VersionPreviewModal (a Sidebar sibling of Canvas) reads it to gate version restore
+  // to the sole-participant case.
+  const awareness = shallowRef(null);
+  provide("awareness", awareness);
+
   // Shared Y.js text — EditorCodeMirror writes, Editor reads for compile
   const ytext = shallowRef(null);
   provide("ytext", ytext);


### PR DESCRIPTION
## What

Gate the version-restore action so it is only available when the current user is the **sole active participant** in the collaborative session. This eliminates the concurrent-edit merge-garble that a blind whole-document restore would otherwise cause (decided 2026-07-17: don't solve concurrent restore, prevent it).

## Why

`VersionPreviewModal.handleRestore` replaces the entire CodeMirror doc (`from: 0, to: doc.length`). If another collaborator is editing concurrently, that whole-doc swap garbles their in-flight edits. Restricting restore to when you're the only participant sidesteps the problem entirely.

## How it's wired

The `awareness` (Y.js presence) ref was previously provided only by `Canvas.vue`. `VersionPreviewModal` lives under `Sidebar` (a **sibling** of `Canvas`), so it was outside that provide scope. The fix mirrors the existing `cmView` pattern:

- **`View.vue`** now creates and `provide`s the shared `awareness` shallowRef (alongside `cmView`/`ydoc`/`ytext`).
- **`Canvas.vue`** now `inject`s that ref (with a `shallowRef(null)` fallback) and re-provides it, so `EditorCodeMirror` (writer) and the minimap are unchanged. The `provide("awareness", ...)` guardrail test still passes.
- **`VersionPreviewModal.vue`** injects `awareness`, tracks a live `participantCount` via the awareness `"change"` event (reactive to joins/leaves while the modal is open), and computes `canRestore = isOwner && participantCount <= 1`.

## Behavior

- **> 1 participant:** restore button hidden, note shown: "Restore is only available when you're the only one editing this document." If a peer joins mid-confirmation, the confirmation collapses and `confirmRestore` re-checks defensively.
- **1 participant + owner:** restore works exactly as before.
- **No collab session** (awareness unavailable): treated as sole user, so restore is not broken in non-collaborative contexts.
- **Non-owner:** unchanged owner-only note.

## Tests

Added 6 Vitest cases to `VersionPreviewModal.test.js` covering: hidden+note when a peer is present, enabled when sole, enabled with no awareness, reactive disable on join, confirmation-collapse on join, and non-owner note precedence. Ran targeted suites (VersionPreviewModal, Minimap guardrail, Canvas, workspace View, DrawerVersions, Sidebar drawer-sync): all green. ESLint clean on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)