### PR TITLE
feat(backend): LSP OOM insurance: size LSP cap to RAM, pool_pre_ping, 2GB (std-9457)

### DIFF
--- a/backend/aris/config.py
+++ b/backend/aris/config.py
@@ -66,10 +66,15 @@ class Settings(BaseSettings):
     """Expiration time in minutes for JWT refresh tokens (default: 129600 = 90 days)."""
 
     LSP_MAX_CONCURRENT_SESSIONS: int = Field(
-        20, json_schema_extra={"env": "LSP_MAX_CONCURRENT_SESSIONS"}
+        8, json_schema_extra={"env": "LSP_MAX_CONCURRENT_SESSIONS"}
     )
-    """Global cap on concurrent LSP WebSocket sessions. Each spawns a ~100MB node
-    subprocess, so this bounds total memory. Tune to the backend instance size."""
+    """Global cap on concurrent LSP WebSocket sessions. Each spawns a ~75-100MB node
+    subprocess, so this bounds total RAM and keeps the box off the OOM killer: OOM is
+    SIGKILL, which skips the graceful 25s Y.js flush and loses in-flight edits with
+    the whole stack (std-9457). Sized to a 2GB machine: backend + multiplayer relay
+    baseline ~600-700MB plus per-file YDocClients leaves ~1.2GB; 8 * ~100MB = ~800MB
+    stays under that with headroom. The old default of 20 (~2GB of node alone) could
+    OOM even a 2GB box. Tune to the backend instance size."""
 
     LSP_MAX_SESSIONS_PER_USER: int = Field(
         3, json_schema_extra={"env": "LSP_MAX_SESSIONS_PER_USER"}

--- a/backend/aris/deps.py
+++ b/backend/aris/deps.py
@@ -48,6 +48,11 @@ ENGINE = create_async_engine(
     pool_size=10,
     max_overflow=5,
     pool_timeout=10,
+    # Validate a pooled connection before handing it out. After Fly auto-stop / idle,
+    # the pool holds sockets the DB has already dropped, so the first request after a
+    # cold start would otherwise fail once (the HTTP 000 seen 2026-07-18). Mirrors
+    # COLLAB_ENGINE below (std-9457).
+    pool_pre_ping=True,
 )
 
 # Separate pool for Y.js collaboration clients so they cannot starve HTTP handlers.

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -59,7 +59,11 @@ kill_timeout = "30s"
     port = 1234
     handlers = ["tls", "http"]
 
+# 2GB (up from 1GB) so backend + multiplayer relay + per-file YDocClients + capped
+# Node LSP subprocesses (see LSP_MAX_CONCURRENT_SESSIONS) fit with headroom and the
+# box stays off the OOM killer, whose SIGKILL skips the graceful Y.js flush above and
+# loses in-flight edits (std-9457). Still auto-stops; this only adds RAM while running.
 [[vm]]
-  memory = '1gb'
+  memory = '2gb'
   cpu_kind = 'shared'
   cpus = 1

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -33,6 +33,22 @@ def test_settings_defaults_and_env_override(monkeypatch):
     assert s.JWT_REFRESH_TOKEN_EXPIRE_MINUTES == 129600
 
 
+def test_lsp_global_cap_sized_to_ram(monkeypatch):
+    # The global LSP cap bounds how many ~75-100MB node subprocesses can run at once.
+    # It must stay small enough that they cannot OOM the 2GB prod box (OOM is SIGKILL,
+    # which skips the graceful Y.js flush and loses in-flight edits, std-9457). Pin the
+    # sized default and a sane upper bound so a future edit cannot silently restore a
+    # value (the old 20) that blows past available RAM.
+    for key in ("LSP_MAX_CONCURRENT_SESSIONS", "LSP_MAX_SESSIONS_PER_USER"):
+        monkeypatch.delenv(key, raising=False)
+
+    s = Settings(_env_file=None)
+    assert s.LSP_MAX_CONCURRENT_SESSIONS == 8
+    assert 1 <= s.LSP_MAX_CONCURRENT_SESSIONS <= 10
+    # Per-user cap must stay sane: at least 1, and never above the global ceiling.
+    assert 1 <= s.LSP_MAX_SESSIONS_PER_USER <= s.LSP_MAX_CONCURRENT_SESSIONS
+
+
 def test_missing_required_env_vars(monkeypatch):
     # Remove all required env vars to trigger validation error
     for key in (

--- a/backend/tests/test_deps.py
+++ b/backend/tests/test_deps.py
@@ -1,0 +1,20 @@
+"""Engine configuration tests for the DB dependency layer (std-9457).
+
+The prod machine auto-stops when idle, so its connection pool routinely holds
+sockets the database has already closed. Without pre-ping, the first request after
+a cold start hands out a dead connection and errors once (the HTTP 000 seen
+2026-07-18). Both engines must validate a connection before use.
+"""
+
+from aris.deps import COLLAB_ENGINE, ENGINE
+
+
+def test_http_engine_has_pool_pre_ping():
+    # SQLAlchemy stores the pool_pre_ping flag as the pool's private _pre_ping; there
+    # is no public accessor, so assert on it directly to prove the HTTP engine (not
+    # just the collaboration engine) revalidates connections after an idle auto-stop.
+    assert ENGINE.pool._pre_ping is True
+
+
+def test_collab_engine_has_pool_pre_ping():
+    assert COLLAB_ENGINE.pool._pre_ping is True


### PR DESCRIPTION
## Why

The 1GB prod machine (`aris-backend`) runs the backend + the multiplayer relay + a YDocClient per open file + a spawned Node LSP subprocess (~75-100MB each) per editor session. A few teams editing at once can exhaust RAM and trip the OOM killer. OOM is `SIGKILL`, so the graceful 25s Y.js flush (the `kill_timeout = "30s"` path already in `fly.toml`) never runs: in-flight, 500ms-debounced Y.js edits are lost along with the whole stack.

Auto-stop is intentional and stays. This PR is cheap insurance (headroom + a cold-start fix), not a change to `min_machines_running`.

## Changes

**1. Size the global LSP cap to RAM (`backend/aris/config.py`)**
Lowered `LSP_MAX_CONCURRENT_SESSIONS` from **20 to 8**. Per-user cap stays **3**.

RAM math for a 2GB box: backend + multiplayer relay baseline ~600-700MB, plus per-file YDocClients, leaves roughly ~1.2GB. At ~100MB per Node LSP, `8 * 100MB = ~800MB` stays under that with headroom. The old cap of 20 (~2GB of node subprocesses alone) could OOM even a 2GB machine before the cap ever engaged.

**2. `pool_pre_ping=True` on the main HTTP DB engine (`backend/aris/deps.py`)**
The `ENGINE` used by HTTP request handlers was missing `pool_pre_ping`, while `COLLAB_ENGINE` already had it. After idle/auto-stop the pool holds connections the DB has already dropped, so the first request after a cold start errored once (the HTTP 000 observed in prod on 2026-07-18). Added `pool_pre_ping=True`, mirroring `COLLAB_ENGINE`. (Neither engine uses `pool_recycle`, so none was added.)

**3. 2GB machine size (`backend/fly.toml`)**
Machine size **is** configured in `fly.toml` (`[[vm]] memory`), so it is bumped there from `'1gb'` to `'2gb'`. The machine still auto-stops when idle; it only has more RAM while running.

## Deploy note (important)

**Merging this PR does NOT resize the running machine.** The `fly.toml` `memory` change only takes effect on the next `fly deploy`. If the running machine needs the new size immediately (or independent of a deploy), apply:

```
fly scale memory 2048 -a aris-backend
```

## Tests
- `backend/tests/test_config.py`: asserts the sized global LSP cap default (8) and sane bounds (1..10, per-user cap <= global).
- `backend/tests/test_deps.py`: asserts both the HTTP and collaboration engines enable `pool_pre_ping`.

Targeted run (`test_config.py`, `test_deps.py`, `test_routes/test_lsp_auth.py`): 21 passed. `ruff check` clean on changed files.

Refs std-9457.