### PR TITLE
feat(collab): surface TRUE save status, closing the silent data-loss window (std-wmjv)

### DIFF
--- a/backend/aris/collaboration/yjs_client.py
+++ b/backend/aris/collaboration/yjs_client.py
@@ -7,6 +7,7 @@ Uses pycrdt's native sync protocol which is compatible with JavaScript y-websock
 import asyncio
 import json
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -17,6 +18,7 @@ from websockets import ClientConnection, connect
 from websockets.exceptions import ConnectionClosed, WebSocketException
 
 from aris.deps import CollabSession
+from aris.services.file_events import get_event_broker
 
 from .auth import mint_collab_token
 
@@ -609,6 +611,30 @@ class YDocClient:
 
         except Exception as e:
             logger.error(f"Failed to save content to DB for file {self.file_id}: {e}", exc_info=True)
+            return
+
+        # Only reached when the write committed. Ack real persistence to open tabs
+        # (std-wmjv) so the editor can show a true "saved" state instead of merely a
+        # relay-connected one, closing the silent data-loss window.
+        self._publish_persisted()
+
+    def _publish_persisted(self) -> None:
+        """Notify this file's open tabs that a DB write just committed.
+
+        Best-effort and fully isolated from the save path: a broker/publish error
+        must never turn a successful save into a failure, so it is caught here and
+        only logged. Runs in-process (the broker is a singleton and this client
+        shares the process), so ``publish`` is a cheap non-blocking fan-out.
+        """
+        try:
+            get_event_broker().publish(
+                self.file_id,
+                {"type": "persisted", "at": int(time.time() * 1000)},
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to publish persisted event for file {self.file_id}: {e}"
+            )
 
     async def _wait_before_reconnect(self):
         """Wait before reconnecting with exponential backoff."""

--- a/backend/tests/test_collaboration/test_yjs_persistence_ack.py
+++ b/backend/tests/test_collaboration/test_yjs_persistence_ack.py
@@ -1,0 +1,117 @@
+"""The backend acks REAL persistence, closing the silent data-loss window (std-wmjv).
+
+Saving flows only through this backend client. The editor's status chip used to
+reflect the relay link, not whether Postgres actually received the write, so a
+crashed persistence peer or a failing DB write left every tab "green" while work
+was silently lost.
+
+Fix: after a successful ``_save_to_db`` commit, publish a ``persisted`` event on
+the file's in-process event broker; the SSE channel relays it to open tabs, which
+turn it into a true "saved" indicator. These tests pin the contract:
+
+  * a committed write publishes exactly one ``persisted`` event for that file, and
+  * a FAILED write publishes nothing (never a false "saved"), and
+  * a broker error can never turn a successful save into a failure.
+"""
+
+import asyncio
+
+import pytest
+from pycrdt import Doc, Text
+
+from aris.collaboration import yjs_client
+from aris.collaboration.yjs_client import YDocClient
+from aris.services.file_events import FileEventBroker
+
+
+class _FakeSession:
+    """Minimal async-context DB session; optionally fails at commit."""
+
+    def __init__(self, fail_commit: bool = False):
+        self.fail_commit = fail_commit
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, statement, params):
+        return None
+
+    async def commit(self):
+        if self.fail_commit:
+            raise RuntimeError("DB write failed")
+        self.committed = True
+
+
+def _make_client(file_id: int = 42) -> YDocClient:
+    c = YDocClient(file_id=file_id, websocket_url="ws://x", debounce_ms=50)
+    c.doc = Doc()
+    c.text = c.doc.get("text", type=Text)
+    with c.doc.transaction():
+        c.text += "hello world"
+    return c
+
+
+@pytest.fixture
+def broker(monkeypatch):
+    """Swap the process-wide broker for a fresh, isolated instance."""
+    b = FileEventBroker()
+    monkeypatch.setattr(yjs_client, "get_event_broker", lambda: b)
+    return b
+
+
+@pytest.mark.asyncio
+async def test_successful_save_publishes_persisted_event(broker, monkeypatch):
+    monkeypatch.setattr(yjs_client, "CollabSession", lambda: _FakeSession())
+    client = _make_client(file_id=7)
+
+    async with broker.subscribe(7) as q:
+        await client._save_to_db()
+        event = await asyncio.wait_for(q.get(), timeout=1)
+
+    assert event["type"] == "persisted"
+    assert isinstance(event["at"], int)
+    assert event["at"] > 0
+
+
+@pytest.mark.asyncio
+async def test_persisted_event_targets_only_this_file(broker, monkeypatch):
+    monkeypatch.setattr(yjs_client, "CollabSession", lambda: _FakeSession())
+    client = _make_client(file_id=7)
+
+    async with broker.subscribe(7) as mine, broker.subscribe(8) as other:
+        await client._save_to_db()
+        assert (await asyncio.wait_for(mine.get(), timeout=1))["type"] == "persisted"
+        assert other.empty()
+
+
+@pytest.mark.asyncio
+async def test_failed_save_publishes_nothing(broker, monkeypatch):
+    """A DB write that never commits must never emit a (false) "saved" ack."""
+    monkeypatch.setattr(yjs_client, "CollabSession", lambda: _FakeSession(fail_commit=True))
+    client = _make_client(file_id=9)
+
+    async with broker.subscribe(9) as q:
+        await client._save_to_db()  # swallows the DB error, does not raise
+        assert q.empty()
+
+
+@pytest.mark.asyncio
+async def test_broker_error_never_breaks_the_save(monkeypatch):
+    """If publishing the ack blows up, the (already committed) save still succeeds."""
+    session = _FakeSession()
+    monkeypatch.setattr(yjs_client, "CollabSession", lambda: session)
+
+    class _BoomBroker:
+        def publish(self, *args, **kwargs):
+            raise RuntimeError("broker exploded")
+
+    monkeypatch.setattr(yjs_client, "get_event_broker", lambda: _BoomBroker())
+    client = _make_client(file_id=11)
+
+    await client._save_to_db()  # must not raise
+
+    assert session.committed is True

