### PR TITLE
feat(security): per-IP rate limiting on login, register, and public render

### DIFF
--- a/backend/aris/rate_limiting.py
+++ b/backend/aris/rate_limiting.py
@@ -1,0 +1,63 @@
+"""Application-wide rate limiting for the public abuse surface.
+
+Protects the endpoints that are cheap to hammer and expensive or sensitive to
+serve: login (credential stuffing), register (spam signups), and the public
+render endpoint (cost/DoS on unauthenticated work). Uses slowapi over an
+in-memory store.
+
+In-memory storage is correct for this deployment: production runs on a single
+auto-stop machine, so there is no second process to share a bucket with. A
+shared store (Redis) would only matter with horizontal scale, which we do not
+have.
+
+Behind Fly's proxy ``request.client.host`` is the proxy address, identical for
+every caller, so keying on it would put all users in one bucket. The limiter
+keys on the real client IP instead (see ``get_real_client_ip``).
+"""
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+
+
+# Per-IP limits. Kept as named constants so they are easy to find and tune.
+LOGIN_RATE_LIMIT = "10/minute"
+REGISTER_RATE_LIMIT = "5/minute"
+PUBLIC_RENDER_RATE_LIMIT = "30/minute"
+
+RATE_LIMIT_MESSAGE = "Too many requests. Please slow down and try again shortly."
+
+
+def get_real_client_ip(request: Request) -> str:
+    """Return the real client IP to key the limiter on.
+
+    Fly terminates TLS at its proxy, so ``request.client.host`` is the proxy and
+    is the same for everyone. Fly sets ``Fly-Client-IP`` to the true client
+    address; fall back to the first hop of ``X-Forwarded-For``, then the socket
+    peer. Distinct callers must map to distinct keys or they share one bucket.
+    """
+    fly_ip = request.headers.get("fly-client-ip")
+    if fly_ip:
+        return fly_ip.strip()
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+limiter = Limiter(key_func=get_real_client_ip)
+
+
+def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """Return a clean 429 JSON body, keeping slowapi's rate-limit headers.
+
+    CORS headers are added by CORSMiddleware, which wraps the whole app, so this
+    response still carries them on the way back out to the browser.
+    """
+    response = JSONResponse(status_code=429, content={"detail": RATE_LIMIT_MESSAGE})
+    return request.app.state.limiter._inject_headers(
+        response, request.state.view_rate_limit
+    )

--- a/backend/aris/rate_limiting.py
+++ b/backend/aris/rate_limiting.py
@@ -15,8 +15,10 @@ every caller, so keying on it would put all users in one bucket. The limiter
 keys on the real client IP instead (see ``get_real_client_ip``).
 """
 
+import os
+
 from fastapi import Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 
@@ -27,6 +29,21 @@ REGISTER_RATE_LIMIT = "5/minute"
 PUBLIC_RENDER_RATE_LIMIT = "30/minute"
 
 RATE_LIMIT_MESSAGE = "Too many requests. Please slow down and try again shortly."
+
+
+def _rate_limiting_enabled() -> bool:
+    """On by default; opt-out only where per-IP keying is meaningless.
+
+    In the Docker compose stack (local dev and CI e2e) every browser reaches the
+    backend from a single source IP, so a per-IP limiter would throttle the whole
+    run and the compose env sets RATE_LIMITING_ENABLED=false. Production behind
+    Fly does not set it, so limiting stays on there.
+    """
+    return os.getenv("RATE_LIMITING_ENABLED", "true").strip().lower() not in (
+        "false",
+        "0",
+        "no",
+    )
 
 
 def get_real_client_ip(request: Request) -> str:
@@ -48,16 +65,19 @@ def get_real_client_ip(request: Request) -> str:
     return "unknown"
 
 
-limiter = Limiter(key_func=get_real_client_ip)
+limiter = Limiter(key_func=get_real_client_ip, enabled=_rate_limiting_enabled())
 
 
-def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:
     """Return a clean 429 JSON body, keeping slowapi's rate-limit headers.
 
     CORS headers are added by CORSMiddleware, which wraps the whole app, so this
     response still carries them on the way back out to the browser.
     """
     response = JSONResponse(status_code=429, content={"detail": RATE_LIMIT_MESSAGE})
-    return request.app.state.limiter._inject_headers(
+    # app.state.limiter is dynamically typed, so annotate the injected result to
+    # keep mypy's no-any-return happy.
+    injected: Response = request.app.state.limiter._inject_headers(
         response, request.state.view_rate_limit
     )
+    return injected

--- a/backend/aris/routes/auth.py
+++ b/backend/aris/routes/auth.py
@@ -10,6 +10,7 @@ from .. import crud, current_user, get_db, jwt
 from ..config import settings
 from ..logging_config import get_logger
 from ..models import User
+from ..rate_limiting import LOGIN_RATE_LIMIT, REGISTER_RATE_LIMIT, limiter
 from ..security import hash_password, verify_password
 from ..services.email import get_email_service
 
@@ -125,6 +126,7 @@ async def me(user: User = Depends(current_user)):
     description="Authenticate a user with email and password to receive access tokens.",
     response_description="JWT access and refresh tokens",
 )
+@limiter.limit(LOGIN_RATE_LIMIT)
 async def login(request: Request, user_data: UserLogin, db: AsyncSession = Depends(get_db)):
     """Authenticate user and return access tokens.
 
