### PR TITLE
fix(collab): surface swallowed collab errors instead of hiding them (std-eisqeg)

### DIFF
--- a/frontend/src/tests/views/workspace/DrawerFile.test.js
+++ b/frontend/src/tests/views/workspace/DrawerFile.test.js
@@ -5,9 +5,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import DrawerFile from "@/views/workspace/DrawerFile.vue";
+import { downloadBlob } from "@/utils/download.js";
+import { toast } from "@/utils/toast.js";
+import { captureException } from "@sentry/vue";
 
 vi.mock("@/utils/download.js", () => ({
   downloadBlob: vi.fn(),
+}));
+
+vi.mock("@/utils/toast.js", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@sentry/vue", () => ({
+  captureException: vi.fn(),
 }));
 
 // Mock vue-router
@@ -164,7 +175,7 @@ describe("DrawerFile", () => {
       expect(mockApi.post).toHaveBeenCalledWith(
         "/files/123/download",
         {},
-        { responseType: "blob" },
+        { responseType: "blob" }
       );
     });
 
@@ -182,7 +193,7 @@ describe("DrawerFile", () => {
       expect(mockApi.post).toHaveBeenCalledWith(
         "/files/123/download",
         {},
-        { responseType: "blob" },
+        { responseType: "blob" }
       );
     });
 