--- a/frontend/src/composables/useSaveStatus.js
+++ b/frontend/src/composables/useSaveStatus.js
@@ -1,0 +1,93 @@
+import { ref, watch, getCurrentScope, onScopeDispose } from "vue";
+
+/**
+ * Derive a TRUE save-status signal for the collaborative editor (std-wmjv).
+ *
+ * All saving flows through the backend Y.js persistence peer, so a "connected"
+ * relay link does NOT mean the work reached Postgres: if that peer is absent or a
+ * DB write fails, edits still relay peer-to-peer while nothing persists, and work
+ * is silently lost. This turns three raw signals into one honest indicator:
+ *
+ *   - a LOCAL doc edit (the user's own keystroke/undo, not a remote peer's edit)
+ *     moves state to "saving" and stamps when it happened;
+ *   - a "persisted" ack (published by the backend only after a committed DB write)
+ *     that lands once local edits have quiesced moves state to "saved";
+ *   - a watchdog moves state to "not-saving" (the warning) when the relay is
+ *     offline, or when work has been "saving" for longer than `watchdogMs` with no
+ *     ack, the visible face of the silent data-loss window.
+ *
+ * Kept transport-free and injectable (`isConnected`, timings, `now`) so it can be
+ * unit-tested without mounting the editor.
+ *
+ * @param {object} [options]
+ * @param {import('vue').Ref<boolean>} [options.isConnected] relay connection signal
+ * @param {number} [options.settleMs] quiet window after a local edit before an ack counts (backend saves on ~500ms debounce)
+ * @param {number} [options.watchdogMs] max time "saving" with no ack before warning
+ * @param {number} [options.checkIntervalMs] watchdog poll interval
+ * @param {() => number} [options.now] clock (injectable for tests)
+ * @returns {{ saveState: import('vue').Ref<'saved'|'saving'|'not-saving'>, noteLocalEdit: () => void, notePersisted: () => void, checkWatchdog: () => void, reset: () => void, stop: () => void }}
+ */
+export function useSaveStatus(options = {}) {
+  const isConnected = options.isConnected ?? ref(true);
+  const settleMs = options.settleMs ?? 400;
+  const watchdogMs = options.watchdogMs ?? 4000;
+  const checkIntervalMs = options.checkIntervalMs ?? 1000;
+  const now = options.now ?? (() => Date.now());
+
+  const saveState = ref("saved");
+  let lastLocalEditAt = null;
+
+  function noteLocalEdit() {
+    lastLocalEditAt = now();
+    saveState.value = isConnected.value ? "saving" : "not-saving";
+  }
+
+  function notePersisted() {
+    if (saveState.value === "saved") return; // nothing outstanding to confirm
+    // Only settle once local edits have quiesced past the backend's save-debounce
+    // window. An ack that races an in-flight keystroke predates that keystroke, so
+    // ignore it and wait for the next ack rather than flashing a premature "saved".
+    if (lastLocalEditAt === null || now() - lastLocalEditAt >= settleMs) {
+      saveState.value = "saved";
+      lastLocalEditAt = null;
+    }
+  }
+
+  function checkWatchdog() {
+    if (saveState.value === "saved") return;
+    if (!isConnected.value) {
+      saveState.value = "not-saving";
+      return;
+    }
+    if (lastLocalEditAt !== null && now() - lastLocalEditAt > watchdogMs) {
+      saveState.value = "not-saving";
+    }
+  }
+
+  function reset() {
+    lastLocalEditAt = null;
+    saveState.value = "saved";
+  }
+
+  // React to relay loss/restore immediately (better than waiting a poll cycle),
+  // but only while there is outstanding unsaved work.
+  const stopConnWatch = watch(
+    () => isConnected.value,
+    (connected) => {
+      if (saveState.value === "saved") return;
+      saveState.value = connected ? "saving" : "not-saving";
+    },
+    { flush: "sync" }
+  );
+
+  const timer = setInterval(checkWatchdog, checkIntervalMs);
+
+  function stop() {
+    clearInterval(timer);
+    stopConnWatch();
+  }
+
+  if (getCurrentScope()) onScopeDispose(stop);
+
+  return { saveState, noteLocalEdit, notePersisted, checkWatchdog, reset, stop };
+}