@@ -217,6 +219,7 @@ async def refresh(body: RefreshRequest, db: AsyncSession = Depends(get_db)):
     description="Create a new user account and receive authentication tokens.",
     response_description="User account details with authentication tokens",
 )
+@limiter.limit(REGISTER_RATE_LIMIT)
 async def register(request: Request, user_data: UserCreate, db: AsyncSession = Depends(get_db)):
     """Register a new user account.
 

--- a/backend/aris/routes/render.py
+++ b/backend/aris/routes/render.py
@@ -1,6 +1,6 @@
 """Routes for rendering RSM into HTML."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,6 +9,7 @@ from ..authorization import PermissionLevel, has_permission
 from ..deps import get_db
 from ..exceptions import forbidden_exception
 from ..logging_config import get_logger
+from ..rate_limiting import PUBLIC_RENDER_RATE_LIMIT, limiter
 
 
 logger = get_logger(__name__)
@@ -29,7 +30,8 @@ class FileRenderObject(BaseModel):
 
 
 @router.post("")
-async def render(data: RenderObject):
+@limiter.limit(PUBLIC_RENDER_RATE_LIMIT)
+async def render(request: Request, data: RenderObject):
     """Public endpoint for rendering RSM source to HTML or structured format.
     
     This endpoint accepts any RSM source and renders it to HTML or structured format.

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from slowapi.errors import RateLimitExceeded
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,6 +17,7 @@ from aris.collaboration import get_collaboration_manager
 from aris.deps import current_user, get_db
 from aris.health import HealthResponse, perform_health_check
 from aris.logging_config import get_logger, setup_logging
+from aris.rate_limiting import limiter, rate_limit_exceeded_handler
 from aris.routes import (
     auth_router,
     feedback_router,
@@ -352,6 +354,13 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Rate limiting is enforced per-route via @limiter.limit decorators. The limiter
+# only needs to be reachable on app.state and the 429 exception mapped to a clean
+# JSON body. CORSMiddleware wraps the whole app, so 429 responses still carry CORS
+# headers regardless of where this is registered.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
 # Include routers with proper tags
 logger.info("Registering API routers")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "shortuuid>=1.0.13",
     "rsm-lang>=1.2.0",
     "sentry-sdk[fastapi]>=2.0.0",
+    "slowapi>=0.1.10",
 ]
 
 [dependency-groups]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -394,6 +394,22 @@ async def second_authenticated_user(client: AsyncClient):
 
 
 @pytest_asyncio.fixture(autouse=True)
+async def reset_rate_limiter():
+    """Clear the in-memory rate-limit store around every test.
+
+    The limiter is app-global and in-memory, so per-IP counts would otherwise
+    accumulate across the run: the suite registers and logs in many times from a
+    single client IP and would trip the per-IP limits partway through. Resetting
+    before and after each test gives every test a clean bucket.
+    """
+    from aris.rate_limiting import limiter
+
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+@pytest_asyncio.fixture(autouse=True)
 async def cleanup_collaboration_manager():
     """Shut down any YDocClient instances after each test.
 

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -1,0 +1,169 @@
+"""Rate limiting on the public abuse surface: /login, /register, /render.
+
+The limiter state is app-global and in-memory. The autouse ``reset_rate_limiter``
+fixture in conftest.py clears it between tests, so each test here starts from a
+clean per-IP bucket. Distinct client IPs are simulated with the ``Fly-Client-IP``
+header, which the limiter's key function reads first (see get_real_client_ip).
+
+These tests assert immediate over-limit behavior (the (N+1)th request is blocked);
+there is no waiting on window resets.
+"""
+
+from conftest import TestDataFactory
+from httpx import AsyncClient
+from starlette.requests import Request
+
+from aris.rate_limiting import (
+    LOGIN_RATE_LIMIT,
+    PUBLIC_RENDER_RATE_LIMIT,
+    RATE_LIMIT_MESSAGE,
+    REGISTER_RATE_LIMIT,
+    get_real_client_ip,
+)
+
+
+def _limit_count(limit_str: str) -> int:
+    """The N in an 'N/minute' limit string."""
+    return int(limit_str.split("/")[0])
+
+
+LOGIN_LIMIT = _limit_count(LOGIN_RATE_LIMIT)
+REGISTER_LIMIT = _limit_count(REGISTER_RATE_LIMIT)
+RENDER_LIMIT = _limit_count(PUBLIC_RENDER_RATE_LIMIT)
+
+BAD_LOGIN = {"email": "nobody@example.com", "password": "wrong-password"}
+
+
+def _ip(addr: str) -> dict:
+    """Headers that make the limiter treat the request as coming from ``addr``."""
+    return {"Fly-Client-IP": addr}
+
+
+def _make_request(headers: dict | None = None, client: tuple | None = None) -> Request:
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request({"type": "http", "headers": raw_headers, "client": client})
+
+
+# --------------------------------------------------------------------------- #
+# Key function: keying must use the real client IP, not Fly's proxy, or every
+# caller shares one bucket.
+# --------------------------------------------------------------------------- #
+
+
+def test_key_function_prefers_fly_client_ip():
+    req = _make_request(
+        headers={"Fly-Client-IP": "1.2.3.4", "X-Forwarded-For": "9.9.9.9"},
+        client=("10.0.0.1", 5000),
+    )
+    assert get_real_client_ip(req) == "1.2.3.4"
+
+
+def test_key_function_falls_back_to_forwarded_for():
+    req = _make_request(
+        headers={"X-Forwarded-For": "5.6.7.8, 9.9.9.9"}, client=("10.0.0.1", 5000)
+    )
+    assert get_real_client_ip(req) == "5.6.7.8"
+
+
+def test_key_function_falls_back_to_socket_peer():
+    req = _make_request(client=("10.0.0.1", 5000))
+    assert get_real_client_ip(req) == "10.0.0.1"
+
+
+def test_key_function_distinct_ips_yield_distinct_keys():
+    a = _make_request(headers={"Fly-Client-IP": "1.1.1.1"})
+    b = _make_request(headers={"Fly-Client-IP": "2.2.2.2"})
+    assert get_real_client_ip(a) != get_real_client_ip(b)
+
+
+# --------------------------------------------------------------------------- #
+# /login: credential stuffing surface. Every request counts toward the limit,
+# even the failed (400) ones, which is the point.
+# --------------------------------------------------------------------------- #
+
+
+async def test_login_allows_requests_under_limit(client: AsyncClient):
+    for _ in range(LOGIN_LIMIT):
+        resp = await client.post("/login", json=BAD_LOGIN, headers=_ip("203.0.113.1"))
+        assert resp.status_code == 400, resp.text
+
+
+async def test_login_blocks_over_limit_with_clean_message(client: AsyncClient):
+    ip = _ip("203.0.113.2")
+    for _ in range(LOGIN_LIMIT):
+        resp = await client.post("/login", json=BAD_LOGIN, headers=ip)
+        assert resp.status_code != 429
+
+    blocked = await client.post("/login", json=BAD_LOGIN, headers=ip)
+    assert blocked.status_code == 429
+    assert blocked.json() == {"detail": RATE_LIMIT_MESSAGE}
+
+
+async def test_login_buckets_are_per_ip(client: AsyncClient):
+    attacker = _ip("203.0.113.3")
+    for _ in range(LOGIN_LIMIT):
+        await client.post("/login", json=BAD_LOGIN, headers=attacker)
+    blocked = await client.post("/login", json=BAD_LOGIN, headers=attacker)
+    assert blocked.status_code == 429
+
+    # A different IP is unaffected: independent bucket, so still just a 400.
+    other = await client.post("/login", json=BAD_LOGIN, headers=_ip("203.0.113.4"))
+    assert other.status_code == 400, other.text
+
+
+# --------------------------------------------------------------------------- #
+# /register: spam signups. Reusing one email keeps the test cheap (one real
+# insert, then 409s), and every attempt still consumes quota.
+# --------------------------------------------------------------------------- #
+
+
+async def test_register_blocks_over_limit_with_clean_message(client: AsyncClient):
+    ip = _ip("203.0.113.5")
+    payload = TestDataFactory.user_registration_data()
+    for _ in range(REGISTER_LIMIT):
+        resp = await client.post("/register", json=payload, headers=ip)
+        assert resp.status_code != 429, resp.text
+
+    blocked = await client.post("/register", json=payload, headers=ip)
+    assert blocked.status_code == 429
+    assert blocked.json() == {"detail": RATE_LIMIT_MESSAGE}
+
+
+# --------------------------------------------------------------------------- #
+# /render: unauthenticated and expensive. The real render is patched out so the
+# test drives the limit, not the RSM engine.
+# --------------------------------------------------------------------------- #
+
+
+async def test_render_blocks_over_limit_with_clean_message(client: AsyncClient, monkeypatch):
+    async def fast_render(src: str) -> str:
+        return "<div>ok</div>"
+
+    monkeypatch.setattr("aris.crud.render", fast_render)
+
+    ip = _ip("203.0.113.6")
+    payload = {"source": "hello", "format": "html"}
+    for _ in range(RENDER_LIMIT):
+        resp = await client.post("/render", json=payload, headers=ip)
+        assert resp.status_code == 200, resp.text
+
+    blocked = await client.post("/render", json=payload, headers=ip)
+    assert blocked.status_code == 429
+    assert blocked.json() == {"detail": RATE_LIMIT_MESSAGE}
+
+
+async def test_render_buckets_are_per_ip(client: AsyncClient, monkeypatch):
+    async def fast_render(src: str) -> str:
+        return "<div>ok</div>"
+
+    monkeypatch.setattr("aris.crud.render", fast_render)
+
+    payload = {"source": "hello", "format": "html"}
+    exhausted = _ip("203.0.113.7")
+    for _ in range(RENDER_LIMIT):
+        await client.post("/render", json=payload, headers=exhausted)
+    blocked = await client.post("/render", json=payload, headers=exhausted)
+    assert blocked.status_code == 429
+
+    other = await client.post("/render", json=payload, headers=_ip("203.0.113.8"))
+    assert other.status_code == 200, other.text

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -79,6 +79,7 @@ dependencies = [
     { name = "rsm-lang" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "shortuuid" },
+    { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "ujson" },
     { name = "uvicorn" },
@@ -126,6 +127,7 @@ requires-dist = [
     { name = "rsm-lang", editable = "../../rsm" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "shortuuid", specifier = ">=1.0.13" },
+    { name = "slowapi", specifier = ">=0.1.10" },
     { name = "sqlalchemy", specifier = ">=2.0.39" },
     { name = "ujson", specifier = ">=5.10.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },
@@ -503,6 +505,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -874,6 +888,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
     { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
     { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1718,7 +1746,7 @@ wheels = [
 
 [[package]]
 name = "rsm-lang"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "../../rsm" }
 dependencies = [
     { name = "grandalf" },
@@ -1836,6 +1864,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
 ]
 
 [[package]]
@@ -2264,4 +2304,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -44,6 +44,9 @@ services:
       - SITE_PORT=${SITE_PORT}
       - STORYBOOK_PORT=${STORYBOOK_PORT}
       - INTERNAL_SHARED_SECRET=${INTERNAL_SHARED_SECRET:?INTERNAL_SHARED_SECRET is required}
+      # E2E browsers all reach the backend from one source IP, so the per-IP
+      # limiter would throttle the whole run. Prod (behind Fly) keeps it on.
+      - RATE_LIMITING_ENABLED=false
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -36,6 +36,10 @@ services:
       - SITE_PORT=${SITE_PORT}
       - STORYBOOK_PORT=${STORYBOOK_PORT}
       - INTERNAL_SHARED_SECRET=${INTERNAL_SHARED_SECRET:?INTERNAL_SHARED_SECRET is required}
+      # Browsers (dev and local e2e) all reach the backend from one source IP, so
+      # the per-IP limiter would throttle the whole run. Prod (behind Fly) keeps
+      # it on because it does not set this flag.
+      - RATE_LIMITING_ENABLED=false
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## What this does

Adds `slowapi`-based per-IP rate limiting to the unauthenticated abuse surface (MVP for std-igyk8l).

### Endpoints protected (per IP)

| Endpoint | Limit | Why |
|---|---|---|
| `POST /login` | 10/minute | credential stuffing |
| `POST /register` | 5/minute | spam signups |
| `POST /render` (public `""`, `render.py:31`) | 30/minute | cost/DoS on an unauthenticated, expensive endpoint |

Limits live as named module-level constants in `backend/aris/rate_limiting.py`, so they are easy to find and tune.

### Real-client-IP keying (behind Fly)

Production runs behind Fly's proxy, so `request.client.host` is the proxy and is identical for every caller. Keying on it would put all users in one shared bucket. The limiter's key function (`get_real_client_ip`) instead uses, in order:

1. `Fly-Client-IP` header (Fly sets this to the true client)
2. first hop of `X-Forwarded-For`
3. `request.client.host` (socket peer, fallback)

A test asserts distinct forwarded IPs map to distinct keys, so this cannot silently regress into one shared bucket.

### In-memory storage rationale

Storage is in-memory (slowapi default). This is correct for this deployment: production runs on a **single auto-stop machine**, so there is no second process to share a bucket with. A shared store (Redis) would only matter with horizontal scale, which we do not have.

### 429 behavior + CORS

Over-limit requests get a clean `429` with JSON body `{"detail": "Too many requests. Please slow down and try again shortly."}` and slowapi's rate-limit headers. `CORSMiddleware` wraps the whole app, so 429 responses still carry CORS headers to the browser. Enforcement is per-route via `@limiter.limit(...)` decorators; `app.state.limiter` is set and `RateLimitExceeded` is mapped to the clean handler.

## Tests

`backend/tests/test_rate_limiting.py` covers:
- under-limit requests succeed
- the (N+1)th request from one IP returns 429
- two different client IPs get independent buckets (proves the key function)
- the 429 body carries the clean message
- the key function unit-tested for Fly-Client-IP / X-Forwarded-For / socket-peer fallback

Rate-limit state is app-global and in-memory, so it would otherwise bleed across the suite (the whole suite registers/logs in from one client IP). An autouse fixture in `conftest.py` resets the limiter store before and after every test. The full backend suite (`pytest -n8 -m "not slow"`): 935 passed, 7 skipped, 14 xfailed. The authz-coverage guard still passes (these routes are unauthenticated, so no new authenticated route is introduced).

## Deferred (fast-follow)

`POST /files` and authenticated asset upload are **not** rate-limited here: they require auth (trusted users), so lower abuse risk. Tracked in **std-h2tg** (P2, discovered-from std-igyk8l).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)