@@ -230,8 +241,107 @@ describe("DrawerFile", () => {
       expect(mockApi.post).toHaveBeenCalledWith(
         "/files/123/download/pdf",
         {},
-        { responseType: "blob", timeout: 120000 },
+        { responseType: "blob", timeout: 120000 }
       );
+    });
+  });
+
+  describe("flush before export (std-eisqeg)", () => {
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("cancels HTML export and surfaces an error when the pre-export flush fails", async () => {
+      const flushError = new Error("flush failed");
+      mockApi.post.mockImplementation((url) => {
+        if (url.includes("/collab/flush")) return Promise.reject(flushError);
+        return Promise.resolve({ data: new Blob() });
+      });
+
+      wrapper = createWrapper();
+      const rows = wrapper.findAll(".action-row");
+      await rows[0].trigger("click");
+      await flushPromises();
+
+      // The flush was attempted, but a stale export must NOT proceed.
+      expect(mockApi.post).toHaveBeenCalledWith("/files/123/collab/flush");
+      expect(mockApi.post).not.toHaveBeenCalledWith(
+        "/files/123/download",
+        {},
+        { responseType: "blob" }
+      );
+      expect(downloadBlob).not.toHaveBeenCalled();
+
+      // The failure is reported rather than swallowed.
+      expect(captureException).toHaveBeenCalledWith(flushError);
+      expect(toast.error).toHaveBeenCalled();
+
+      // Button is re-enabled so the user can retry.
+      expect(rows[0].attributes("disabled")).toBeUndefined();
+    });
+
+    it("cancels PDF export and surfaces an error when the pre-export flush fails", async () => {
+      const flushError = new Error("flush failed");
+      mockApi.post.mockImplementation((url) => {
+        if (url.includes("/collab/flush")) return Promise.reject(flushError);
+        return Promise.resolve({ data: new Blob() });
+      });
+
+      wrapper = createWrapper();
+      const rows = wrapper.findAll(".action-row");
+      await rows[1].trigger("click");
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith("/files/123/collab/flush");
+      expect(mockApi.post).not.toHaveBeenCalledWith(
+        "/files/123/download/pdf",
+        {},
+        { responseType: "blob", timeout: 120000 }
+      );
+      expect(downloadBlob).not.toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalledWith(flushError);
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    it("proceeds with the export after a successful flush", async () => {
+      mockApi.post.mockResolvedValue({ data: new Blob() });
+
+      wrapper = createWrapper();
+      const rows = wrapper.findAll(".action-row");
+      await rows[0].trigger("click");
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith("/files/123/collab/flush");
+      expect(mockApi.post).toHaveBeenCalledWith(
+        "/files/123/download",
+        {},
+        { responseType: "blob" }
+      );
+      expect(downloadBlob).toHaveBeenCalled();
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("reports an error when the download itself fails after a successful flush", async () => {
+      const downloadError = new Error("download boom");
+      mockApi.post.mockImplementation((url) => {
+        if (url.includes("/collab/flush")) return Promise.resolve({ data: {} });
+        return Promise.reject(downloadError);
+      });
+
+      wrapper = createWrapper();
+      const rows = wrapper.findAll(".action-row");
+      await rows[0].trigger("click");
+      await flushPromises();
+
+      expect(captureException).toHaveBeenCalledWith(downloadError);
+      expect(toast.error).toHaveBeenCalled();
+      expect(downloadBlob).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/tests/views/workspace/EditorCollabRetry.test.js
+++ b/frontend/src/tests/views/workspace/EditorCollabRetry.test.js
@@ -151,7 +151,15 @@ vi.mock("@/composables/useFileEvents.js", () => ({
   useFileEvents: () => ({ close: vi.fn() }),
 }));
 
+vi.mock("@/utils/toast.js", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@sentry/vue", () => ({ captureException: vi.fn() }));
+
 import EditorCodeMirror from "@/views/workspace/EditorCodeMirror.vue";
+import { toast } from "@/utils/toast.js";
+import { captureException } from "@sentry/vue";
 
 describe("EditorCodeMirror — collab-start failure surfacing and retry", () => {
   let mockApi;
@@ -265,5 +273,67 @@ describe("EditorCodeMirror — collab-start failure surfacing and retry", () => 
     expect(collabConnectError.value).toBe(false);
 
     wrapper.unmount();
+  });
+});
+
+describe("EditorCodeMirror — collab/stop error surfacing (std-eisqeg)", () => {
+  let mockApi;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    providerInstances.length = 0;
+    AuthedWebSocket._tokens.clear();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    toast.warning.mockClear();
+    captureException.mockClear();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  const mountEditor = () =>
+    mount(EditorCodeMirror, {
+      props: { modelValue: { id: 77, source: "", role: "AUTHOR" } },
+      global: {
+        provide: {
+          api: mockApi,
+          user: ref({ id: 1, name: "Tester", email: "t@e.com", avatar_color: "#0E9AE9" }),
+          mobileMode: ref(false),
+          compile: vi.fn(),
+          cmView: shallowRef(null),
+          cursorPos: ref(0),
+          ydoc: shallowRef(null),
+          ytext: shallowRef(null),
+          awareness: shallowRef(null),
+          collabIsConnected: ref(false),
+          collabIsSynced: ref(false),
+          collabConnectError: ref(false),
+          collabRetry: shallowRef(null),
+        },
+      },
+    });
+
+  it("reports a failed collab/stop on cleanup instead of swallowing it", async () => {
+    const stopError = new Error("stop failed");
+    mockApi = {
+      get: vi.fn().mockResolvedValue({ data: {} }),
+      post: vi.fn().mockImplementation((url) => {
+        if (url.includes("/collab/stop")) return Promise.reject(stopError);
+        return Promise.resolve({ data: { token: "tok" } });
+      }),
+    };
+
+    const wrapper = mountEditor();
+    await flushPromises();
+
+    // Unmount runs cleanup(), which posts /collab/stop for the active file.
+    wrapper.unmount();
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith("/files/77/collab/stop");
+    expect(captureException).toHaveBeenCalledWith(stopError);
+    expect(toast.warning).toHaveBeenCalled();
   });
 });

--- a/frontend/src/views/workspace/DrawerFile.vue
+++ b/frontend/src/views/workspace/DrawerFile.vue
@@ -1,8 +1,10 @@
 <script setup>
   import { ref, inject, computed } from "vue";
   import { useRouter } from "vue-router";
+  import { captureException } from "@sentry/vue";
   import { File } from "@/models/File.js";
   import { downloadBlob } from "@/utils/download.js";
+  import { toast } from "@/utils/toast.js";
   import ConfirmationModal from "@/components/ConfirmationModal.vue";
 
   const api = inject("api");
@@ -15,6 +17,24 @@
   function getCurrentSource() {
     if (cmView.value) return cmView.value.state.doc.toString();
     return file.value?.source || "";
+  }
+
+  // Push the live Y.js content to the DB so a subsequent export reflects the
+  // user's latest edits. Returns true if the export may proceed, false if the
+  // flush failed (in which case the caller must abort rather than export stale
+  // content). std-eisqeg: never swallow this failure silently.
+  async function flushBeforeExport() {
+    try {
+      await api.post(`/files/${fileId.value}/collab/flush`);
+      return true;
+    } catch (error) {
+      captureException(error);
+      toast.error(
+        "Couldn't sync your latest changes, so the export was cancelled to avoid " +
+          "downloading an out-of-date file. Please try again."
+      );
+      return false;
+    }
   }
 
   const isDownloading = ref(false);
@@ -34,19 +54,24 @@
     if (isDownloading.value || !fileId.value) return;
     isDownloading.value = true;
     try {
-      // Flush Y.js content to DB before export (non-competing path)
-      await api.post(`/files/${fileId.value}/collab/flush`).catch(() => {});
+      // Flush Y.js content to the DB so the export reflects the user's latest
+      // edits. If the flush fails the DB may still hold stale content, so we
+      // must NOT silently export it (std-eisqeg): cancel the export and warn
+      // the user rather than handing them an out-of-date file.
+      if (!(await flushBeforeExport())) return;
 
       const title = fileTitle.value || "manuscript";
       const filename = title.replace(/[<>:"/\\|?*]/g, "_") + ".html";
       const response = await api.post(
         `/files/${fileId.value}/download`,
         {},
-        { responseType: "blob" },
+        { responseType: "blob" }
       );
       const blob = new Blob([response.data], { type: "text/html" });
       downloadBlob(blob, filename);
     } catch (error) {
+      captureException(error);
+      toast.error("Download failed. Please try again.");
       console.error("Download failed:", error);
     } finally {
       isDownloading.value = false;
@@ -57,19 +82,22 @@
     if (isDownloadingPdf.value || !fileId.value) return;
     isDownloadingPdf.value = true;
     try {
-      // Flush Y.js content to DB before export (non-competing path)
-      await api.post(`/files/${fileId.value}/collab/flush`).catch(() => {});
+      // See onDownload: a failed pre-export flush must not silently yield a
+      // stale PDF (std-eisqeg).
+      if (!(await flushBeforeExport())) return;
 
       const title = fileTitle.value || "manuscript";
       const filename = title.replace(/[<>:"/\\|?*]/g, "_") + ".pdf";
       const response = await api.post(
         `/files/${fileId.value}/download/pdf`,
         {},
-        { responseType: "blob", timeout: 120000 },
+        { responseType: "blob", timeout: 120000 }
       );
       const blob = new Blob([response.data], { type: "application/pdf" });
       downloadBlob(blob, filename);
     } catch (error) {
+      captureException(error);
+      toast.error("PDF download failed. Please try again.");
       console.error("PDF download failed:", error);
     } finally {
       isDownloadingPdf.value = false;
@@ -133,8 +161,13 @@
           <Icon name="ChevronRight" class="action-chevron" />
         </button>
         <button class="action-row" :disabled="isDownloadingPdf" @click="onDownloadPdf">
-          <Icon :name="isDownloadingPdf ? 'Loader2' : 'FileTypePdf'" :class="{ spinning: isDownloadingPdf }" />
-          <span class="action-label">{{ isDownloadingPdf ? "Generating PDF…" : "Download PDF" }}</span>
+          <Icon
+            :name="isDownloadingPdf ? 'Loader2' : 'FileTypePdf'"
+            :class="{ spinning: isDownloadingPdf }"
+          />
+          <span class="action-label">{{
+            isDownloadingPdf ? "Generating PDF…" : "Download PDF"
+          }}</span>
           <Icon v-if="!isDownloadingPdf" name="ChevronRight" class="action-chevron" />
         </button>
       </template>
@@ -225,8 +258,12 @@
   }
 
   @keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
 
   .action-row--danger {

--- a/frontend/src/views/workspace/EditorCodeMirror.vue
+++ b/frontend/src/views/workspace/EditorCodeMirror.vue
@@ -33,7 +33,9 @@
   import { yCollab, yUndoManagerKeymap } from "y-codemirror.next";
   import * as Y from "yjs";
   import { WebsocketProvider } from "y-websocket";
+  import { captureException } from "@sentry/vue";
   import { AuthedWebSocket } from "@/composables/authedWebSocket";
+  import { toast } from "@/utils/toast.js";
   import { useLSPClient } from "@/composables/useLSPClient";
   import { semanticTokensExtension, requestSemanticTokens } from "@/composables/useSemanticTokens";
   import { rsmKeymap } from "@/composables/useRSMCommands";
@@ -166,7 +168,15 @@
     }
 
     if (activeCollabFileId.value) {
-      api.post(`/files/${activeCollabFileId.value}/collab/stop`).catch(() => {});
+      // Best-effort: cleanup must not block on the network, but a failed stop
+      // leaves a backend Y.js client lingering, so report it (std-eisqeg)
+      // instead of swallowing. The notice stays non-blocking since the user has
+      // already navigated away from this file.
+      const stoppingFileId = activeCollabFileId.value;
+      api.post(`/files/${stoppingFileId}/collab/stop`).catch((err) => {
+        captureException(err);
+        toast.warning("Couldn't cleanly close the previous collaboration session.");
+      });
       activeCollabFileId.value = null;
     }
 


### PR DESCRIPTION
## Problem (std-eisqeg)

Three critical frontend paths swallowed errors with `.catch(() => {})`:

- `frontend/src/views/workspace/DrawerFile.vue` (HTML + PDF export): a failed `/collab/flush` before an export silently proceeded, so the user could download **stale** content with no warning.
- `frontend/src/views/workspace/EditorCodeMirror.vue` (cleanup): a failed `/collab/stop` was swallowed, leaving a backend Y.js client lingering with no signal.

## Fix

- **Flush-before-export (UX decision: BLOCK, not just warn):** extracted a shared `flushBeforeExport()` helper. On flush failure it reports to Sentry, shows an error toast, and returns early so the export is **cancelled** rather than handing the user an out-of-date file. This is the strongest guarantee against the "silent stale export" worst case; the user can retry once collaboration recovers. Applies to both HTML and PDF.
- **Export catch blocks:** a failed download previously only hit `console.error`; now it also reports to Sentry and surfaces an error toast.
- **collab/stop cleanup:** reports to Sentry with a non-blocking warning toast (the user has already navigated away, so no modal).

Errors go to Sentry via the existing `@sentry/vue` integration (no-op unless `VITE_SENTRY_DSN` is set, matching `main.js`) and to the user via the existing `@/utils/toast.js` service. No new error-reporting mechanism was introduced.

## Tests (TDD)

- `DrawerFile.test.js`: rejected `/collab/flush` cancels the export (download endpoint not called, `downloadBlob` not called), reports to Sentry, and shows a toast; success path still exports; a download failure after a successful flush is reported.
- `EditorCollabRetry.test.js`: a rejected `/collab/stop` on cleanup is reported (Sentry + warning toast) rather than swallowed.

Targeted run: `npx vitest run` on both files -> 30 passed.

## Notes

- `eslint --fix` (the repo's `lint` command) incidentally cleaned a few pre-existing prettier formatting issues in `DrawerFile.vue` (an `<Icon>` attribute wrap and a `@keyframes` block) that sit in files I touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)