### PR TITLE
fix(observability): activate multiplayer Sentry (supervisord env) + real release tag

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -101,6 +101,15 @@ COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY docker/health-check.sh /usr/local/bin/health-check.sh
 RUN chmod +x /usr/local/bin/health-check.sh
 
+# Commit the image was built from, surfaced as the Sentry `release` tag by both
+# the backend (inherits this env) and multiplayer (supervisord forwards it). Set
+# via `--build-arg GIT_COMMIT=$(git rev-parse --short HEAD)` at deploy; defaults
+# to "dev" so an un-plumbed build still resolves rather than reporting no release.
+# Declared late so a changed commit only busts these cheap trailing layers, not
+# the expensive uv sync / node build above.
+ARG GIT_COMMIT=dev
+ENV GIT_COMMIT=$GIT_COMMIT
+
 # Expose ports: 8080 (HTTP), 1234 (WebSocket)
 EXPOSE 8080 1234
 

--- a/backend/tests/test_docker_config.py
+++ b/backend/tests/test_docker_config.py
@@ -46,6 +46,16 @@ class TestDockerfile:
         assert "rsm-lang==" in self.dockerfile
         assert 'path = "../../rsm"' not in self.dockerfile
 
+    def test_git_commit_baked_as_env(self):
+        """GIT_COMMIT is the Sentry `release` tag for both backend and
+        multiplayer. Baking it as a runtime ENV (defaulting to "dev") means the
+        %(ENV_GIT_COMMIT)s forward in supervisord.conf always resolves and the
+        backend, which inherits the container env, tags releases too. Passed at
+        deploy via `--build-arg GIT_COMMIT=$(git rev-parse --short HEAD)`.
+        """
+        assert "ARG GIT_COMMIT" in self.dockerfile
+        assert "ENV GIT_COMMIT=$GIT_COMMIT" in self.dockerfile
+
     def test_no_separate_tree_sitter_copy_to_runtime(self):
         """tree-sitter-rsm should be embedded in rsm-lsp/node_modules, not copied separately."""
         runtime_copies = [
@@ -119,6 +129,26 @@ class TestSupervisordConf:
         assert "localhost:8080" in env_line, (
             "BACKEND_INTERNAL_URL must point at the prod backend port (8080)."
         )
+
+    def test_multiplayer_env_forwards_sentry_config(self):
+        """The multiplayer Sentry (server.js) inits only when
+        SENTRY_DSN_MULTIPLAYER is present and reads ENV/GIT_COMMIT for its
+        environment/release tags. supervisord's `environment=` replaces the
+        inherited env wholesale, so these MUST be forwarded explicitly via
+        %(ENV_*)s interpolation, or the multiplayer Sentry can never init in
+        prod even though the Fly secret is set (std-2k9s).
+        """
+        env_line = self._multiplayer_env_line()
+        for var in ("SENTRY_DSN_MULTIPLAYER", "ENV", "GIT_COMMIT"):
+            assert f"{var}=" in env_line, (
+                f"supervisord.conf [program:multiplayer] must forward {var} — "
+                "without it the multiplayer Sentry stays dark in prod "
+                "(std-2k9s)."
+            )
+            assert f"%(ENV_{var})s" in env_line, (
+                f"{var} must reference the parent-env value via supervisord's "
+                "%(ENV_*)s interpolation, not be hardcoded."
+            )
 
 
 class TestFlyToml:

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -32,7 +32,12 @@ directory=/app/multi-player
 ; INTERNAL_SHARED_SECRET (the JWT-verify key for the WS auth handshake) and
 ; BACKEND_INTERNAL_URL (used by auto-bootstrap) MUST be forwarded explicitly.
 ; Without them every WS connection 4401s and the editor goes offline.
-environment=MULTIPLAYER_PORT="1234",HOST="0.0.0.0",INTERNAL_SHARED_SECRET="%(ENV_INTERNAL_SHARED_SECRET)s",BACKEND_INTERNAL_URL="http://localhost:8080"
+; SENTRY_DSN_MULTIPLAYER/ENV/GIT_COMMIT are likewise forwarded so server.js's
+; Sentry can init in prod (it no-ops without the DSN) and tag the right
+; environment/release; ENV is always set (the app crashes without it) and
+; GIT_COMMIT is baked into the image (Dockerfile ENV, defaults to "dev"), so
+; both %(ENV_*)s references always resolve (std-2k9s).
+environment=MULTIPLAYER_PORT="1234",HOST="0.0.0.0",INTERNAL_SHARED_SECRET="%(ENV_INTERNAL_SHARED_SECRET)s",BACKEND_INTERNAL_URL="http://localhost:8080",SENTRY_DSN_MULTIPLAYER="%(ENV_SENTRY_DSN_MULTIPLAYER)s",ENV="%(ENV_ENV)s",GIT_COMMIT="%(ENV_GIT_COMMIT)s"
 autostart=true
 autorestart=true
 startsecs=3

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ deploy:
 # studio/ is needed and the deploy no longer runs from the ~/aris parent.
 deploy-backend:
     @echo "🚀 Deploying backend to Fly.io..."
-    fly deploy --config backend/fly.toml --dockerfile backend/Dockerfile
+    fly deploy --config backend/fly.toml --dockerfile backend/Dockerfile --build-arg GIT_COMMIT=$(git rev-parse --short HEAD)
     @echo "✅ Backend deployed: https://aris-backend.fly.dev"
 
 # Push to GitHub to trigger Netlify deployments


### PR DESCRIPTION
## Problem (std-2k9s)

Multiplayer error tracking has been dark in prod. `multi-player/server.js` gates `Sentry.init` on `SENTRY_DSN_MULTIPLAYER` and reads `ENV`/`GIT_COMMIT` for the `environment`/`release` tags. But `docker/supervisord.conf`'s `[program:multiplayer]` sets `environment=`, which **replaces the inherited container env wholesale** (there's a load-bearing comment about this). That list forwarded only `MULTIPLAYER_PORT`, `HOST`, `INTERNAL_SHARED_SECRET`, `BACKEND_INTERNAL_URL` — so `SENTRY_DSN_MULTIPLAYER`, `ENV`, and `GIT_COMMIT` never reached the process. Result: multiplayer Sentry could never init, even though the `SENTRY_DSN_MULTIPLAYER` Fly secret is set in prod (verified).

