### PR TITLE
fix(email): require FROM_EMAIL in prod, drop silent unverified-domain fallback

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,5 +28,5 @@ INTERNAL_SHARED_SECRET=test_internal_shared_secret_for_ci_development_only_min_3
 
 # Email Configuration (blank = disabled for testing)
 RESEND_API_KEY=
-FROM_EMAIL=noreply@aris.pub
+FROM_EMAIL=noreply@updates.aris.pub  # must be an address on a verified Resend domain
 ADMIN_EMAIL=

--- a/backend/aris/config.py
+++ b/backend/aris/config.py
@@ -102,8 +102,11 @@ class Settings(BaseSettings):
     RESEND_API_KEY: str = Field("", json_schema_extra={"env": "RESEND_API_KEY"})
     """Resend API key for sending emails."""
 
-    FROM_EMAIL: str = Field("noreply@aris.pub", json_schema_extra={"env": "FROM_EMAIL"})
-    """Default from email address."""
+    FROM_EMAIL: str = Field("", json_schema_extra={"env": "FROM_EMAIL"})
+    """Sender address for outgoing email. No hardcoded default on purpose: a silent
+    fallback to an unverified domain let a broken sender hide for a year. Empty here,
+    required in PROD and STAGING (see require_prod_email_config), optional in
+    LOCAL/TEST/CI where email is off. Must be an address on a verified Resend domain."""
 
     ADMIN_EMAIL: str = Field("", json_schema_extra={"env": "ADMIN_EMAIL"})
     """Admin email for notifications (signups, etc.)."""
@@ -164,6 +167,20 @@ class Settings(BaseSettings):
                 self.DB_URL_LOCAL = f"postgresql+asyncpg://postgres:postgres@localhost:{self.DB_PORT}/{self.DB_NAME}"
             if not self.ALEMBIC_DB_URL_LOCAL:
                 self.ALEMBIC_DB_URL_LOCAL = f"postgresql+psycopg2://postgres:postgres@localhost:{self.DB_PORT}/{self.DB_NAME}"
+        return self
+
+    @model_validator(mode="after")
+    def require_prod_email_config(self):
+        """Fail fast at boot in PROD/STAGING if the email sender is not configured.
+        A missing critical var must crash, not degrade to a silent bad default. A
+        silent noreply@aris.pub fallback let a broken, unverified sender hide for a
+        year, this refuses to boot instead."""
+        if self.ENV in ("PROD", "STAGING") and not self.FROM_EMAIL:
+            raise ValueError(
+                "FROM_EMAIL is not set. It is required in PROD and STAGING and must be "
+                "an address on a verified Resend domain (e.g. noreply@updates.aris.pub). "
+                "Refusing to boot rather than silently fall back to an unverified domain."
+            )
         return self
 
     def get_test_database_url(self) -> str:

--- a/backend/aris/services/email.py
+++ b/backend/aris/services/email.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 
 class EmailConfig(BaseModel):
     resend_api_key: str
-    from_email: str = "noreply@aris.pub"
+    from_email: str
     admin_email: Optional[str] = None
 
 


### PR DESCRIPTION
FROM_EMAIL defaulted to the unverified aris.pub domain, so every send failed silently until Sentry exposed it (#457). Removes the default, crashes at boot in PROD/STAGING when FROM_EMAIL is unset, and points prod at the verified noreply@updates.aris.pub (Fly secret). Verified end to end in prod via POST /signup/. Follow-up audit: std-kca4.