--- a/frontend/src/tests/composables/useSaveStatus.test.js
+++ b/frontend/src/tests/composables/useSaveStatus.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ref } from "vue";
+
+import { useSaveStatus } from "@/composables/useSaveStatus.js";
+
+describe("useSaveStatus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setup(overrides = {}) {
+    const isConnected = ref(overrides.connected ?? true);
+    const s = useSaveStatus({
+      isConnected,
+      settleMs: 400,
+      watchdogMs: 4000,
+      checkIntervalMs: 1000,
+      ...overrides,
+    });
+    return { isConnected, ...s };
+  }
+
+  it("starts in the saved state with no pending edits", () => {
+    const { saveState } = setup();
+    expect(saveState.value).toBe("saved");
+  });
+
+  it("moves to saving on a local edit", () => {
+    const { saveState, noteLocalEdit } = setup();
+    noteLocalEdit();
+    expect(saveState.value).toBe("saving");
+  });
+
+  it("settles to saved on a persisted ack once edits have quiesced", () => {
+    const { saveState, noteLocalEdit, notePersisted } = setup();
+    noteLocalEdit();
+    vi.advanceTimersByTime(500); // past settleMs, no interval tick yet
+    notePersisted();
+    expect(saveState.value).toBe("saved");
+  });
+
+  it("ignores a persisted ack that races an in-flight edit (stays saving)", () => {
+    const { saveState, noteLocalEdit, notePersisted } = setup();
+    noteLocalEdit();
+    vi.advanceTimersByTime(100); // within settleMs, so this ack predates the edit
+    notePersisted();
+    expect(saveState.value).toBe("saving");
+  });
+
+  it("ignores a persisted ack when nothing is pending", () => {
+    const { saveState, notePersisted } = setup();
+    notePersisted();
+    expect(saveState.value).toBe("saved");
+  });
+
+  it("warns (not-saving) when saving persists past the watchdog with no ack", () => {
+    const { saveState, noteLocalEdit } = setup();
+    noteLocalEdit();
+    expect(saveState.value).toBe("saving");
+    // No ack ever arrives; the warning fires on the first poll past watchdogMs
+    // (4000ms), i.e. the 5000ms tick with a 1000ms poll interval.
+    vi.advanceTimersByTime(5001);
+    expect(saveState.value).toBe("not-saving");
+  });
+
+  it("stays saving (not a false warning) while the user keeps typing", () => {
+    const { saveState, noteLocalEdit } = setup();
+    // Simulate continuous typing: an edit every 500ms for 6s. The backend never
+    // hits its debounce gap, so no ack arrives, but this is healthy, not a failure.
+    for (let i = 0; i < 12; i++) {
+      noteLocalEdit();
+      vi.advanceTimersByTime(500);
+    }
+    expect(saveState.value).toBe("saving");
+  });
+
+  it("warns immediately when a local edit happens while the relay is offline", () => {
+    const { saveState, noteLocalEdit } = setup({ connected: false });
+    noteLocalEdit();
+    expect(saveState.value).toBe("not-saving");
+  });
+
+  it("warns when the relay drops mid-save, then recovers on reconnect", () => {
+    const { saveState, isConnected, noteLocalEdit } = setup();
+    noteLocalEdit();
+    expect(saveState.value).toBe("saving");
+
+    isConnected.value = false;
+    expect(saveState.value).toBe("not-saving");
+
+    isConnected.value = true;
+    expect(saveState.value).toBe("saving"); // still unsaved, hoping for an ack
+  });
+
+  it("recovers to saved after a warning once a real ack lands", () => {
+    const { saveState, noteLocalEdit, notePersisted } = setup();
+    noteLocalEdit();
+    vi.advanceTimersByTime(5001);
+    expect(saveState.value).toBe("not-saving");
+
+    notePersisted(); // last edit was long ago -> past settle window
+    expect(saveState.value).toBe("saved");
+  });
+
+  it("leaves saved alone when the relay drops with nothing pending", () => {
+    const { saveState, isConnected } = setup();
+    expect(saveState.value).toBe("saved");
+    isConnected.value = false;
+    expect(saveState.value).toBe("saved");
+  });
+
+  it("reset() clears pending state back to saved", () => {
+    const { saveState, noteLocalEdit, reset } = setup();
+    noteLocalEdit();
+    expect(saveState.value).toBe("saving");
+    reset();
+    expect(saveState.value).toBe("saved");
+  });
+});