`[program:backend]` has no `environment=` line, so it inherits the full env — that's why backend Sentry is already live and is out of scope here.

## Fix

- **supervisord.conf**: forward `SENTRY_DSN_MULTIPLAYER`, `ENV`, and `GIT_COMMIT` on the `[program:multiplayer]` `environment=` line via supervisord's `%(ENV_*)s` interpolation — the same pattern `INTERNAL_SHARED_SECRET` already uses. `ENV` is always set (the app crashes without it) and `GIT_COMMIT` is now baked into the image, so both references always resolve. This file is only used by the prod Fly image (dev/CI use `docker/multi-player/Dockerfile.dev`).
- **GIT_COMMIT release tag (done, clean to plumb)**: `backend/Dockerfile` now declares `ARG GIT_COMMIT=dev` + `ENV GIT_COMMIT=$GIT_COMMIT` (placed late so a changed commit only busts cheap trailing layers), and `just deploy-backend` passes `--build-arg GIT_COMMIT=$(git rev-parse --short HEAD)`. Backend Sentry release picks this up for free (backend inherits the container env); previously both backend and multiplayer release tags fell back to `'dev'`.
- Server.js and backend Sentry code are **untouched** — env plumbing only.

## Tests (TDD)

`backend/tests/test_docker_config.py`:
- `TestSupervisordConf::test_multiplayer_env_forwards_sentry_config` — asserts the multiplayer `environment=` forwards `SENTRY_DSN_MULTIPLAYER`, `ENV`, and `GIT_COMMIT` via `%(ENV_*)s`. Confirmed red before the fix, green after.
- `TestDockerfile::test_git_commit_baked_as_env` — locks in the `ARG`/`ENV GIT_COMMIT` release plumbing.

`uv run pytest tests/test_docker_config.py` → 18 passed. `ruff check` clean.

## Remaining non-code ops item (not in this PR)

- Verify the frontend Netlify `VITE_SENTRY_DSN` env is set so the frontend Sentry is live. This is an ops-console check, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)