### PR TITLE
test(email): assert from_email is required (fix CI from FROM_EMAIL hardening)

### DIFF
--- a/backend/tests/test_services/test_email.py
+++ b/backend/tests/test_services/test_email.py
@@ -4,6 +4,7 @@ import logging
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from aris.services.email import EmailConfig, EmailService, get_email_service
 
@@ -20,10 +21,11 @@ class TestEmailConfig:
         assert config.resend_api_key == "test_key"
         assert config.from_email == "test@example.com"
 
-    def test_email_config_default_from_email(self):
-        """Test EmailConfig uses default from_email."""
-        config = EmailConfig(resend_api_key="test_key")
-        assert config.from_email == "noreply@aris.pub"
+    def test_email_config_requires_from_email(self):
+        """from_email has no default: omitting it must raise, so a broken or unset
+        sender can never silently fall back to an unverified domain."""
+        with pytest.raises(ValidationError):
+            EmailConfig(resend_api_key="test_key")
 
 
 class TestEmailService:


### PR DESCRIPTION
The FROM_EMAIL hardening (PR #490) removed EmailConfig.from_email's default, but a unit test still asserted that default, so CI went red on main. This updates the test to the new contract: from_email is required, omitting it raises. Verified locally (email suite 10 passed). Note: the e2e-site job in the red run failed separately on a transient npm-registry/corepack error, unrelated to this change.