--- a/frontend/src/tests/views/workspace/EditorStatusBar.test.js
+++ b/frontend/src/tests/views/workspace/EditorStatusBar.test.js
@@ -46,12 +46,42 @@ describe("EditorStatusBar", () => {
     wrapper.unmount();
   });
 
-  it("shows nothing in the right section when connected and synced", () => {
+  it("shows 'Saved' when connected, synced and persisted", () => {
     const wrapper = createWrapper({
       collabIsConnected: ref(true),
       collabIsSynced: ref(true),
+      saveState: ref("saved"),
     });
-    expect(wrapper.find(".right").exists()).toBe(false);
+    expect(wrapper.find(".status-saved").exists()).toBe(true);
+    expect(wrapper.find(".status-label").text()).toBe("Saved");
+    wrapper.unmount();
+  });
+
+  it("shows 'Saving…' while the user's edits are being persisted", () => {
+    const wrapper = createWrapper({ saveState: ref("saving") });
+    expect(wrapper.find(".status-warning").exists()).toBe(true);
+    expect(wrapper.find(".status-label").text()).toBe("Saving…");
+    wrapper.unmount();
+  });
+
+  it("shows a distinct warning when work is not being saved", () => {
+    const wrapper = createWrapper({ saveState: ref("not-saving") });
+    const right = wrapper.find(".right");
+    expect(right.classes()).toContain("status-error");
+    expect(right.classes()).toContain("status-critical");
+    expect(wrapper.find(".status-label").text()).toBe("Not saving. Check your connection");
+    wrapper.unmount();
+  });
+
+  it("the not-saving warning outranks the plain connection indicator", () => {
+    // Relay looks fine but the backend never acked persistence: the data-loss
+    // warning must win over any calm connection state.
+    const wrapper = createWrapper({
+      collabIsConnected: ref(true),
+      collabIsSynced: ref(true),
+      saveState: ref("not-saving"),
+    });
+    expect(wrapper.find(".status-label").text()).toBe("Not saving. Check your connection");
     wrapper.unmount();
   });
 

--- a/frontend/src/views/workspace/Editor.vue
+++ b/frontend/src/views/workspace/Editor.vue
@@ -68,10 +68,14 @@
   // Collab/LSP state from EditorCodeMirror (shared with status bar)
   const collabIsConnected = ref(false);
   const collabIsSynced = ref(false);
+  // True persistence state (std-wmjv): "saved" | "saving" | "not-saving".
+  // Reflects whether the backend actually committed to the DB, not just the relay.
+  const saveState = ref("saved");
   const lspClient = inject("lspClient", shallowRef(null));
   const documentUri = inject("documentUri", ref(""));
   provide("collabIsConnected", collabIsConnected);
   provide("collabIsSynced", collabIsSynced);
+  provide("saveState", saveState);
   provide("lspClient", lspClient);
   provide("documentUri", documentUri);
 

--- a/frontend/src/views/workspace/EditorCodeMirror.vue
+++ b/frontend/src/views/workspace/EditorCodeMirror.vue
@@ -38,6 +38,7 @@
   import { semanticTokensExtension, requestSemanticTokens } from "@/composables/useSemanticTokens";
   import { rsmKeymap } from "@/composables/useRSMCommands";
   import { useFileEvents } from "@/composables/useFileEvents.js";
+  import { useSaveStatus } from "@/composables/useSaveStatus.js";
 
   const file = defineModel({ type: Object, required: true });
   const api = inject("api");
@@ -67,6 +68,11 @@
   const isInitialized = ref(false);
   const roomName = ref("");
   const readOnlyCompartment = new Compartment();
+
+  // True save state (std-wmjv): tracks whether the user's edits have actually
+  // been persisted to the DB, from local edits + backend "persisted" acks + the
+  // relay link, not just whether the relay is connected.
+  const saveStatus = useSaveStatus({ isConnected });
 
   // WebSocket server URL
   const serverUrl = ref(import.meta.env.VITE_MULTIPLAYER_URL || "ws://localhost:1234");
@@ -171,6 +177,8 @@
     isConnected.value = false;
     isSynced.value = false;
     isInitialized.value = false;
+    // Don't carry a stale save indicator into the next file.
+    saveStatus.reset();
 
     // Clean up window globals for testing
     if (import.meta.env.DEV) {
@@ -205,6 +213,9 @@
       // manual save. Reuses the general per-file event channel (std-iu0n).
       fileEvents = useFileEvents(fileId, {
         "asset-changed": () => compile && compile(true),
+        // The backend published this only after a committed DB write, so it is a
+        // true persistence ack: settle the save indicator to "saved" (std-wmjv).
+        persisted: () => saveStatus.notePersisted(),
       });
 
       // Tell the backend to start its Y.js client and get a short-lived WS auth
@@ -282,18 +293,20 @@
       // copies (the historical 1x->2x->4x content-duplication bug). Restores are
       // idempotent only because they go through the backend's encoded ydoc_state.
 
-      // Setup auto-compilation on Y.Doc changes (local edits + remote agent edits)
-      if (compile) {
-        const handleYtextChange = () => {
-          compile();
-        };
+      // Observe Y.Text changes for two things: auto-compilation (local + remote
+      // agent edits) and the save indicator. Only the user's OWN edits move the
+      // indicator to "saving"; remote edits (transaction.local === false) arrive
+      // already persisted by whoever made them, so they must not.
+      const handleYtextChange = (_event, transaction) => {
+        if (transaction?.local) saveStatus.noteLocalEdit();
+        if (compile) compile();
+      };
 
-        ytext.value.observe(handleYtextChange);
+      ytext.value.observe(handleYtextChange);
 
-        ytextObserverCleanup = () => {
-          ytext.value.unobserve(handleYtextChange);
-        };
-      }
+      ytextObserverCleanup = () => {
+        ytext.value.unobserve(handleYtextChange);
+      };
 
       // Create editor immediately — don't wait for WebSocket sync
       const MAX_UNDO_STACK = 200;
@@ -415,6 +428,7 @@
   // Shared refs from parent Editor.vue (for status bar sibling)
   const parentCollabConnected = inject("collabIsConnected", null);
   const parentCollabSynced = inject("collabIsSynced", null);
+  const parentSaveState = inject("saveState", null);
   const parentLspClient = inject("lspClient", null);
   const parentDocumentUri = inject("documentUri", null);
   // awaitIndexReady is a stable function from useLSPClient; publish it once for
@@ -426,6 +440,13 @@
     isConnected,
     (v) => {
       if (parentCollabConnected) parentCollabConnected.value = v;
+    },
+    { immediate: true }
+  );
+  watch(
+    saveStatus.saveState,
+    (v) => {
+      if (parentSaveState) parentSaveState.value = v;
     },
     { immediate: true }
   );

--- a/frontend/src/views/workspace/EditorStatusBar.vue
+++ b/frontend/src/views/workspace/EditorStatusBar.vue
@@ -1,6 +1,12 @@
 <script setup>
-  import { computed, inject, toRaw, useTemplateRef } from "vue";
-  import { IconClock, IconWifiOff, IconMapPin } from "@/components/base/iconRegistry.js";
+  import { computed, inject, ref, toRaw, useTemplateRef } from "vue";
+  import {
+    IconClock,
+    IconWifiOff,
+    IconMapPin,
+    IconCheck,
+    IconAlertTriangleFilled,
+  } from "@/components/base/iconRegistry.js";
   import { useScrollShadows } from "@/composables/useScrollShadows.js";
   import { useDocumentBreadcrumbs } from "@/composables/useDocumentBreadcrumbs.js";
 
@@ -13,6 +19,8 @@
   const documentUri = inject("documentUri", null);
   const collabIsConnected = inject("collabIsConnected", null);
   const collabIsSynced = inject("collabIsSynced", null);
+  // True persistence state (std-wmjv): "saved" | "saving" | "not-saving".
+  const saveState = inject("saveState", ref("saved"));
 
   const { breadcrumbs } = useDocumentBreadcrumbs({
     lspClient,
@@ -52,25 +60,44 @@
     raw.focus();
   }
 
+  // The save state is the primary signal: it reflects whether the backend
+  // actually persisted the user's work, not merely whether the relay is linked
+  // (std-wmjv). A stalled save or offline relay with unsaved work outranks the
+  // plain connection/sync info, because that is the real data-loss risk.
   const statusIndicator = computed(() => {
     const connected = collabIsConnected?.value ?? true;
     const synced = collabIsSynced?.value ?? true;
+    const save = saveState?.value ?? "saved";
 
+    if (save === "not-saving") {
+      return {
+        label: "Not saving. Check your connection",
+        icon: "alert",
+        cls: "status-error status-critical",
+      };
+    }
+    if (save === "saving") {
+      return { label: "Saving\u2026", icon: "clock", cls: "status-warning" };
+    }
+    // save === "saved": work is persisted; still surface relay context if degraded.
     if (!connected) return { label: "Offline", icon: "wifi-off", cls: "status-error" };
     if (!synced) return { label: "Syncing\u2026", icon: "clock", cls: "status-warning" };
-    return null;
+    return { label: "Saved", icon: "check", cls: "status-saved" };
   });
 
   // Tooltip anchor
   const statusRef = useTemplateRef("status-indicator");
 
   const statusTooltip = computed(() => {
-    const s = statusIndicator.value;
-    if (!s) return "";
+    const save = saveState?.value ?? "saved";
+    if (save === "not-saving") {
+      return "Your recent changes have not been saved. Check your connection.";
+    }
+    if (save === "saving") return "Saving your changes\u2026";
     const connected = collabIsConnected?.value ?? true;
     if (!connected) return "Connection lost. Changes will sync when reconnected.";
     if (!(collabIsSynced?.value ?? true)) return "Syncing changes with collaborators\u2026";
-    return "";
+    return "All changes saved.";
   });
 
   const { scrollElementRef, showLeftShadow, showRightShadow } = useScrollShadows();
@@ -92,6 +119,8 @@
     </div>
     <div v-if="statusIndicator" ref="status-indicator" class="right" :class="statusIndicator.cls">
       <IconWifiOff v-if="statusIndicator.icon === 'wifi-off'" />
+      <IconAlertTriangleFilled v-else-if="statusIndicator.icon === 'alert'" />
+      <IconCheck v-else-if="statusIndicator.icon === 'check'" />
       <IconClock v-else-if="statusIndicator.icon === 'clock'" />
       <span class="status-label">{{ statusIndicator.label }}</span>
     </div>
@@ -188,11 +217,28 @@
     font-weight: var(--weight-medium, 500);
   }
 
+  .status-saved {
+    color: var(--gray-600, var(--gray-800));
+  }
+
+  .status-saved > :deep(svg) {
+    color: var(--success-600, var(--gray-600));
+  }
+
   .status-warning {
     color: var(--warning-600);
   }
 
   .status-error {
     color: var(--error-600);
+  }
+
+  .status-error > :deep(svg) {
+    color: var(--error-600);
+  }
+
+  /* The data-loss warning must stand out from the calm "Saved"/"Saving" states. */
+  .status-critical {
+    font-weight: var(--weight-semibold, 600);
   }
 </style>


### PR DESCRIPTION
## Problem (std-wmjv)

Saving flows only through the backend Y.js persistence peer, but the editor's status chip reflected only the **relay** connection. If that peer is absent/crashed or a DB write fails mid-session, every tab stays "green" while nothing reaches Postgres, and if clients leave before the peer rejoins, work is **silently lost**. The status told you "connected", never "is my work actually saved".

## Fix

The backend now **acks real persistence**, and the editor derives an honest save state from it.

### Backend (`backend/aris/collaboration/yjs_client.py`)
- After `_save_to_db` completes a **successful DB commit**, publish a `{"type": "persisted", "at": <ms>}` event to the file's in-process event broker (`aris.services.file_events.get_event_broker()`), reusing the per-file channel from std-iu0n.
- The publish is a small helper, best-effort and **fully isolated**: a broker/publish error can never turn a successful save into a failure, and a **failed** DB write publishes nothing (no false "saved"). No persistence/CRDT/seed logic was touched.

### Frontend
- New composable `frontend/src/composables/useSaveStatus.js` turns three signals into one state (`saved` / `saving` / `not-saving`):
  - a **local** doc edit (`transaction.local`, distinguished from remote peers' edits) → `saving`;
  - a `persisted` ack that lands **after edits quiesce** (past a ~400ms settle window, since the backend saves on a ~500ms debounce) → `saved`;
  - a watchdog → `not-saving` when the relay is offline, or when work has been unsaved for longer than the threshold (~4s, first poll strictly past it) with no ack.
- Wired in `EditorCodeMirror.vue`: the Y.Text observer flags local edits, the SSE `persisted` handler settles the state, and the state is provided to the status bar.
- `EditorStatusBar.vue` now shows **Saved / Saving… / Not saving. Check your connection** (the warning is visually distinct), with relay/sync context kept underneath.
- Kept as a testable unit so the state logic is unit-tested without mounting the editor.

## Tests (TDD, both sides)
- Backend `test_yjs_persistence_ack.py`: a committed save publishes exactly one `persisted` event (correct file only); a failed write publishes nothing; a broker error never breaks the save.
- Frontend `useSaveStatus.test.js` (12 cases): local-edit→saving, ack→saved, raced-ack ignored, watchdog→not-saving, continuous-typing stays saving (no false warning), offline handling, recovery.
- Updated `EditorStatusBar.test.js` for the new save-centric indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)