### PR TITLE
feat(collab): surface collab-start failure with a retry (std-liw8)

### DIFF
--- a/frontend/src/tests/views/workspace/EditorCollabRetry.test.js
+++ b/frontend/src/tests/views/workspace/EditorCollabRetry.test.js
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ref, shallowRef, nextTick } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import { AuthedWebSocket } from "@/composables/authedWebSocket";
+
+// EditorCodeMirror pulls in CodeMirror, Yjs, y-websocket and the LSP stack.
+// We stub all of it so the test can drive the collab-start / retry logic in
+// isolation, mocking only the API and the WebSocket provider (per std-liw8).
+
+// Hoisted so the (hoisted) vi.mock factory below can reference the class, while
+// the test body can still read the recorded provider instances.
+const { providerInstances, MockWebsocketProvider } = vi.hoisted(() => {
+  const instances = [];
+  class MockWebsocketProvider {
+    constructor(serverUrl, roomName, ydoc, opts) {
+      this.serverUrl = serverUrl;
+      this.roomname = roomName;
+      this.ydoc = ydoc;
+      this.opts = opts;
+      this.awareness = { setLocalStateField: vi.fn(), getStates: () => new Map() };
+      this.ws = { addEventListener: vi.fn() };
+      this._handlers = {};
+      this.connect = vi.fn();
+      this.disconnect = vi.fn();
+      this.destroy = vi.fn();
+      instances.push(this);
+    }
+    on(event, cb) {
+      (this._handlers[event] = this._handlers[event] || []).push(cb);
+    }
+    once() {}
+    emit(event, payload) {
+      (this._handlers[event] || []).forEach((cb) => cb(payload));
+    }
+  }
+  return { providerInstances: instances, MockWebsocketProvider };
+});
+
+vi.mock("y-websocket", () => ({ WebsocketProvider: MockWebsocketProvider }));
+
+vi.mock("yjs", () => {
+  class Doc {
+    getText() {
+      return { toString: () => "", observe: vi.fn(), unobserve: vi.fn() };
+    }
+    destroy() {}
+  }
+  class UndoManager {
+    constructor() {
+      this.undoStack = [];
+    }
+    on() {}
+  }
+  return { Doc, UndoManager, Text: class {} };
+});
+
+vi.mock("y-codemirror.next", () => ({ yCollab: () => [], yUndoManagerKeymap: [] }));
+
+vi.mock("@codemirror/view", () => {
+  class EditorView {
+    constructor(config) {
+      this.config = config;
+    }
+    destroy() {}
+    dispatch() {}
+  }
+  EditorView.updateListener = { of: () => ({}) };
+  EditorView.editable = { of: () => ({}) };
+  EditorView.lineWrapping = {};
+  EditorView.theme = () => ({});
+  const ext = () => ({});
+  return {
+    EditorView,
+    keymap: { of: () => ({}) },
+    lineNumbers: ext,
+    highlightActiveLineGutter: ext,
+    highlightSpecialChars: ext,
+    drawSelection: ext,
+    dropCursor: ext,
+    rectangularSelection: ext,
+    crosshairCursor: ext,
+    highlightActiveLine: ext,
+  };
+});
+
+vi.mock("@codemirror/state", () => {
+  class Compartment {
+    of() {
+      return {};
+    }
+    reconfigure() {
+      return {};
+    }
+  }
+  return {
+    EditorState: {
+      allowMultipleSelections: { of: () => ({}) },
+      readOnly: { of: () => ({}) },
+      create: () => ({}),
+    },
+    Compartment,
+    StateEffect: { appendConfig: { of: () => ({}) } },
+  };
+});
+
+vi.mock("@codemirror/language", () => {
+  const ext = () => ({});
+  return {
+    defaultHighlightStyle: {},
+    syntaxHighlighting: ext,
+    indentOnInput: ext,
+    bracketMatching: ext,
+    foldGutter: ext,
+    foldKeymap: [],
+  };
+});
+
+vi.mock("@codemirror/commands", () => ({ defaultKeymap: [] }));
+vi.mock("@codemirror/search", () => ({
+  search: () => ({}),
+  highlightSelectionMatches: () => ({}),
+}));
+vi.mock("@codemirror/autocomplete", () => ({
+  autocompletion: () => ({}),
+  completionKeymap: [],
+  closeBrackets: () => ({}),
+  closeBracketsKeymap: [],
+}));
+vi.mock("@codemirror/lint", () => ({ lintKeymap: [], lintGutter: () => ({}) }));
+
+vi.mock("@/composables/useLSPClient", async () => {
+  const { ref: r, shallowRef: sr } = await import("vue");
+  return {
+    useLSPClient: () => ({
+      client: sr(null),
+      isConnected: r(false),
+      connect: vi.fn().mockResolvedValue(null),
+      disconnect: vi.fn(),
+      awaitIndexReady: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+});
+
+vi.mock("@/composables/useSemanticTokens", () => ({
+  semanticTokensExtension: () => ({}),
+  requestSemanticTokens: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/composables/useRSMCommands", () => ({ rsmKeymap: [] }));
+vi.mock("@/composables/useFileEvents.js", () => ({
+  useFileEvents: () => ({ close: vi.fn() }),
+}));
+
+import EditorCodeMirror from "@/views/workspace/EditorCodeMirror.vue";
+
+describe("EditorCodeMirror — collab-start failure surfacing and retry", () => {
+  let mockApi;
+  let collabIsConnected;
+  let collabConnectError;
+  let collabRetry;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    providerInstances.length = 0;
+    AuthedWebSocket._tokens.clear();
+    vi.spyOn(AuthedWebSocket, "registerToken");
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    mockApi = { post: vi.fn(), get: vi.fn().mockResolvedValue({ data: {} }) };
+    collabIsConnected = ref(false);
+    collabConnectError = ref(false);
+    collabRetry = shallowRef(null);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  const mountEditor = () =>
+    mount(EditorCodeMirror, {
+      props: { modelValue: { id: 42, source: "", role: "AUTHOR" } },
+      global: {
+        provide: {
+          api: mockApi,
+          user: ref({ id: 1, name: "Tester", email: "t@e.com", avatar_color: "#0E9AE9" }),
+          mobileMode: ref(false),
+          compile: vi.fn(),
+          cmView: shallowRef(null),
+          cursorPos: ref(0),
+          ydoc: shallowRef(null),
+          ytext: shallowRef(null),
+          awareness: shallowRef(null),
+          collabIsConnected,
+          collabIsSynced: ref(false),
+          collabConnectError,
+          collabRetry,
+        },
+      },
+    });
+
+  it("surfaces a connect-error state when /collab/start fails, then a retry clears it on success", async () => {
+    mockApi.post.mockRejectedValue({ response: { status: 503 }, message: "backend down" });
+
+    const wrapper = mountEditor();
+    await flushPromises();
+    await nextTick();
+
+    // The failed start is surfaced to the shared status-bar ref, and a retry
+    // handler is published for the Retry affordance.
+    expect(collabConnectError.value).toBe(true);
+    expect(typeof collabRetry.value).toBe("function");
+    expect(providerInstances).toHaveLength(1);
+
+    // Retry now succeeds: fresh token, provider forced to reconnect immediately.
+    mockApi.post.mockReset();
+    mockApi.post.mockResolvedValue({ data: { token: "fresh-tok" } });
+
+    await collabRetry.value();
+    await flushPromises();
+
+    expect(collabConnectError.value).toBe(false);
+    expect(mockApi.post).toHaveBeenCalledWith("/files/42/collab/start");
+    expect(AuthedWebSocket.registerToken).toHaveBeenLastCalledWith(
+      expect.stringContaining("file-42"),
+      "fresh-tok"
+    );
+    const provider = providerInstances[0];
+    expect(provider.disconnect).toHaveBeenCalledTimes(1);
+    expect(provider.connect).toHaveBeenCalledTimes(1);
+
+    wrapper.unmount();
+  });
+
+  it("keeps the connect-error state when a retry also fails", async () => {
+    mockApi.post.mockRejectedValue({ response: { status: 503 }, message: "still down" });
+
+    const wrapper = mountEditor();
+    await flushPromises();
+    await nextTick();
+    expect(collabConnectError.value).toBe(true);
+
+    await collabRetry.value();
+    await flushPromises();
+
+    expect(collabConnectError.value).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("clears the connect-error state when the connection later succeeds on its own", async () => {
+    mockApi.post.mockRejectedValue({ response: { status: 503 }, message: "down" });
+
+    const wrapper = mountEditor();
+    await flushPromises();
+    await nextTick();
+    expect(collabConnectError.value).toBe(true);
+
+    // y-websocket eventually reconnects (e.g. backend recovered): the provider
+    // emits a 'connected' status, which must clear the surfaced error.
+    providerInstances[0].emit("status", { status: "connected" });
+    await nextTick();
+
+    expect(collabIsConnected.value).toBe(true);
+    expect(collabConnectError.value).toBe(false);
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/tests/views/workspace/EditorStatusBarConnectError.test.js
+++ b/frontend/src/tests/views/workspace/EditorStatusBarConnectError.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+import EditorStatusBar from "@/views/workspace/EditorStatusBar.vue";
+
+vi.mock("@/composables/useDocumentBreadcrumbs.js", () => ({
+  useDocumentBreadcrumbs: () => ({
+    breadcrumbs: ref([]),
+    symbols: ref([]),
+    refreshSymbols: vi.fn(),
+  }),
+}));
+
+vi.mock("@/composables/useScrollShadows.js", () => ({
+  useScrollShadows: () => ({
+    scrollElementRef: ref(null),
+    showLeftShadow: ref(false),
+    showRightShadow: ref(false),
+    updateShadows: vi.fn(),
+    setupScrollShadows: vi.fn(),
+    cleanupScrollShadows: vi.fn(),
+  }),
+}));
+
+function createWrapper(provides = {}) {
+  return mount(EditorStatusBar, {
+    global: {
+      provide: {
+        file: ref({ title: "Test Doc" }),
+        cmView: ref(null),
+        cursorPos: ref(0),
+        lspClient: ref(null),
+        documentUri: ref(""),
+        collabIsConnected: ref(true),
+        collabIsSynced: ref(true),
+        collabConnectError: ref(false),
+        collabRetry: ref(null),
+        ...provides,
+      },
+    },
+  });
+}
+
+describe("EditorStatusBar — collab connect error state", () => {
+  it("shows a distinct 'Can't connect' chip when the session failed to start", () => {
+    const wrapper = createWrapper({
+      collabIsConnected: ref(false),
+      collabConnectError: ref(true),
+    });
+    expect(wrapper.find(".status-error").exists()).toBe(true);
+    expect(wrapper.find(".status-label").text()).toBe("Can't connect");
+    wrapper.unmount();
+  });
+
+  it("renders a Retry button only in the connect-error state", () => {
+    const offline = createWrapper({
+      collabIsConnected: ref(false),
+      collabConnectError: ref(false),
+    });
+    // Plain offline (transient) must NOT offer retry.
+    expect(offline.find(".retry-btn").exists()).toBe(false);
+    expect(offline.find(".status-label").text()).toBe("Offline");
+    offline.unmount();
+
+    const failed = createWrapper({
+      collabIsConnected: ref(false),
+      collabConnectError: ref(true),
+    });
+    expect(failed.find(".retry-btn").exists()).toBe(true);
+    failed.unmount();
+  });
+
+  it("invokes the injected retry handler when Retry is clicked", async () => {
+    const retry = vi.fn();
+    const wrapper = createWrapper({
+      collabIsConnected: ref(false),
+      collabConnectError: ref(true),
+      collabRetry: ref(retry),
+    });
+    await wrapper.find(".retry-btn").trigger("click");
+    expect(retry).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
+  });
+
+  it("connect-error takes priority over the transient offline state", () => {
+    const wrapper = createWrapper({
+      collabIsConnected: ref(false),
+      collabIsSynced: ref(false),
+      collabConnectError: ref(true),
+    });
+    expect(wrapper.find(".status-label").text()).toBe("Can't connect");
+    expect(wrapper.find(".retry-btn").exists()).toBe(true);
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/views/workspace/Editor.vue
+++ b/frontend/src/views/workspace/Editor.vue
@@ -71,11 +71,17 @@
   // True persistence state (std-wmjv): "saved" | "saving" | "not-saving".
   // Reflects whether the backend actually committed to the DB, not just the relay.
   const saveState = ref("saved");
+  // collabConnectError: session could not be started (needs an explicit retry).
+  // collabRetry: EditorCodeMirror publishes its retry handler here for the bar.
+  const collabConnectError = ref(false);
+  const collabRetry = shallowRef(null);
   const lspClient = inject("lspClient", shallowRef(null));
   const documentUri = inject("documentUri", ref(""));
   provide("collabIsConnected", collabIsConnected);
   provide("collabIsSynced", collabIsSynced);
   provide("saveState", saveState);
+  provide("collabConnectError", collabConnectError);
+  provide("collabRetry", collabRetry);
   provide("lspClient", lspClient);
   provide("documentUri", documentUri);
 
@@ -169,7 +175,12 @@
 
 <template>
   <div class="editor">
-    <EditorTopbar v-model="tabIndex" @compile="onCompile" @upload="onUpload" @sync-to-preview="onSyncToPreview" />
+    <EditorTopbar
+      v-model="tabIndex"
+      @compile="onCompile"
+      @upload="onUpload"
+      @sync-to-preview="onSyncToPreview"
+    />
     <div class="content">
       <EditorToolbar v-if="tabIndex === 0 && !mobileMode" />
       <div v-if="mobileMode && tabIndex === 0" class="mobile-readonly-banner">

--- a/frontend/src/views/workspace/EditorCodeMirror.vue
+++ b/frontend/src/views/workspace/EditorCodeMirror.vue
@@ -66,6 +66,10 @@
   const isConnected = ref(false);
   const isSynced = ref(false);
   const isInitialized = ref(false);
+  // True when the collaborative session could not be started (/collab/start
+  // failed or returned no token). Distinct from a transient !isConnected drop:
+  // it means no session was ever established, so an explicit retry is offered.
+  const collabStartFailed = ref(false);
   const roomName = ref("");
   const readOnlyCompartment = new Compartment();
 
@@ -179,6 +183,7 @@
     isInitialized.value = false;
     // Don't carry a stale save indicator into the next file.
     saveStatus.reset();
+    collabStartFailed.value = false;
 
     // Clean up window globals for testing
     if (import.meta.env.DEV) {
@@ -227,9 +232,11 @@
         const startResp = await api.post(`/files/${fileId}/collab/start`);
         token = startResp?.data?.token ?? null;
         if (!token) {
+          collabStartFailed.value = true;
           console.error(`[Collab] /collab/start for file ${fileId} returned no token`);
         }
       } catch (err) {
+        collabStartFailed.value = true;
         console.error(
           `[Collab] Failed to start backend client for file ${fileId}:`,
           err?.response?.status,
@@ -429,8 +436,38 @@
   const parentCollabConnected = inject("collabIsConnected", null);
   const parentCollabSynced = inject("collabIsSynced", null);
   const parentSaveState = inject("saveState", null);
+  const parentCollabConnectError = inject("collabConnectError", null);
+  const parentCollabRetry = inject("collabRetry", null);
   const parentLspClient = inject("lspClient", null);
   const parentDocumentUri = inject("documentUri", null);
+
+  // Re-attempt a failed collaborative session without a full page reload:
+  // fetch a fresh token and force the existing provider to reconnect now
+  // instead of waiting for y-websocket's backoff. Wired to the status bar's
+  // Retry affordance via the injected collabRetry ref.
+  async function retryCollabConnection() {
+    const fileId = file.value?.id;
+    if (!fileId) return;
+    try {
+      const startResp = await api.post(`/files/${fileId}/collab/start`);
+      const token = startResp?.data?.token ?? null;
+      if (!token) throw new Error("/collab/start returned no token");
+      AuthedWebSocket.registerToken(`${serverUrl.value}/${roomName.value}`, token);
+      collabStartFailed.value = false;
+      if (provider.value) {
+        provider.value.disconnect();
+        provider.value.connect();
+      }
+    } catch (err) {
+      collabStartFailed.value = true;
+      console.error(
+        `[Collab] Retry to start backend client for file ${fileId} failed:`,
+        err?.response?.status,
+        err?.response?.data || err.message
+      );
+    }
+  }
+  if (parentCollabRetry) parentCollabRetry.value = retryCollabConnection;
   // awaitIndexReady is a stable function from useLSPClient; publish it once for
   // Canvas's source<->preview navigation.
   const parentAwaitIndexReady = inject("awaitIndexReady", null);
@@ -440,6 +477,16 @@
     isConnected,
     (v) => {
       if (parentCollabConnected) parentCollabConnected.value = v;
+      // A successful (re)connect clears any prior start failure, covering both
+      // manual retry and y-websocket's own eventual reconnect.
+      if (v) collabStartFailed.value = false;
+    },
+    { immediate: true }
+  );
+  watch(
+    collabStartFailed,
+    (v) => {
+      if (parentCollabConnectError) parentCollabConnectError.value = v;
     },
     { immediate: true }
   );

--- a/frontend/src/views/workspace/EditorStatusBar.vue
+++ b/frontend/src/views/workspace/EditorStatusBar.vue
@@ -21,6 +21,8 @@
   const collabIsSynced = inject("collabIsSynced", null);
   // True persistence state (std-wmjv): "saved" | "saving" | "not-saving".
   const saveState = inject("saveState", ref("saved"));
+  const collabConnectError = inject("collabConnectError", null);
+  const collabRetry = inject("collabRetry", null);
 
   const { breadcrumbs } = useDocumentBreadcrumbs({
     lspClient,
@@ -69,6 +71,10 @@
     const synced = collabIsSynced?.value ?? true;
     const save = saveState?.value ?? "saved";
 
+    // A failed session start won't self-heal on its own timeline, so it outranks
+    // the save/relay states: label it and offer a retry.
+    if (collabConnectError?.value)
+      return { label: "Can't connect", icon: "wifi-off", cls: "status-error", retry: true };
     if (save === "not-saving") {
       return {
         label: "Not saving. Check your connection",
@@ -89,6 +95,10 @@
   const statusRef = useTemplateRef("status-indicator");
 
   const statusTooltip = computed(() => {
+    const s = statusIndicator.value;
+    if (!s) return "";
+    if (collabConnectError?.value)
+      return "Couldn't connect to the collaboration server. Click Retry to reconnect.";
     const save = saveState?.value ?? "saved";
     if (save === "not-saving") {
       return "Your recent changes have not been saved. Check your connection.";
@@ -99,6 +109,10 @@
     if (!(collabIsSynced?.value ?? true)) return "Syncing changes with collaborators\u2026";
     return "All changes saved.";
   });
+
+  function onRetry() {
+    collabRetry?.value?.();
+  }
 
   const { scrollElementRef, showLeftShadow, showRightShadow } = useScrollShadows();
 </script>
@@ -123,6 +137,9 @@
       <IconCheck v-else-if="statusIndicator.icon === 'check'" />
       <IconClock v-else-if="statusIndicator.icon === 'clock'" />
       <span class="status-label">{{ statusIndicator.label }}</span>
+      <button v-if="statusIndicator.retry" type="button" class="retry-btn" @click="onRetry">
+        Retry
+      </button>
     </div>
     <Tooltip
       v-if="statusIndicator"
@@ -240,5 +257,21 @@
   /* The data-loss warning must stand out from the calm "Saved"/"Saving" states. */
   .status-critical {
     font-weight: var(--weight-semibold, 600);
+  }
+
+  .retry-btn {
+    margin-left: 6px;
+    padding: 0 6px;
+    height: 16px;
+    border: var(--border-extrathin) solid currentColor;
+    border-radius: 3px;
+    background: transparent;
+    color: inherit;
+    font-weight: var(--weight-medium, 500);
+    cursor: pointer;
+  }
+
+  .retry-btn:hover {
+    background-color: var(--surface-hint);
   }
 </style>


### PR DESCRIPTION
## Problem

On editor mount the frontend calls `POST /files/{id}/collab/start` to get a short-lived WS auth token. If that call failed (or returned no token), the code only `console.error`-ed and left the token null. The `AuthedWebSocket` then resolved a null token and self-closed with code `4401`, so the provider never connected. The user was left with a permanently **"Offline"** editor: no cause shown, and no way to recover short of a full page reload.

## Fix

Surface the failure as a distinct state and give the user an in-place retry.

- **`EditorCodeMirror.vue`**: track a new `collabStartFailed` flag (set when `/collab/start` throws or returns no token) and publish a `retryCollabConnection()` handler. Retry fetches a fresh token, registers it, and forces the existing provider to `disconnect()`/`connect()` immediately instead of waiting for y-websocket's backoff. A successful (re)connect clears the flag, so both manual retry and y-websocket's own eventual reconnect resolve the state.
- **`Editor.vue`**: provide `collabConnectError` + `collabRetry` alongside the existing collab refs.
- **`EditorStatusBar.vue`**: render a distinct **"Can't connect"** chip with a **Retry** button, kept separate from the transient **"Offline"/reconnecting** state (which self-heals and gets no button).

Changes are additive and localized to minimize merge friction with the concurrent save-status work (std-wmjv) that also touches these two files.

## Tests (vitest)

- `EditorCollabRetry.test.js` mounts the real `EditorCodeMirror` with the API and WebSocket provider mocked: start fails -> error surfaced -> retry re-attempts and clears on success; a retry that also fails stays errored; a later auto-connect clears it.
- `EditorStatusBarConnectError.test.js` covers the "Can't connect" chip, the Retry button (present only in the connect-error state), its click wiring to the injected handler, and its priority over the offline state.

Targeted run of the new + adjacent suites passes; `eslint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)