### PR TITLE
feat(security): enforce max size on file asset uploads (413)

### DIFF
--- a/backend/aris/config.py
+++ b/backend/aris/config.py
@@ -120,6 +120,15 @@ class Settings(BaseSettings):
     """Sentry ingest DSN for backend error tracking. Optional: when empty, Sentry is
     not initialized (local/CI/test), so it is a no-op until a DSN is set in prod."""
 
+    MAX_ASSET_BYTES: int = Field(
+        25 * 1024 * 1024, json_schema_extra={"env": "MAX_ASSET_BYTES"}
+    )
+    """Maximum DECODED size (bytes) of a single uploaded file asset. Sized for the
+    single small prod machine: a large base64 upload decodes into memory, so an
+    unbounded payload is a memory/abuse vector. Enforced on the decoded byte length
+    in routes/file.py (base64 inflates ~33%). Default 25 MB; lower via env to fit a
+    smaller instance."""
+
 
     model_config = SettingsConfigDict(
         extra="ignore",

--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
@@ -14,6 +16,7 @@ from ..authorization import (
     require_view,
 )
 from ..collaboration import get_collaboration_manager, mint_collab_token
+from ..config import settings
 from ..crud.file_assets import FileAssetCreate, FileAssetDB, FileAssetOut, FileAssetUpdate
 from ..crud.permissions import create_permission
 from ..deps import UserRead
@@ -745,14 +748,56 @@ class _AssetBody(BaseModel):
 
     @model_validator(mode="after")
     def _validate_base64_content(self) -> "_AssetBody":
-        import base64 as _b64
-        import binascii
         if self.content_encoding == "base64":
             try:
-                _b64.b64decode(self.content)
+                base64.b64decode(self.content)
             except (TypeError, binascii.Error):
                 raise ValueError("Invalid base64-encoded string")
         return self
+
+
+def _enforce_asset_size_limit(content: str, content_encoding: str) -> None:
+    """Reject asset content whose decoded size exceeds ``settings.MAX_ASSET_BYTES``.
+
+    Raises HTTP 413 when the limit is exceeded. The limit is on the DECODED byte
+    length, so it is stable regardless of encoding (base64 inflates the wire size
+    by ~33%). For base64 we first reject on the raw string length when it is large
+    enough that no valid base64 could possibly fit under the limit: that avoids
+    allocating a huge buffer just to measure an abusive payload, which is the whole
+    point on the single small prod machine.
+    """
+    max_bytes = settings.MAX_ASSET_BYTES
+
+    if content_encoding == "base64":
+        # 4 base64 chars encode 3 bytes, so any string longer than this cannot
+        # decode to <= max_bytes. Reject before decoding to avoid the allocation.
+        max_b64_chars = ((max_bytes + 2) // 3) * 4
+        if len(content) > max_b64_chars:
+            _raise_asset_too_large(max_bytes)
+        try:
+            decoded_len = len(base64.b64decode(content))
+        except (TypeError, binascii.Error):
+            # Invalid base64 is a 422 handled by the request model, not our concern.
+            return
+    else:
+        # A UTF-8 string is at least one byte per character, so a character count
+        # over the limit is already over the byte limit; skip encoding it.
+        if len(content) > max_bytes:
+            _raise_asset_too_large(max_bytes)
+        decoded_len = len(content.encode("utf-8"))
+
+    if decoded_len > max_bytes:
+        _raise_asset_too_large(max_bytes)
+
+
+def _raise_asset_too_large(max_bytes: int) -> None:
+    if max_bytes >= 1024 * 1024:
+        limit = f"{max_bytes // (1024 * 1024)} MB"
+    elif max_bytes >= 1024:
+        limit = f"{max_bytes // 1024} KB"
+    else:
+        limit = f"{max_bytes} bytes"
+    raise HTTPException(status_code=413, detail=f"Asset exceeds {limit} limit")
 
 
 @router.get("/{file_id}/assets", response_model=list[FileAssetOut])
@@ -781,6 +826,7 @@ async def create_asset_for_file(
     file_service: InMemoryFileService = Depends(get_file_service),
 ):
     """Upload a new asset to a file. Requires edit permission."""
+    _enforce_asset_size_limit(payload.content, payload.content_encoding)
     asset = await FileAssetDB.create_asset(
         FileAssetCreate(
             filename=payload.filename,
@@ -877,6 +923,10 @@ async def update_asset_for_file(
     asset = await db.get(FileAsset, asset_id)
     if not asset or asset.file_id != file_id or asset.deleted_at is not None:
         raise HTTPException(status_code=404, detail="Asset not found")
+    if payload.content is not None:
+        # An update carries no encoding of its own; reuse the stored asset's so the
+        # decoded-size check matches how the content will actually be persisted.
+        _enforce_asset_size_limit(payload.content, getattr(asset, "content_encoding", "base64"))
     result = await FileAssetDB.update_asset(asset, payload, db)
     await file_service.clear_file_cache(file_id)
     get_event_broker().publish(file_id, {"type": "asset-changed"})

--- a/backend/tests/test_routes/test_routes_file_assets.py
+++ b/backend/tests/test_routes/test_routes_file_assets.py
@@ -5,6 +5,8 @@ import base64
 import pytest
 from httpx import AsyncClient
 
+from aris.config import settings
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -282,3 +284,137 @@ async def test_list_excludes_deleted_assets(
     remaining = (await client.get(f"/files/{test_file['id']}/assets", headers=headers)).json()
     assert len(remaining) == 1
     assert remaining[0]["filename"] == "keep.png"
+
+
+# ---------------------------------------------------------------------------
+# Asset size limit (std-n1m251): enforced on DECODED bytes, rejected with 413
+# ---------------------------------------------------------------------------
+
+
+def _base64_decoding_to(n_bytes: int) -> str:
+    """A base64 string that decodes to exactly ``n_bytes`` bytes."""
+    return base64.b64encode(b"\0" * n_bytes).decode()
+
+
+async def test_upload_asset_over_size_limit_returns_413(
+    client: AsyncClient, authenticated_user, test_file, monkeypatch
+):
+    """Base64 content whose decoded size is over the limit is refused with 413."""
+    monkeypatch.setattr(settings, "MAX_ASSET_BYTES", 1024 * 1024)
+    headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    response = await client.post(
+        f"/files/{test_file['id']}/assets",
+        headers=headers,
+        json={
+            "filename": "big.png",
+            "mime_type": "image/png",
+            "content": _base64_decoding_to(1024 * 1024 + 1),
+            "content_encoding": "base64",
+        },
+    )
+    assert response.status_code == 413
+    assert "1 MB" in response.json()["detail"]
+    assert "limit" in response.json()["detail"].lower()
+
+
+async def test_upload_asset_at_size_limit_succeeds(
+    client: AsyncClient, authenticated_user, test_file, monkeypatch
+):
+    """Content decoding to exactly the limit is accepted.
+
+    The base64 string here is ~1.33x the byte limit, so its raw length is over the
+    limit while its decoded length is not. Accepting it proves the check is on the
+    DECODED size, not the raw wire length.
+    """
+    monkeypatch.setattr(settings, "MAX_ASSET_BYTES", 1024 * 1024)
+    headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    response = await client.post(
+        f"/files/{test_file['id']}/assets",
+        headers=headers,
+        json={
+            "filename": "atlimit.png",
+            "mime_type": "image/png",
+            "content": _base64_decoding_to(1024 * 1024),
+            "content_encoding": "base64",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["filename"] == "atlimit.png"
+
+
+async def test_upload_asset_just_over_bound_rejected(
+    client: AsyncClient, authenticated_user, test_file, monkeypatch
+):
+    """A base64 string just one decoded byte over the bound is rejected."""
+    monkeypatch.setattr(settings, "MAX_ASSET_BYTES", 1024 * 1024)
+    headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+
+    under = await client.post(
+        f"/files/{test_file['id']}/assets",
+        headers=headers,
+        json={
+            "filename": "under.bin",
+            "mime_type": "application/octet-stream",
+            "content": _base64_decoding_to(1024 * 1024 - 3),
+            "content_encoding": "base64",
+        },
+    )
+    assert under.status_code == 200, under.text
+
+    over = await client.post(
+        f"/files/{test_file['id']}/assets",
+        headers=headers,
+        json={
+            "filename": "over.bin",
+            "mime_type": "application/octet-stream",
+            "content": _base64_decoding_to(1024 * 1024 + 1),
+            "content_encoding": "base64",
+        },
+    )
+    assert over.status_code == 413
+
+
+async def test_update_asset_over_size_limit_returns_413(
+    client: AsyncClient, authenticated_user, test_file, valid_base64_image, monkeypatch
+):
+    """Updating an asset with over-limit base64 content is refused with 413."""
+    headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    create_resp = await client.post(
+        f"/files/{test_file['id']}/assets",
+        headers=headers,
+        json={
+            "filename": "u.png",
+            "mime_type": "image/png",
+            "content": valid_base64_image,
+            "content_encoding": "base64",
+        },
+    )
+    asset_id = create_resp.json()["id"]
+
+    monkeypatch.setattr(settings, "MAX_ASSET_BYTES", 1024 * 1024)
+    response = await client.put(
+        f"/files/{test_file['id']}/assets/{asset_id}",
+        headers=headers,
+        json={"content": _base64_decoding_to(1024 * 1024 + 1)},
+    )
+    assert response.status_code == 413
+    assert "limit" in response.json()["detail"].lower()
+
+
+async def test_upload_asset_over_default_limit_returns_413(
+    client: AsyncClient, authenticated_user, test_file
+):
+    """With the shipped 25 MB default, an over-limit upload returns the 413 message."""
+    headers = {"Authorization": f"Bearer {authenticated_user['token']}"}
+    response = await client.post(
+        f"/files/{test_file['id']}/assets",
+        headers=headers,
+        json={
+            "filename": "huge.png",
+            "mime_type": "image/png",
+            "content": _base64_decoding_to(25 * 1024 * 1024 + 1),
+            "content_encoding": "base64",
+        },
+    )
+    assert response.status_code == 413
+    assert response.json()["detail"] == "Asset exceeds 25 MB limit"


### PR DESCRIPTION
## Problem
The file asset upload endpoints accepted base64-encoded `content` with **no size limit** (std-n1m251). On the single small prod machine, a large upload decodes into memory, a memory/abuse vector.

## Fix
Enforce a maximum **decoded** size and reject over-limit content with **HTTP 413** and a clear JSON message stating the limit.

- New config constant `MAX_ASSET_BYTES` (default **25 MB** decoded, configurable via the `MAX_ASSET_BYTES` env var), sized for the small prod machine and tunable per instance.
- Enforced on the **decoded** byte length (base64 inflates ~33%), so the limit is stable regardless of wire encoding.
- For base64, a cheap **raw-string-length guard runs first**: when the string is long enough that no valid base64 could possibly fit under the limit, it is rejected **before decoding**, so an abusive payload never forces a large allocation just to be measured.
- Message: `Asset exceeds 25 MB limit` (the size adapts to the configured limit).

## Endpoints covered
Both asset write paths that accept base64 content:
- `POST /files/{file_id}/assets` (create)
- `PUT /files/{file_id}/assets/{asset_id}` (update, when `content` is present)

## Tests (TDD, in `test_routes_file_assets.py`)
- under-limit upload succeeds
- over-limit upload returns 413 with the clear message
- boundary: content decoding to exactly the limit succeeds; one decoded byte over is rejected (proves enforcement is on **decoded** size, not raw wire length)
- update path over-limit returns 413
- real 25 MB default: over-limit upload returns `Asset exceeds 25 MB limit`

All 20 asset-route tests pass; authz-coverage guard, asset validators, CRUD, and config tests unaffected. `ruff check` and `mypy` clean on changed files.

Refs std-n1m251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpvQQYTDRUqP7S48tUZPrH